### PR TITLE
fix: fixed long file name wrapping in language panel of documents tab (ZNTA-1647)

### DIFF
--- a/server/zanata-frontend/src/frontend/app/styles/style.less
+++ b/server/zanata-frontend/src/frontend/app/styles/style.less
@@ -3705,11 +3705,14 @@ button.list-group-item {
 
 #documents h2 span#document-label {
   max-width: 100%;
+  hyphens: initial;
+}
+
+.ellipsis {
   text-overflow: ellipsis;
   white-space: nowrap;
   overflow: hidden;
   word-wrap: normal;
-  hyphens: initial;
 }
 
 .panel-heading > .dropdown .dropdown-toggle {

--- a/server/zanata-frontend/src/frontend/app/styles/style.less
+++ b/server/zanata-frontend/src/frontend/app/styles/style.less
@@ -3703,6 +3703,15 @@ button.list-group-item {
   background-color: #fff;
 }
 
+#documents h2 span#document-label {
+  max-width: 100%;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  overflow: hidden;
+  word-wrap: normal;
+  hyphens: initial;
+}
+
 .panel-heading > .dropdown .dropdown-toggle {
   color: inherit;
 }

--- a/server/zanata-war/src/main/webapp/WEB-INF/layout/version/documents-tab.xhtml
+++ b/server/zanata-war/src/main/webapp/WEB-INF/layout/version/documents-tab.xhtml
@@ -269,7 +269,7 @@
     <h2 class="panel__heading">
       <zanata:loader jsHandle="true" layout="inline" type="loader--small"
         visible="false" id="documentsTab-document-label-loader"/>
-      <h:panelGroup id="document-label">
+      <h:panelGroup id="document-label" class="ellipsis">
         #{versionHomeAction.selectedDocument.name}
       </h:panelGroup>
       #{msgs['jsf.Languages']}


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-1647

Long file names in languages panel of documents tab do not appear on one line and file name overlays languages panel content. 

Issue:
![longname-overflow](https://cloud.githubusercontent.com/assets/18179401/21877949/88ea9ca4-d8da-11e6-935b-61986eff3608.png)

Fix:
![longfilenamefix](https://cloud.githubusercontent.com/assets/18179401/21877920/5f463200-d8da-11e6-8be6-9f8083831d99.png)




## Reviewer tasks

The following is based on the
[Zanata Development Guidelines](https://github.com/zanata/zanata-server/wiki/Development-Guidelines).
As a reviewer, you should check the guidelines regularly for updates, and just
to refresh your memory.


The reviewer can use this list for reference to make sure
they have considered all the important points.

Use the checkboxes or not, whatever works best for you.

 - Code quality
   - [ ] Code passes style check (checkstyle/eslint)
   - [ ] Code is clear and concise
   - [ ] UI code is internationalised
   - [ ] Code has adequate comments where appropriate
   - Code is in an appropriate place
     - [ ] Classes are in appropriate packages
     - [ ] Code fits with class's responsibilities (SRP)
   - [ ] Configuration files are documented enough
   - If code is removed
     - [ ] No remaining code references the removed code
       - [ ] No orphaned rewrite rules
       - [ ] No orphaned config settings
     - [ ] No remaining comments refer to the removed code
     - [ ] Unused imports and libraries are removed
 - Testing
   - [ ] New code has tests
   - [ ] Changed code has tests
   - [ ] All tests pass
   - [ ] Test coverage stable or increased
 - Documentation
   - [ ] New features are documented
   - [ ] Docs removed for deleted features
   - [ ] Docs updated for all changed features
   - [ ] Developer/sysadmin docs updated if appropriate
 - If there are new dependencies
   - [ ] Does each new dependency pass all the
         [Considerations for new dependencies](https://github.com/zanata/zanata-server/wiki/Development-Guidelines#new-technologies-and-dependencies)?


----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/141)
<!-- Reviewable:end -->
