### PR TITLE
fix(editor): display plural translations when nplurals=1

### DIFF
--- a/server/zanata-frontend/src/editor/app/actions/phrases.js
+++ b/server/zanata-frontend/src/editor/app/actions/phrases.js
@@ -1,6 +1,6 @@
 import { fetchPhraseList, fetchPhraseDetail, savePhrase } from '../api'
 import { toggleDropdown } from '.'
-import { isEmpty, isUndefined, mapValues, slice } from 'lodash'
+import { isUndefined, mapValues, slice } from 'lodash'
 import {
   defaultSaveStatus,
   STATUS_NEW,
@@ -110,7 +110,7 @@ function transUnitDetailToPhraseDetail (transUnitDetail, localeId) {
     const source = transUnit.source
     const plural = source.plural
     const trans = transUnit[localeId]
-    const translations = extractTranslations(source, trans)
+    const translations = extractTranslations(trans)
     return {
       id: parseInt(id, 10),
       plural,
@@ -128,24 +128,14 @@ function transUnitDetailToPhraseDetail (transUnitDetail, localeId) {
  * Get translations from a TransUnit in a consistent form (array of strings)
  *
  * This will always return an Array<String>, but the array may be empty.
- *
- * There is a problem with the API that means plurals for languages with a
- * single plural form will use trans.content instead of trans.contents for the
- * plural form. The result of this function has everything normalised to prevent
- * it causing any problems.
  */
-function extractTranslations (source, trans) {
+function extractTranslations (trans) {
   if (!trans) {
     return []
   }
-
-  const isPlural = source.plural
-
-  // API uses trans.content if nplurals=1, so use that regardless of plural
-  // forms when it is defined.
-  return trans.content ? [trans.content] : (
+  return trans.content ? [trans.content]
     // Array.slice() efficiently makes a copy of the array.
-    (isPlural && trans.contents) ? trans.contents.slice() : [])
+    : (trans.contents ? trans.contents.slice() : [])
 }
 
 /**

--- a/server/zanata-frontend/src/editor/app/actions/phrases.js
+++ b/server/zanata-frontend/src/editor/app/actions/phrases.js
@@ -139,14 +139,13 @@ function extractTranslations (source, trans) {
     return []
   }
 
-  // For non-plurals, just use the singluar content
-  // API uses trans.content if nplurals=1, so treat them like singular if
-  // trans.contents are empty.
-  if (!source.plural || isEmpty(trans.contents)) {
-    return trans.content ? [trans.content] : []
-  }
+  const isPlural = source.plural
 
-  return trans.contents ? trans.contents.slice() : []
+  // API uses trans.content if nplurals=1, so use that regardless of plural
+  // forms when it is defined.
+  return trans.content ? [trans.content] : (
+    // Array.slice() efficiently makes a copy of the array.
+    (isPlural && trans.contents) ? trans.contents.slice() : [])
 }
 
 /**

--- a/server/zanata-frontend/src/editor/app/actions/phrases.js
+++ b/server/zanata-frontend/src/editor/app/actions/phrases.js
@@ -1,6 +1,6 @@
 import { fetchPhraseList, fetchPhraseDetail, savePhrase } from '../api'
 import { toggleDropdown } from '.'
-import { isUndefined, mapValues, slice } from 'lodash'
+import { isEmpty, isUndefined, mapValues, slice } from 'lodash'
 import {
   defaultSaveStatus,
   STATUS_NEW,
@@ -128,12 +128,25 @@ function transUnitDetailToPhraseDetail (transUnitDetail, localeId) {
  * Get translations from a TransUnit in a consistent form (array of strings)
  *
  * This will always return an Array<String>, but the array may be empty.
+ *
+ * There is a problem with the API that means plurals for languages with a
+ * single plural form will use trans.content instead of trans.contents for the
+ * plural form. The result of this function has everything normalised to prevent
+ * it causing any problems.
  */
 function extractTranslations (source, trans) {
-  if (source.plural) {
-    return trans && trans.contents ? trans.contents.slice() : []
+  if (!trans) {
+    return []
   }
-  return trans ? [trans.content] : []
+
+  // For non-plurals, just use the singluar content
+  // API uses trans.content if nplurals=1, so treat them like singular if
+  // trans.contents are empty.
+  if (!source.plural || isEmpty(trans.contents)) {
+    return trans.content ? [trans.content] : []
+  }
+
+  return trans.contents ? trans.contents.slice() : []
 }
 
 /**


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-1511

Languages with nplurals=1 would not have plural translations displayed in the React editor. This fixes the display.


## Testing notes

Just needs a document with one plural form, and a language with nplurals=1 (e.g. Japanese). I used the document linked in a JIRA comment to reproduce it before the fix.

When the bug is present, the translation area is blank (no "Singular form" label and no text).


## Reviewer tasks

The following is based on the
[Zanata Development Guidelines](https://github.com/zanata/zanata-server/wiki/Development-Guidelines).
As a reviewer, you should check the guidelines regularly for updates, and just
to refresh your memory.


The reviewer can use this list for reference to make sure
they have considered all the important points.

Use the checkboxes or not, whatever works best for you.

 - Code quality
   - [ ] Code passes style check (checkstyle/eslint)
   - [ ] Code is clear and concise
   - [ ] UI code is internationalised
   - [ ] Code has adequate comments where appropriate
   - Code is in an appropriate place
     - [ ] Classes are in appropriate packages
     - [ ] Code fits with class's responsibilities (SRP)
   - [ ] Configuration files are documented enough
   - If code is removed
     - [ ] No remaining code references the removed code
       - [ ] No orphaned rewrite rules
       - [ ] No orphaned config settings
     - [ ] No remaining comments refer to the removed code
     - [ ] Unused imports and libraries are removed
 - Testing
   - [ ] New code has tests
   - [ ] Changed code has tests
   - [ ] All tests pass
   - [ ] Test coverage stable or increased
 - Documentation
   - [ ] New features are documented
   - [ ] Docs removed for deleted features
   - [ ] Docs updated for all changed features
   - [ ] Developer/sysadmin docs updated if appropriate
 - If there are new dependencies
   - [ ] Does each new dependency pass all the
         [Considerations for new dependencies](https://github.com/zanata/zanata-server/wiki/Development-Guidelines#new-technologies-and-dependencies)?


----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*

The editor was not compensating for an API abnormality that meant
that languages with only a single plural form would store that as
content instead of a length-one array in contents. This was leading
to plurals not being displayed for these languages. This change
fixes that display.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/59)
<!-- Reviewable:end -->
