### PR TITLE
ZNTA-1729 - fix translation file ignore mapping rules

### DIFF
--- a/client/zanata-client-commands/src/main/java/org/zanata/client/commands/pull/PropertiesStrategy.java
+++ b/client/zanata-client-commands/src/main/java/org/zanata/client/commands/pull/PropertiesStrategy.java
@@ -21,6 +21,7 @@
 
 package org.zanata.client.commands.pull;
 
+import java.io.File;
 import java.io.IOException;
 
 import org.zanata.adapter.properties.PropWriter;
@@ -62,9 +63,11 @@ public class PropertiesStrategy extends AbstractPullStrategy {
             LocaleMapping localeMapping, TranslationsResource targetDoc)
             throws IOException {
         boolean createSkeletons = getOpts().getCreateSkeletons();
-        PropWriter.writeTranslations(createSkeletons ? doc : null, targetDoc,
-            getOpts().getTransDir(), docName,
-            localeMapping.getJavaLocale(), PropWriter.CHARSET.Latin1, createSkeletons);
+        File transFileToWrite = getTransFileToWrite(docName, localeMapping);
+        PropWriter.writeTranslationsFile(createSkeletons ? doc : null,
+                targetDoc, transFileToWrite, PropWriter.CHARSET.Latin1,
+                createSkeletons);
+
         return null;
     }
 

--- a/client/zanata-client-commands/src/main/java/org/zanata/client/commands/pull/UTF8PropertiesStrategy.java
+++ b/client/zanata-client-commands/src/main/java/org/zanata/client/commands/pull/UTF8PropertiesStrategy.java
@@ -21,6 +21,7 @@
 
 package org.zanata.client.commands.pull;
 
+import java.io.File;
 import java.io.IOException;
 
 import org.zanata.adapter.properties.PropWriter;
@@ -50,9 +51,9 @@ public class UTF8PropertiesStrategy extends PropertiesStrategy {
             LocaleMapping localeMapping, TranslationsResource targetDoc)
             throws IOException {
         boolean createSkeletons = getOpts().getCreateSkeletons();
-        PropWriter.writeTranslations(createSkeletons ? doc : null, targetDoc,
-            getOpts().getTransDir(),
-            docName, localeMapping.getJavaLocale(),
+        File transFileToWrite = getTransFileToWrite(docName, localeMapping);
+        PropWriter.writeTranslationsFile(doc, targetDoc,
+            transFileToWrite,
             PropWriter.CHARSET.UTF8, createSkeletons);
         return null;
     }

--- a/client/zanata-client-commands/src/main/java/org/zanata/client/commands/pull/XliffStrategy.java
+++ b/client/zanata-client-commands/src/main/java/org/zanata/client/commands/pull/XliffStrategy.java
@@ -21,6 +21,7 @@
 
 package org.zanata.client.commands.pull;
 
+import java.io.File;
 import java.io.IOException;
 
 import org.zanata.adapter.xliff.XliffWriter;
@@ -61,7 +62,8 @@ public class XliffStrategy extends AbstractPullStrategy {
     public FileDetails writeTransFile(Resource doc, String docName,
             LocaleMapping localeMapping, TranslationsResource targetDoc)
             throws IOException {
-        XliffWriter.write(getOpts().getTransDir(), doc, localeMapping
+        File transFileToWrite = getTransFileToWrite(docName, localeMapping);
+        XliffWriter.writeFile(transFileToWrite, doc, localeMapping
                 .getLocalLocale(), targetDoc, getOpts().getCreateSkeletons());
         return null;
     }


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-1729

- property and xliff projects will ignore how file mapping rules are set in turns of the translation file name.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/260)
<!-- Reviewable:end -->
