### PR TITLE
fix: padding added to admin TM page so that dropdown shows (ZNTA-1776)

### DIFF
--- a/server/zanata-frontend/src/frontend/app/styles/style.less
+++ b/server/zanata-frontend/src/frontend/app/styles/style.less
@@ -5978,6 +5978,12 @@ i.i--left.i--lock, i.i--left.i--trash {x
   width: 100%;
 }
 
+/* bugfix for cut off dropdown on TM admin page */
+
+.g--padded {
+  padding-bottom:4.2em !important;
+}
+
 .tabs__content {
   padding-bottom:@spacing-base-and-a-half;
 

--- a/server/zanata-war/src/main/webapp/tm/home.xhtml
+++ b/server/zanata-war/src/main/webapp/tm/home.xhtml
@@ -158,7 +158,7 @@
     </a4j:jsFunction>
 
   </h:form>
-  <div class="g--centered">
+  <div class="g--centered g--padded">
     <div class="g__item w--1-m w--1-2-l w--1-2 l--push-bottom-half">
       <p class="txt--meta l--push-all-0">
         <h:link outcome="/admin/home.xhtml"


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-1776

The last dropdown in the list of the admin translation memory page was not showing correctly - needed some specific css to make the parent block bigger (.g--padded with padding-bottom:4.2em).

## Reviewer tasks

The following is based on the
[Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines).
As a reviewer, you should check the guidelines regularly for updates, and just
to refresh your memory.


The reviewer can use this list for reference to make sure
they have considered all the important points.

Use the checkboxes or not, whatever works best for you.

 - Code quality
   - [ ] Code passes style check (checkstyle/eslint)
   - [ ] Code is clear and concise
   - [ ] UI code is internationalised
   - [ ] Code has adequate comments where appropriate
   - Code is in an appropriate place
     - [ ] Classes are in appropriate packages
     - [ ] Code fits with class's responsibilities (SRP)
   - [ ] Configuration files are documented enough
   - If code is removed
     - [ ] No remaining code references the removed code
       - [ ] No orphaned rewrite rules
       - [ ] No orphaned config settings
     - [ ] No remaining comments refer to the removed code
     - [ ] Unused imports and libraries are removed
 - Testing
   - [ ] New code has tests
   - [ ] Changed code has tests
   - [ ] All tests pass
   - [ ] Test coverage stable or increased
 - Documentation
   - [ ] New features are documented
   - [ ] Docs removed for deleted features
   - [ ] Docs updated for all changed features
   - [ ] Developer/sysadmin docs updated if appropriate
 - If there are new dependencies
   - [ ] Does each new dependency pass all the
         [Considerations for new dependencies](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines#new-technologies-and-dependencies)?


----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/217)
<!-- Reviewable:end -->
