### PR TITLE
Enable GWT draft mode by default

### DIFF
--- a/server/gwt-editor/pom.xml
+++ b/server/gwt-editor/pom.xml
@@ -10,7 +10,11 @@
   <name>gwt-editor</name>
   <packaging>war</packaging>
   <properties>
-    <zanata.gwt.module>org.zanata.webtrans.Application</zanata.gwt.module>
+    <gwt.module>org.zanata.webtrans.Application</gwt.module>
+    <!-- Enable draft-mode and PRETTY style by default. The
+         optimisedBuild profile overrides these. -->
+    <gwt.draftCompile>true</gwt.draftCompile>
+    <gwt.style>PRETTY</gwt.style>
   </properties>
   <dependencies>
     <dependency>
@@ -200,9 +204,6 @@
               <goal>compile</goal>
               <!-- compile, generateAsync, test -->
             </goals>
-            <configuration>
-              <module>${zanata.gwt.module}</module>
-            </configuration>
           </execution>
           <execution>
             <id>clean</id>
@@ -217,7 +218,6 @@
               <goal>debug</goal>
             </goals>
             <configuration>
-              <module>${zanata.gwt.module}</module>
               <gen>${project.build.directory}/gwt-gen</gen>
               <webappDirectory>
                 ${as.deploy}/zanata.war
@@ -234,9 +234,6 @@
             <goals>
               <goal>run-codeserver</goal>
             </goals>
-            <configuration>
-              <module>${zanata.gwt.module}</module>
-            </configuration>
           </execution>
         </executions>
         <configuration>
@@ -407,7 +404,7 @@
 
     <profile>
       <!-- This profile tells GWT to use an alternative GWT module which has
-        only one permutation, and to compile in draft mode -->
+           only one permutation -->
       <id>chrome</id>
       <activation>
         <property>
@@ -415,25 +412,13 @@
         </property>
       </activation>
       <properties>
-        <zanata.gwt.module>org.zanata.webtrans.ApplicationSafari</zanata.gwt.module>
+        <gwt.module>org.zanata.webtrans.ApplicationSafari</gwt.module>
       </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>gwt-maven-plugin</artifactId>
-            <configuration>
-              <draftCompile>true</draftCompile>
-              <style>PRETTY</style>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
     </profile>
 
     <profile>
       <!-- This profile tells GWT to use an alternative GWT module which has
-        only one permutation, and to compile in draft mode -->
+           only one permutation -->
       <id>firefox</id>
       <activation>
         <property>
@@ -441,25 +426,13 @@
         </property>
       </activation>
       <properties>
-        <zanata.gwt.module>org.zanata.webtrans.ApplicationGecko18</zanata.gwt.module>
+        <gwt.module>org.zanata.webtrans.ApplicationGecko18</gwt.module>
       </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>gwt-maven-plugin</artifactId>
-            <configuration>
-              <draftCompile>true</draftCompile>
-              <style>PRETTY</style>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
     </profile>
 
     <profile>
       <!-- This profile tells GWT to use an alternative GWT module which has
-              only two permutations, and to compile in draft mode -->
+           only two permutations -->
       <id>chromefirefox</id>
       <activation>
         <property>
@@ -467,20 +440,23 @@
         </property>
       </activation>
       <properties>
-        <zanata.gwt.module>org.zanata.webtrans.ApplicationChromeFirefox</zanata.gwt.module>
+        <gwt.module>org.zanata.webtrans.ApplicationChromeFirefox</gwt.module>
       </properties>
-      <build>
-        <plugins>
-          <plugin>
-            <groupId>org.codehaus.mojo</groupId>
-            <artifactId>gwt-maven-plugin</artifactId>
-            <configuration>
-              <draftCompile>true</draftCompile>
-              <style>PRETTY</style>
-            </configuration>
-          </plugin>
-        </plugins>
-      </build>
     </profile>
+
+    <!-- Trigger an optimised build (for production), instead of the default draft build. -->
+    <profile>
+      <id>optimisedBuild</id>
+      <activation>
+        <property>
+          <name>optimise</name>
+        </property>
+      </activation>
+      <properties>
+        <gwt.draftCompile>false</gwt.draftCompile>
+        <gwt.style>OBFUSCATED</gwt.style>
+      </properties>
+    </profile>
+
   </profiles>
 </project>


### PR DESCRIPTION
Draft mode saves about 13 seconds in my unscientific tests running `mvn clean package` (with soft permutations - https://github.com/zanata/zanata-platform/pull/73), compared to `mvn clean package -Doptimise`.

Running `mvn clean package -Dgwt.validateOnly` only saves another 3, but `mvn clean package -Dgwt.compiler.skip` saves 39 seconds (compared to draft) - note that this doesn't run the GWT compiler at all, although it still runs the Java compiler.

## Reviewer tasks

The following is based on the
[Zanata Development Guidelines](https://github.com/zanata/zanata-server/wiki/Development-Guidelines).
As a reviewer, you should check the guidelines regularly for updates, and just
to refresh your memory.


The reviewer can use this list for reference to make sure
they have considered all the important points.

Use the checkboxes or not, whatever works best for you.

 - Code quality
   - [ ] Code passes style check (checkstyle/eslint)
   - [ ] Code is clear and concise
   - [ ] UI code is internationalised
   - [ ] Code has adequate comments where appropriate
   - Code is in an appropriate place
     - [ ] Classes are in appropriate packages
     - [ ] Code fits with class's responsibilities (SRP)
   - [ ] Configuration files are documented enough
   - If code is removed
     - [ ] No remaining code references the removed code
       - [ ] No orphaned rewrite rules
       - [ ] No orphaned config settings
     - [ ] No remaining comments refer to the removed code
     - [ ] Unused imports and libraries are removed
 - Testing
   - [ ] New code has tests
   - [ ] Changed code has tests
   - [ ] All tests pass
   - [ ] Test coverage stable or increased
 - Documentation
   - [ ] New features are documented
   - [ ] Docs removed for deleted features
   - [ ] Docs updated for all changed features
   - [ ] Developer/sysadmin docs updated if appropriate
 - If there are new dependencies
   - [ ] Does each new dependency pass all the
         [Considerations for new dependencies](https://github.com/zanata/zanata-server/wiki/Development-Guidelines#new-technologies-and-dependencies)?


----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/76)
<!-- Reviewable:end -->
