### PR TITLE
Allow translating previously untranslated strings in React editor (ZNTA-1767)

### DIFF
--- a/server/zanata-frontend/src/editor/__tests__/utils/UtilTest.js
+++ b/server/zanata-frontend/src/editor/__tests__/utils/UtilTest.js
@@ -1,0 +1,160 @@
+jest.disableAutomock()
+
+import {
+  parseNPlurals,
+  prepareDocs,
+  prepareLocales,
+  prepareStats
+} from '../../app/utils/Util'
+
+
+describe('parseNPluralsTest', () => {
+  it('can parse valid Plural-Forms string', () => {
+    // Valid plural forms from
+    // https://www.gnu.org/software/gettext/manual/html_node/Plural-forms.html
+    expect(parseNPlurals('nplurals=2; plural=n == 1 ? 0 : 1;')).toEqual(2)
+    expect(parseNPlurals('nplurals=1; plural=0;')).toEqual(1)
+    expect(parseNPlurals('nplurals=2; plural=n != 1;')).toEqual(2)
+    expect(parseNPlurals('nplurals=2; plural=n>1;')).toEqual(2)
+    expect(parseNPlurals(
+      'nplurals=3; plural=n%10==1 && n%100!=11 ? 0 : n != 0 ? 1 : 2;'))
+      .toEqual(3)
+    expect(parseNPlurals(
+      'nplurals=6; plural=n==0 ? 0 : n==1 ? 1 : n==2 ? 2 ' +
+      ': n%100>=3 && n%100<=10 ? 3 : n%100>=11 ? 4 : 5;')).toEqual(6)
+  })
+
+  it('returns undefined when plural string is null or empty', () => {
+    expect(parseNPlurals(undefined)).toBeUndefined()
+    expect(parseNPlurals(null)).toBeUndefined()
+    expect(parseNPlurals('')).toBeUndefined()
+  })
+
+  it('returns undefined for strings without valid nplurals', () => {
+    expect(parseNPlurals('nplurals=x; plural=y;')).toBeUndefined()
+    expect(parseNPlurals('not even a plural forms string')).toBeUndefined()
+    expect(parseNPlurals('mplurals=7; the mumber of plurals')).toBeUndefined()
+  })
+})
+
+describe('prepareLocalesTest', () => {
+  it('Can transform locales to the expected form', () => {
+    // Values taken from API response.
+    const unpreparedLocales =
+      [
+        {
+          'localeId': 'de',
+          'displayName': 'German',
+          'nativeName': 'Deutsch',
+          'enabled': true,
+          'enabledByDefault': true,
+          'pluralForms': 'nplurals=2; plural=(n != 1)'
+        }, {
+          'localeId': 'ja',
+          'displayName': 'Japanese',
+          'nativeName': '日本語',
+          'enabled': true,
+          'enabledByDefault': true,
+          'pluralForms': 'nplurals=1; plural=0'
+        }
+      ]
+
+    const preparedLocales = {
+      de: {
+        id: 'de',
+        name: 'German',
+        nplurals: 2
+      },
+      ja: {
+        id: 'ja',
+        name: 'Japanese',
+        nplurals: 1
+      }
+    }
+
+    expect(prepareLocales(unpreparedLocales)).toEqual(preparedLocales)
+  })
+})
+
+
+describe('prepareStatsTest', () => {
+  it('Can can translate statistics to the expected form.', () => {
+    // Values taken from API response.
+    const unpreparedStats = [
+      {
+        'total': 4592,
+        'untranslated': 4592,
+        'needReview': 0,
+        'translated': 0,
+        'approved': 0,
+        'rejected': 0,
+        'fuzzy': 0,
+        'unit': 'WORD',
+        'locale': 'de',
+        'lastTranslated': null,
+        'translatedOnly': 0
+      }, {
+        'total': 495,
+        'untranslated': 460,
+        'needReview': 0,
+        'translated': 15,
+        'approved': 5,
+        'rejected': 0,
+        'fuzzy': 20,
+        'unit': 'MESSAGE',
+        'locale': 'de',
+        'lastTranslated': null,
+        'translatedOnly': 10
+      }
+    ]
+
+    // just the MESSAGE stats
+    const preparedStats = {
+      'total': 495,
+      'untranslated': 460,
+      'approved': 5,
+      'rejected': 0,
+      'needswork': 20,
+      'translated': 10
+    }
+
+    expect(prepareStats(unpreparedStats)).toEqual(preparedStats)
+  })
+})
+
+describe('prepareDocsTest', () => {
+  it('Can handle a null document list', () => {
+    expect(prepareDocs([])).toEqual([])
+  })
+
+  it('Can transform a list of documents to the expected structure.', () => {
+    // Values taken from API response.
+    const unpreparedDocs = [
+      {
+        'name': 'template20161102.pot',
+        'contentType': 'application/x-gettext',
+        'lang': 'en-US',
+        'type': 'FILE',
+        'revision': 1
+      }, {
+        'name': 'flags/template20161102.pot',
+        'contentType': 'application/x-gettext',
+        'lang': 'en-US',
+        'type': 'FILE',
+        'revision': 1
+      }, {
+        'name': 'msgctxt/template20161102.pot',
+        'contentType': 'application/x-gettext',
+        'lang': 'en-US',
+        'type': 'FILE',
+        'revision': 1
+      }
+    ]
+    const preparedDocs = [
+      'template20161102.pot',
+      'flags/template20161102.pot',
+      'msgctxt/template20161102.pot'
+    ]
+    expect(prepareDocs(unpreparedDocs)).toEqual(preparedDocs)
+  })
+})

--- a/server/zanata-frontend/src/editor/__tests__/utils/phraseTest.js
+++ b/server/zanata-frontend/src/editor/__tests__/utils/phraseTest.js
@@ -1,0 +1,101 @@
+jest.disableAutomock()
+
+import {
+  getSaveButtonStatus,
+} from '../../app/utils/phrase'
+import {
+    STATUS_UNTRANSLATED,
+    STATUS_NEEDS_WORK,
+    STATUS_TRANSLATED
+} from '../../app/utils/status'
+
+describe('getSaveButtonStatusTest', () => {
+  it('Returns UNTRANSLATED when nothing is translated', () => {
+    const phrase1 = {
+      newTranslations: []
+    }
+
+    const phrase2 = {
+      newTranslations: [
+        '',
+        ''
+      ]
+    }
+
+    expect(getSaveButtonStatus(phrase1)).toEqual(STATUS_UNTRANSLATED)
+    expect(getSaveButtonStatus(phrase2)).toEqual(STATUS_UNTRANSLATED)
+  })
+
+  it('Returns NEEDS_WORK when some but not all translations are empty', () => {
+    const phrase1 = {
+      newTranslations: [
+        '',
+        'Hello'
+      ]
+    }
+    const phrase2 = {
+      newTranslations: [
+        'Hi',
+        '',
+        'Hello'
+      ]
+    }
+
+    expect(getSaveButtonStatus(phrase1)).toEqual(STATUS_NEEDS_WORK)
+    expect(getSaveButtonStatus(phrase2)).toEqual(STATUS_NEEDS_WORK)
+  })
+
+  it('Returns TRANSLATED when all translated and something changed', () => {
+    const phrase1 = {
+      translations: [
+        'Hi',
+        ''
+      ],
+      newTranslations: [
+        'Hi',
+        'Hello'
+      ]
+    }
+    const phrase2 = {
+      translations: [
+        'Hi',
+        'Hello'
+      ],
+      newTranslations: [
+        'Hi',
+        'Haldo'
+      ]
+    }
+
+    expect(getSaveButtonStatus(phrase1)).toEqual(STATUS_TRANSLATED)
+    expect(getSaveButtonStatus(phrase2)).toEqual(STATUS_TRANSLATED)
+  })
+
+  it('Returns the current status when nothing has changed', () => {
+    const phrase1 = {
+      status: STATUS_NEEDS_WORK,
+      translations: [
+        'Hi',
+        'Hello'
+      ],
+      newTranslations: [
+        'Hi',
+        'Hello'
+      ]
+    }
+    const phrase2 = {
+      status: STATUS_TRANSLATED,
+      translations: [
+        'Hi',
+        'Hello'
+      ],
+      newTranslations: [
+        'Hi',
+        'Hello'
+      ]
+    }
+
+    expect(getSaveButtonStatus(phrase1)).toEqual(STATUS_NEEDS_WORK)
+    expect(getSaveButtonStatus(phrase2)).toEqual(STATUS_TRANSLATED)
+  })
+})

--- a/server/zanata-frontend/src/editor/app/utils/Util.js
+++ b/server/zanata-frontend/src/editor/app/utils/Util.js
@@ -1,5 +1,24 @@
 import { chain, isNaN, map } from 'lodash'
 
+const npluralRegex = /^nplurals\s*=\s*(\d*)\s*;/
+
+/**
+ * Extract nplurals value as an integer from a Plural-Forms string.
+ *
+ * Given a string in the form 'nplurals=x; plural=(y)', extract x
+ */
+export const parseNPlurals = (pluralFormsString) => {
+  const result = npluralRegex.exec(pluralFormsString)
+  if (result !== null) {
+    const nplurals = parseInt(result[1], 10)
+    if (!isNaN(nplurals)) {
+      return nplurals
+    }
+  }
+  // Could not find and parse a valid nplurals integer
+  return undefined
+}
+
 /* convert from structure used in angular to structure used in react */
 // TODO we should change the server response to save us from doing this
 //      transformation
@@ -16,25 +35,6 @@ export const prepareLocales = (locales) => {
       })
       .keyBy('id')
       .value()
-}
-
-const npluralRegex = /^nplurals\s*=\s*(\d*)\s*;/
-
-/**
- * Extract nplurals value as an integer from a Plural-Forms string.
- *
- * Given a string in the form 'nplurals=x; plural=(y)', extract x
- */
-function parseNPlurals (pluralFormsString) {
-  const result = npluralRegex.exec(pluralFormsString)
-  if (result !== null) {
-    const nplurals = parseInt(result[1], 10)
-    if (!isNaN(nplurals)) {
-      return nplurals
-    }
-  }
-  // Could not find and parse a valid nplurals integer
-  return undefined
 }
 
 /**

--- a/server/zanata-frontend/src/editor/app/utils/Util.js
+++ b/server/zanata-frontend/src/editor/app/utils/Util.js
@@ -1,4 +1,4 @@
-import { chain, map } from 'lodash'
+import { chain, isNaN, map } from 'lodash'
 
 /* convert from structure used in angular to structure used in react */
 // TODO we should change the server response to save us from doing this
@@ -6,13 +6,35 @@ import { chain, map } from 'lodash'
 export const prepareLocales = (locales) => {
   return chain(locales || [])
       .map(function (locale) {
+        const nplurals = parseNPlurals(locale.pluralForms)
+
         return {
           id: locale.localeId,
-          name: locale.displayName
+          name: locale.displayName,
+          nplurals
         }
       })
       .keyBy('id')
       .value()
+}
+
+const npluralRegex = /^nplurals\s*=\s*(\d*)\s*;/
+
+/**
+ * Extract nplurals value as an integer from a Plural-Forms string.
+ *
+ * Given a string in the form 'nplurals=x; plural=(y)', extract x
+ */
+function parseNPlurals (pluralFormsString) {
+  const result = npluralRegex.exec(pluralFormsString)
+  if (result !== null) {
+    const nplurals = parseInt(result[1], 10)
+    if (!isNaN(nplurals)) {
+      return nplurals
+    }
+  }
+  // Could not find and parse a valid nplurals integer
+  return undefined
 }
 
 /**

--- a/server/zanata-frontend/src/editor/app/utils/phrase.js
+++ b/server/zanata-frontend/src/editor/app/utils/phrase.js
@@ -24,11 +24,15 @@ export function getSaveButtonStatus (phrase) {
 export function hasTranslationChanged (phrase) {
   // on Firefox with input method turned on,
   // when hitting tab it seems to turn undefined value into ''
-  var allSame = every(phrase.translations,
+
+  // Iterating newTranslations since those are guaranteed to exist for all
+  // plural forms. translations can be just an empty array.
+  const allSame = every(phrase.newTranslations,
       function (translation, index) {
         return nullToEmpty(translation) ===
-            nullToEmpty(phrase.newTranslations[index])
+            nullToEmpty(phrase.translations[index])
       })
+
   return !allSame
 }
 


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-1767

Ensured the redux backend populates empty translation objects so that the frontend will allow adding translations.

Also includes an incidental fix for the save buttons - they weren't selecting "Translated" button automatically upon change like they should have been.

## Reviewer tasks

The following is based on the
[Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines).
As a reviewer, you should check the guidelines regularly for updates, and just
to refresh your memory.


The reviewer can use this list for reference to make sure
they have considered all the important points.

Use the checkboxes or not, whatever works best for you.

 - Code quality
   - [ ] Code passes style check (checkstyle/eslint)
   - [ ] Code is clear and concise
   - [ ] UI code is internationalised
   - [ ] Code has adequate comments where appropriate
   - Code is in an appropriate place
     - [ ] Classes are in appropriate packages
     - [ ] Code fits with class's responsibilities (SRP)
   - [ ] Configuration files are documented enough
   - If code is removed
     - [ ] No remaining code references the removed code
       - [ ] No orphaned rewrite rules
       - [ ] No orphaned config settings
     - [ ] No remaining comments refer to the removed code
     - [ ] Unused imports and libraries are removed
 - Testing
   - [ ] New code has tests
   - [ ] Changed code has tests
   - [ ] All tests pass
   - [ ] Test coverage stable or increased
 - Documentation
   - [ ] New features are documented
   - [ ] Docs removed for deleted features
   - [ ] Docs updated for all changed features
   - [ ] Developer/sysadmin docs updated if appropriate
 - If there are new dependencies
   - [ ] Does each new dependency pass all the
         [Considerations for new dependencies](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines#new-technologies-and-dependencies)?


----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/227)
<!-- Reviewable:end -->
