### PR TITLE
fix(ZNTA-1597): User can search for a glossary entry

### DIFF
--- a/client/zanata-cli/src/main/java/org/zanata/client/ZanataClient.java
+++ b/client/zanata-cli/src/main/java/org/zanata/client/ZanataClient.java
@@ -26,6 +26,7 @@ import org.zanata.client.commands.ZanataCommand;
 import org.zanata.client.commands.glossary.delete.GlossaryDeleteOptionsImpl;
 import org.zanata.client.commands.glossary.pull.GlossaryPullOptionsImpl;
 import org.zanata.client.commands.glossary.push.GlossaryPushOptionsImpl;
+import org.zanata.client.commands.glossary.search.GlossarySearchOptionsImpl;
 import org.zanata.client.commands.init.InitOptionsImpl;
 import org.zanata.client.commands.pull.PullOptionsImpl;
 import org.zanata.client.commands.push.PushOptionsImpl;
@@ -70,7 +71,8 @@ public class ZanataClient extends BasicOptionsImpl {
             @SubCommand(name = "stats", impl = GetStatisticsOptionsImpl.class),
             @SubCommand(name = "glossary-delete", impl = GlossaryDeleteOptionsImpl.class),
             @SubCommand(name = "glossary-push", impl = GlossaryPushOptionsImpl.class),
-            @SubCommand(name = "glossary-pull", impl = GlossaryPullOptionsImpl.class)})
+            @SubCommand(name = "glossary-pull", impl = GlossaryPullOptionsImpl.class),
+            @SubCommand(name = "glossary-search", impl = GlossarySearchOptionsImpl.class)})
 
     // if this field name changes, change COMMAND_FIELD too
     private Object command;

--- a/client/zanata-client-commands/src/main/java/org/zanata/client/commands/glossary/search/GlossarySearchCommand.java
+++ b/client/zanata-client-commands/src/main/java/org/zanata/client/commands/glossary/search/GlossarySearchCommand.java
@@ -1,0 +1,97 @@
+package org.zanata.client.commands.glossary.search;
+
+import org.apache.commons.lang3.StringUtils;
+import org.codehaus.jackson.JsonNode;
+import org.codehaus.jackson.JsonParser;
+import org.codehaus.jackson.map.ObjectMapper;
+import org.codehaus.jackson.node.ObjectNode;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.zanata.client.commands.ConfigurableCommand;
+import org.zanata.client.commands.OptionsUtil;
+import org.zanata.rest.client.GlossaryClient;
+import org.zanata.rest.client.RestClientFactory;
+
+import javax.ws.rs.client.ResponseProcessingException;
+import javax.ws.rs.core.Response;
+import java.util.ArrayList;
+import java.util.LinkedHashMap;
+import java.util.Map;
+
+/**
+ *
+ * @author Damian Jansen <a href="mailto:djansen@redhat.com">djansen@redhat.com</a>
+ *
+ **/
+public class GlossarySearchCommand extends ConfigurableCommand<GlossarySearchOptions> {
+
+    private static final Logger log = LoggerFactory
+            .getLogger(GlossarySearchCommand.class);
+    private final GlossaryClient client;
+
+    public GlossarySearchCommand(GlossarySearchOptions opts,
+                                 RestClientFactory clientFactory) {
+        super(opts, clientFactory);
+        client = getClientFactory().getGlossaryClient();
+    }
+
+    public GlossarySearchCommand(GlossarySearchOptions opts) {
+        this(opts, OptionsUtil.createClientFactory(opts));
+    }
+
+    @Override
+    public void run() throws Exception {
+        log.info("Server: {}", getOpts().getUrl());
+        log.info("Username: {}", getOpts().getUsername());
+
+        if (StringUtils.isNotBlank(getOpts().getProject())) {
+            log.info("Project: {}", getOpts().getProject());
+        }
+
+        String project = getOpts().getProject();
+        String qualifiedName;
+        try {
+            qualifiedName = StringUtils.isBlank(project)
+                    ? client.getGlobalQualifiedName()
+                    : client.getProjectQualifiedName(project);
+        } catch (ResponseProcessingException rpe) {
+            if (rpe.getResponse().getStatus() == 404) {
+                log.error("Project {} not found", project);
+                return;
+            } else {
+                throw rpe;
+            }
+        }
+        if (StringUtils.isBlank(getOpts().getFilter())) {
+            log.error("Filter query parameter required");
+            return;
+        }
+        Response response = client.find(getOpts().getFilter(), qualifiedName);
+        String responseText = response.readEntity(String.class);
+        if (getOpts().getRaw()) {
+            log.info("Raw JSON:\n{}", responseText);
+        } else {
+            printFind(responseText);
+        }
+        log.info("Search complete");
+    }
+
+    private void printFind(String jsonResponse) throws Exception {
+        ObjectMapper mapper = new ObjectMapper();
+        mapper.configure(JsonParser.Feature.ALLOW_UNQUOTED_FIELD_NAMES, true);
+        Map<?,?> jsonMap = mapper.readValue(jsonResponse, Map.class);
+        log.debug("Entries {}", jsonMap);
+        log.info("Entries found: {}", jsonMap.get("totalCount"));
+
+        ArrayList<ObjectNode> results = (ArrayList)jsonMap.get("results");
+        for (Object node : results) {
+            LinkedHashMap<String,JsonNode> item = (LinkedHashMap)node;
+            log.info("");
+            log.debug("Entry: {}", node);
+            log.info("Result:");
+            log.info("ID: {}", item.get("id"));
+            log.info("Part of Speech: {}", item.get("pos"));
+            log.info("Terms: {}", item.get("glossaryTerms"));
+        }
+    }
+}

--- a/client/zanata-client-commands/src/main/java/org/zanata/client/commands/glossary/search/GlossarySearchOptions.java
+++ b/client/zanata-client-commands/src/main/java/org/zanata/client/commands/glossary/search/GlossarySearchOptions.java
@@ -1,0 +1,10 @@
+package org.zanata.client.commands.glossary.search;
+
+import org.zanata.client.commands.ConfigurableGlossaryOptions;
+
+public interface GlossarySearchOptions extends ConfigurableGlossaryOptions {
+
+    public String getFilter();
+    public String getProject();
+    public boolean getRaw();
+}

--- a/client/zanata-client-commands/src/main/java/org/zanata/client/commands/glossary/search/GlossarySearchOptionsImpl.java
+++ b/client/zanata-client-commands/src/main/java/org/zanata/client/commands/glossary/search/GlossarySearchOptionsImpl.java
@@ -1,0 +1,61 @@
+package org.zanata.client.commands.glossary.search;
+
+import org.kohsuke.args4j.Option;
+import org.zanata.client.commands.ConfigurableGlossaryOptionsImpl;
+import org.zanata.client.commands.ZanataCommand;
+
+public class GlossarySearchOptionsImpl extends ConfigurableGlossaryOptionsImpl
+        implements GlossarySearchOptions {
+
+    private String filter;
+    private String project;
+    private boolean raw;
+
+    @Override
+    public String getFilter() {
+        return filter;
+    }
+
+    @Override
+    public String getProject() {
+        return this.project;
+    }
+
+    @Override
+    public boolean getRaw() {
+        return this.raw;
+    }
+
+    @Option(name = "--filter", metaVar = "FILTER", required = true,
+            usage = "Search term for glossary entries.")
+    public void setFilter(String filter) {
+        this.filter = filter;
+    }
+
+    @Option(name = "--project-glossary", metaVar = "PROJECT",
+            usage = "Project Glossary ID to restrict search.")
+    public void setProject(String project) {
+        this.project = project;
+    }
+
+    @Option(name = "--raw", metaVar = "RAW",
+            usage = "Print the raw JSON response.")
+    public void setRaw(boolean raw) {
+        this.raw = raw;
+    }
+
+    @Override
+    public ZanataCommand initCommand() {
+        return new GlossarySearchCommand(this);
+    }
+
+    @Override
+    public String getCommandName() {
+        return "glossary-search";
+    }
+
+    @Override
+    public String getCommandDescription() {
+        return "Find glossary entries in Zanata";
+    }
+}

--- a/client/zanata-rest-client/src/main/java/org/zanata/rest/client/GlossaryClient.java
+++ b/client/zanata-rest-client/src/main/java/org/zanata/rest/client/GlossaryClient.java
@@ -25,7 +25,6 @@ import java.net.URI;
 import java.util.List;
 import javax.ws.rs.client.Entity;
 import javax.ws.rs.client.WebTarget;
-import javax.ws.rs.core.GenericEntity;
 import javax.ws.rs.core.MediaType;
 import javax.ws.rs.core.Response;
 
@@ -99,6 +98,14 @@ public class GlossaryClient {
                 .request(MediaType.APPLICATION_JSON_TYPE)
                 .get(QualifiedName.class)
                 .getName();
+    }
+
+    public Response find(String query, String qualifiedName) {
+        return webResource().path("entries/")
+                .queryParam("qualifiedName", qualifiedName)
+                .queryParam("filter", query)
+                .request(MediaType.APPLICATION_JSON_TYPE)
+                .get();
     }
 
     private WebTarget webResource() {


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-1597

Added a command for the user to search for glossary entries

## Reviewer tasks

The following is based on the
[Zanata Development Guidelines](https://github.com/zanata/zanata-server/wiki/Development-Guidelines).
As a reviewer, you should check the guidelines regularly for updates, and just
to refresh your memory.


The reviewer can use this list for reference to make sure
they have considered all the important points.

Use the checkboxes or not, whatever works best for you.

 - Code quality
   - [ ] Code passes style check (checkstyle/eslint)
   - [ ] Code is clear and concise
   - [ ] UI code is internationalised
   - [ ] Code has adequate comments where appropriate
   - Code is in an appropriate place
     - [ ] Classes are in appropriate packages
     - [ ] Code fits with class's responsibilities (SRP)
   - [ ] Configuration files are documented enough
   - If code is removed
     - [ ] No remaining code references the removed code
       - [ ] No orphaned rewrite rules
       - [ ] No orphaned config settings
     - [ ] No remaining comments refer to the removed code
     - [ ] Unused imports and libraries are removed
 - Testing
   - [ ] New code has tests
   - [ ] Changed code has tests
   - [ ] All tests pass
   - [ ] Test coverage stable or increased
 - Documentation
   - [ ] New features are documented
   - [ ] Docs removed for deleted features
   - [ ] Docs updated for all changed features
   - [ ] Developer/sysadmin docs updated if appropriate
 - If there are new dependencies
   - [ ] Does each new dependency pass all the
         [Considerations for new dependencies](https://github.com/zanata/zanata-server/wiki/Development-Guidelines#new-technologies-and-dependencies)?


----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
