### PR TITLE
Reduce log verbosity in FacesMessages

### DIFF
--- a/server/zanata-war/src/main/java/org/zanata/i18n/Messages.java
+++ b/server/zanata-war/src/main/java/org/zanata/i18n/Messages.java
@@ -20,6 +20,7 @@
  */
 package org.zanata.i18n;
 
+import java.io.Serializable;
 import java.text.MessageFormat;
 import java.util.AbstractMap;
 import java.util.Enumeration;
@@ -49,9 +50,8 @@ import javax.enterprise.event.Observes;
  * Utility component to help with programmatic access to the message resource
  * bundle.
  *
- * Unlike the {@link org.jboss.seam.international.Messages} component, this
- * component formats messages using positional arguments like {0} and
- * {1}, not by interpolating EL expressions.
+ * Unlike Seam 2's Messages component, this component formats messages using
+ * positional arguments like {0} and {1}, not by interpolating EL expressions.
  *
  * @author Carlos Munoz <a
  *         href="mailto:camunoz@redhat.com">camunoz@redhat.com</a>
@@ -60,7 +60,8 @@ import javax.enterprise.event.Observes;
  */
 
 @Alternative
-public class Messages extends AbstractMap<String, String> {
+public class Messages extends AbstractMap<String, String>
+        implements Serializable {
 
     /**
      * Gets the 'messages' ResourceBundle for the specified locale.
@@ -86,11 +87,13 @@ public class Messages extends AbstractMap<String, String> {
         }
     }
 
+    // non-private for AutoLocaleMessages's benefit
     Locale locale;
     // NB: getBundle will load the bundle whenever it is null
     @Nullable
     transient ResourceBundle resourceBundle;
 
+    // non-private constructor for CDI proxy
     protected Messages() {
     }
 

--- a/server/zanata-war/src/main/java/org/zanata/ui/faces/FacesContextProducer.java
+++ b/server/zanata-war/src/main/java/org/zanata/ui/faces/FacesContextProducer.java
@@ -1,0 +1,36 @@
+/*
+ * Copyright 2017, Red Hat, Inc. and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.zanata.ui.faces;
+
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.inject.Produces;
+import javax.faces.context.FacesContext;
+
+/**
+ * @author Sean Flanigan <a href="mailto:sflaniga@redhat.com">sflaniga@redhat.com</a>
+ */
+public class FacesContextProducer {
+    @Produces
+    @RequestScoped
+    public FacesContext getFacesContext() {
+        return FacesContext.getCurrentInstance();
+    }
+}

--- a/server/zanata-war/src/main/java/org/zanata/ui/faces/FacesMessages.java
+++ b/server/zanata-war/src/main/java/org/zanata/ui/faces/FacesMessages.java
@@ -130,9 +130,7 @@ public class FacesMessages implements Serializable {
     }
 
     /**
-     * Add a status message, looking up the message in the resource bundle using
-     * the provided key. If the message is found, it is used, otherwise, the
-     * defaultMessageTemplate will be used.
+     * Add a status message.
      * <p/>
      * The message will be added to the widget specified by the ID. The
      * algorithm used determine which widget the id refers to is determined by
@@ -140,28 +138,26 @@ public class FacesMessages implements Serializable {
      * <p/>
      * You can also specify the severity, and parameters to be interpolated
      */
-    private void addToControl(String id, Severity severity,
-            String messageTemplate, final Object... params) {
+    private void addToControl(String id, Severity severity, String message) {
         log.debug("{}: addToControl(id={}, template={})", this, id,
-                messageTemplate);
-        String interpolatedMessage = MessageFormat.format(messageTemplate, params);
+                message);
         FacesMessage jsfMssg =
-                new FacesMessage(severity, interpolatedMessage, null);
+                new FacesMessage(severity, message, null);
         if (id == null) {
             if (shouldLogAsWarning(severity)) {
                 log.warn("Global message to user (wid: {}): {})",
                         windowContext.getCurrentWindowId(),
-                        interpolatedMessage);
+                        message);
             } else {
                 log.debug("Global message to user (wid: {}): {})",
                         windowContext.getCurrentWindowId(),
-                        interpolatedMessage);
+                        message);
             }
             // Global message
             globalMessages.add(jsfMssg);
         } else {
             log.debug("Message to user (wid: {} id: {}): {})",
-                    windowContext.getCurrentWindowId(), id, interpolatedMessage);
+                    windowContext.getCurrentWindowId(), id, message);
             // Control specific message
             if (keyedMessages.containsKey(id)) {
                 keyedMessages.get(id).add(jsfMssg);
@@ -178,21 +174,20 @@ public class FacesMessages implements Serializable {
         return severity.compareTo(SEVERITY_ERROR) >= 0;
     }
 
-    public void addToControl(String id, String messageTemplate,
-            final Object... params) {
-        addToControl(id, SEVERITY_INFO, messageTemplate, params);
+    public void addToControl(String id, String message) {
+        addToControl(id, SEVERITY_INFO, message);
     }
 
     /**
      * Adds a global message with the default severity (info).
      *
-     * @param messageTemplate
-     *            The message template string (not a key).
+     * @param message
+     *            The message string (not a key).
      * @param params
      *            The parameters to be interpolated into the template.
      */
-    public void addGlobal(String messageTemplate, final Object... params) {
-        addToControl(null, SEVERITY_INFO, messageTemplate, params);
+    public void addGlobal(String message) {
+        addGlobal(SEVERITY_INFO, message);
     }
 
     /**
@@ -200,14 +195,13 @@ public class FacesMessages implements Serializable {
      *
      * @param severity
      *            Message severity
-     * @param messageTemplate
-     *            The message template string (not a key).
+     * @param message
+     *            The message string (not a key).
      * @param params
      *            The parameters to be interpolated into the template.
      */
-    public void addGlobal(Severity severity, String messageTemplate,
-            final Object... params) {
-        addToControl(null, severity, messageTemplate, params);
+    public void addGlobal(Severity severity, String message) {
+        addToControl(null, severity, message);
     }
 
     public void addGlobal(FacesMessage msg) {
@@ -231,7 +225,7 @@ public class FacesMessages implements Serializable {
     public void addFromResourceBundle(Severity severity, String key,
             final Object... params) {
         String formatedMssg = msgs.formatWithAnyArgs(key, params);
-        addGlobal(severity, formatedMssg, params);
+        addGlobal(severity, formatedMssg);
     }
 
     /**

--- a/server/zanata-war/src/test/java/org/zanata/cdi/WithActiveWindow.java
+++ b/server/zanata-war/src/test/java/org/zanata/cdi/WithActiveWindow.java
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2017, Red Hat, Inc. and individual contributors as indicated by the
+ * @author tags. See the copyright.txt file in the distribution for a full
+ * listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this software; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA, or see the FSF
+ * site: http://www.fsf.org.
+ */
+package org.zanata.cdi;
+
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Inherited;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.enterprise.util.Nonbinding;
+import javax.interceptor.InterceptorBinding;
+
+/**
+ * Controls DeltaSpike's window scope around the annotated method (or all
+ * test methods in a class). Remember to use @SupportDeltaspikeCore too.
+ *
+ * <pre>
+ * &#064;Test
+ * &#064;WithActiveWindow
+ * // This test will be run within the context of a window
+ * void testStart() {
+ *     starship.start();
+ * }
+ * </pre>
+ *
+ * @author Sean Flanigan
+ */
+@InterceptorBinding
+@Inherited
+@Target({ ElementType.METHOD, ElementType.TYPE })
+@Retention(RetentionPolicy.RUNTIME)
+public @interface WithActiveWindow {
+    /**
+     * The windowId to use for the test method.
+     * @return the requested windowId
+     */
+    @Nonbinding
+    String value() default "1";
+}

--- a/server/zanata-war/src/test/java/org/zanata/cdi/WithActiveWindowInterceptor.java
+++ b/server/zanata-war/src/test/java/org/zanata/cdi/WithActiveWindowInterceptor.java
@@ -1,0 +1,61 @@
+/*
+ * Copyright 2017, Red Hat, Inc. and individual contributors as indicated by the
+ * @author tags. See the copyright.txt file in the distribution for a full
+ * listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this software; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA, or see the FSF
+ * site: http://www.fsf.org.
+ */
+package org.zanata.cdi;
+
+import java.io.Serializable;
+import javax.inject.Inject;
+import javax.interceptor.AroundInvoke;
+import javax.interceptor.Interceptor;
+import javax.interceptor.InvocationContext;
+
+import org.apache.deltaspike.core.spi.scope.window.WindowContext;
+
+@Interceptor
+@WithActiveWindow
+public class WithActiveWindowInterceptor implements Serializable {
+
+    public WithActiveWindowInterceptor() {
+    }
+
+    @Inject
+    private WindowContext windowContext;
+
+    @AroundInvoke
+    public Object around(InvocationContext ctx) throws Exception {
+        String windowId = getWindowId(ctx);
+        windowContext.activateWindow(windowId);
+        try {
+            return ctx.proceed();
+        } finally {
+            windowContext.closeWindow(windowId);
+        }
+    }
+
+    private String getWindowId(InvocationContext context) {
+        WithActiveWindow methodAnnot =
+                context.getMethod().getAnnotation(WithActiveWindow.class);
+        if (methodAnnot != null) return methodAnnot.value();
+        WithActiveWindow classAnnot =
+                context.getMethod().getDeclaringClass().getAnnotation(WithActiveWindow.class);
+        if (classAnnot != null) return classAnnot.value();
+        return "1";
+    }
+}

--- a/server/zanata-war/src/test/java/org/zanata/ui/faces/FacesMessagesTest.java
+++ b/server/zanata-war/src/test/java/org/zanata/ui/faces/FacesMessagesTest.java
@@ -1,0 +1,114 @@
+/*
+ * Copyright 2014, Red Hat, Inc. and individual contributors as indicated by the
+ * @author tags. See the copyright.txt file in the distribution for a full
+ * listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it under the
+ * terms of the GNU Lesser General Public License as published by the Free
+ * Software Foundation; either version 2.1 of the License, or (at your option)
+ * any later version.
+ *
+ * This software is distributed in the hope that it will be useful, but WITHOUT
+ * ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS
+ * FOR A PARTICULAR PURPOSE. See the GNU Lesser General Public License for more
+ * details.
+ *
+ * You should have received a copy of the GNU Lesser General Public License
+ * along with this software; if not, write to the Free Software Foundation,
+ * Inc., 51 Franklin St, Fifth Floor, Boston, MA 02110-1301 USA, or see the FSF
+ * site: http://www.fsf.org.
+ */
+package org.zanata.ui.faces;
+
+import javax.enterprise.context.RequestScoped;
+import javax.enterprise.inject.Produces;
+import javax.faces.application.FacesMessage;
+import javax.faces.component.UIViewRoot;
+import javax.faces.context.FacesContext;
+import javax.inject.Inject;
+
+import org.jglue.cdiunit.AdditionalClasses;
+import org.jglue.cdiunit.InRequestScope;
+import org.jglue.cdiunit.ProducesAlternative;
+import org.jglue.cdiunit.deltaspike.SupportDeltaspikeCore;
+import org.jglue.cdiunit.internal.InRequestInterceptor;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.ArgumentCaptor;
+import org.mockito.Mock;
+import org.zanata.cdi.WithActiveWindow;
+import org.zanata.cdi.WithActiveWindowInterceptor;
+import org.zanata.i18n.Messages;
+import org.zanata.test.CdiUnitRunner;
+
+import static java.util.Collections.emptyIterator;
+import static org.assertj.core.api.Assertions.assertThat;
+import static org.mockito.Matchers.eq;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+
+
+/**
+ * @author Sean Flanigan <a href="mailto:sflaniga@redhat.com">sflaniga@redhat.com</a>
+ */
+@RunWith(CdiUnitRunner.class)
+@AdditionalClasses({ InRequestInterceptor.class, WithActiveWindowInterceptor.class})
+@InRequestScope
+@WithActiveWindow("34")
+@SupportDeltaspikeCore
+public class FacesMessagesTest {
+
+    @Inject
+    private FacesMessages facesMessages;
+
+    @Produces @Mock
+    private Messages msgs;
+
+    @Produces @Mock @ProducesAlternative
+    @RequestScoped
+    private FacesContext facesContext;
+    @Produces @Mock
+    private UIViewRoot uiViewRoot;
+
+    @Before
+    public void setup() {
+        when(facesContext.getViewRoot()).thenReturn(uiViewRoot);
+        when(uiViewRoot.getFacetsAndChildren()).thenReturn(emptyIterator());
+    }
+
+    @Test
+    public void addInfoToControl() throws Exception {
+        when(uiViewRoot.getId()).thenReturn("id");
+        when(uiViewRoot.getClientId()).thenReturn("clientId");
+        facesMessages.addToControl("id", "This is a message with {0}.", "parameters");
+        facesMessages.beforeRenderResponse();
+
+        ArgumentCaptor<FacesMessage> message = ArgumentCaptor.forClass(FacesMessage.class);
+        String expectedMessage = "This is a message with parameters.";
+        verify(facesContext).addMessage(eq("clientId"), message.capture());
+        assertThat(message.getValue().getSummary()).isEqualTo(expectedMessage);
+    }
+
+    @Test
+    public void addGlobal() throws Exception {
+        String expectedMessage = "test message";
+        FacesMessage msg = new FacesMessage(expectedMessage);
+        facesMessages.addGlobal(msg);
+        facesMessages.beforeRenderResponse();
+        ArgumentCaptor<FacesMessage> message = ArgumentCaptor.forClass(FacesMessage.class);
+        verify(facesContext).addMessage(eq(null), message.capture());
+        assertThat(message.getValue().getSummary()).isEqualTo(expectedMessage);
+    }
+
+//    @Test
+//    public void getMessagesList() throws Exception {
+////        facesMessages.getMessagesList();
+//    }
+//
+//    @Test
+//    public void getGlobalMessagesList() throws Exception {
+//        facesMessages.getGlobalMessagesList();
+//    }
+
+}

--- a/server/zanata-war/src/test/java/org/zanata/ui/faces/FacesMessagesTest.java
+++ b/server/zanata-war/src/test/java/org/zanata/ui/faces/FacesMessagesTest.java
@@ -23,6 +23,7 @@ package org.zanata.ui.faces;
 import javax.enterprise.context.RequestScoped;
 import javax.enterprise.inject.Produces;
 import javax.faces.application.FacesMessage;
+import javax.faces.application.FacesMessage.Severity;
 import javax.faces.component.UIViewRoot;
 import javax.faces.context.FacesContext;
 import javax.inject.Inject;
@@ -43,6 +44,7 @@ import org.zanata.i18n.Messages;
 import org.zanata.test.CdiUnitRunner;
 
 import static java.util.Collections.emptyIterator;
+import static javax.faces.application.FacesMessage.SEVERITY_INFO;
 import static org.assertj.core.api.Assertions.assertThat;
 import static org.mockito.Matchers.eq;
 import static org.mockito.Mockito.verify;
@@ -58,6 +60,10 @@ import static org.mockito.Mockito.when;
 @WithActiveWindow("34")
 @SupportDeltaspikeCore
 public class FacesMessagesTest {
+
+    private String testMessage = "test message";
+    private ArgumentCaptor<FacesMessage> message =
+            ArgumentCaptor.forClass(FacesMessage.class);
 
     @Inject
     private FacesMessages facesMessages;
@@ -78,37 +84,40 @@ public class FacesMessagesTest {
     }
 
     @Test
-    public void addInfoToControl() throws Exception {
+    public void addToControl() throws Exception {
         when(uiViewRoot.getId()).thenReturn("id");
         when(uiViewRoot.getClientId()).thenReturn("clientId");
-        facesMessages.addToControl("id", "This is a message with {0}.", "parameters");
+        facesMessages.addToControl("id", testMessage);
         facesMessages.beforeRenderResponse();
 
-        ArgumentCaptor<FacesMessage> message = ArgumentCaptor.forClass(FacesMessage.class);
-        String expectedMessage = "This is a message with parameters.";
         verify(facesContext).addMessage(eq("clientId"), message.capture());
-        assertThat(message.getValue().getSummary()).isEqualTo(expectedMessage);
+        assertThat(message.getValue().getSummary()).isEqualTo(testMessage);
+        //noinspection unchecked
+        assertThat(message.getValue().getSeverity()).isEqualTo(
+                SEVERITY_INFO);
     }
 
     @Test
-    public void addGlobal() throws Exception {
-        String expectedMessage = "test message";
-        FacesMessage msg = new FacesMessage(expectedMessage);
-        facesMessages.addGlobal(msg);
+    public void addGlobalString() throws Exception {
+        facesMessages.addGlobal(testMessage);
         facesMessages.beforeRenderResponse();
-        ArgumentCaptor<FacesMessage> message = ArgumentCaptor.forClass(FacesMessage.class);
         verify(facesContext).addMessage(eq(null), message.capture());
-        assertThat(message.getValue().getSummary()).isEqualTo(expectedMessage);
+        assertThat(message.getValue().getSummary()).isEqualTo(testMessage);
+        //noinspection unchecked
+        assertThat(message.getValue().getSeverity()).isEqualTo(
+                SEVERITY_INFO);
     }
 
-//    @Test
-//    public void getMessagesList() throws Exception {
-////        facesMessages.getMessagesList();
-//    }
-//
-//    @Test
-//    public void getGlobalMessagesList() throws Exception {
-//        facesMessages.getGlobalMessagesList();
-//    }
+    @Test
+    public void addGlobalFacesMessage() throws Exception {
+        FacesMessage msg = new FacesMessage(testMessage);
+        facesMessages.addGlobal(msg);
+        facesMessages.beforeRenderResponse();
+        verify(facesContext).addMessage(eq(null), message.capture());
+        assertThat(message.getValue()).isSameAs(msg);
+        //noinspection unchecked
+        assertThat(message.getValue().getSeverity()).isEqualTo(
+                SEVERITY_INFO);
+    }
 
 }


### PR DESCRIPTION
This logging isn't useful:

```
2017-02-27 07:01:14,607 INFO  [org.zanata.ui.faces.FacesMessages] (default task-25) message to user (wid: 1): Please log in first)
2017-02-27 07:01:16,561 INFO  [org.zanata.ui.faces.FacesMessages] (default task-27) message to user (wid: 1): Please log in first)
2017-02-27 07:01:16,564 INFO  [org.zanata.ui.faces.FacesMessages] (default task-27) message to user (wid: 1): Please log in first)
2017-02-27 07:01:44,621 INFO  [org.zanata.ui.faces.FacesMessages] (default task-30) message to user (wid: 1): Please log in first)
2017-02-27 07:01:44,624 INFO  [org.zanata.ui.faces.FacesMessages] (default task-30) message to user (wid: 1): Please log in first)
2017-02-27 07:01:46,593 INFO  [org.zanata.ui.faces.FacesMessages] (default task-31) message to user (wid: 1): Please log in first)
2017-02-27 07:01:46,596 INFO  [org.zanata.ui.faces.FacesMessages] (default task-31) message to user (wid: 1): Please log in first)
2017-02-27 07:02:14,623 INFO  [org.zanata.ui.faces.FacesMessages] (default task-1) message to user (wid: 1): Please log in first)
2017-02-27 07:02:14,625 INFO  [org.zanata.ui.faces.FacesMessages] (default task-1) message to user (wid: 1): Please log in first)
2017-02-27 07:02:16,624 INFO  [org.zanata.ui.faces.FacesMessages] (default task-3) message to user (wid: 1): Please log in first)
2017-02-27 07:02:16,626 INFO  [org.zanata.ui.faces.FacesMessages] (default task-3) message to user (wid: 1): Please log in first)
```


## Reviewer tasks

The following is based on the
[Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines).
As a reviewer, you should check the guidelines regularly for updates, and just
to refresh your memory.


The reviewer can use this list for reference to make sure
they have considered all the important points.

Use the checkboxes or not, whatever works best for you.

 - Code quality
   - [ ] Code passes style check (checkstyle/eslint)
   - [ ] Code is clear and concise
   - [ ] UI code is internationalised
   - [ ] Code has adequate comments where appropriate
   - Code is in an appropriate place
     - [ ] Classes are in appropriate packages
     - [ ] Code fits with class's responsibilities (SRP)
   - [ ] Configuration files are documented enough
   - If code is removed
     - [ ] No remaining code references the removed code
       - [ ] No orphaned rewrite rules
       - [ ] No orphaned config settings
     - [ ] No remaining comments refer to the removed code
     - [ ] Unused imports and libraries are removed
 - Testing
   - [ ] New code has tests
   - [ ] Changed code has tests
   - [ ] All tests pass
   - [ ] Test coverage stable or increased
 - Documentation
   - [ ] New features are documented
   - [ ] Docs removed for deleted features
   - [ ] Docs updated for all changed features
   - [ ] Developer/sysadmin docs updated if appropriate
 - If there are new dependencies
   - [ ] Does each new dependency pass all the
         [Considerations for new dependencies](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines#new-technologies-and-dependencies)?


----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/210)
<!-- Reviewable:end -->
