### PR TITLE
chore: limit concurrency for integration tests

### DIFF
--- a/build-tools/src/test/java/TestJenkinsfile.java
+++ b/build-tools/src/test/java/TestJenkinsfile.java
@@ -45,8 +45,11 @@ public class TestJenkinsfile extends BasePipelineTestCPS {
         getHelper().registerAllowedMethod("archive", ImmutableList.of(Object.class), null);
         getHelper().registerAllowedMethod("hipchatSend", ImmutableList.of(Map.class), null);
         getHelper().registerAllowedMethod("junit", ImmutableList.of(Map.class), null);
-        getHelper().registerAllowedMethod("timestamps", ImmutableList.of(Closure.class), null);
+        getHelper().registerAllowedMethod("lock", ImmutableList.of(Map.class, Closure.class), null);
+        getHelper().registerAllowedMethod("lock", ImmutableList.of(String.class, Closure.class), null);
+        getHelper().registerAllowedMethod("milestone", ImmutableList.of(), null);
         getHelper().registerAllowedMethod("stash", ImmutableList.of(Map.class), null);
+        getHelper().registerAllowedMethod("timestamps", ImmutableList.of(Closure.class), null);
         getHelper().registerAllowedMethod("unstash", ImmutableList.of(Map.class), null);
         getHelper().registerAllowedMethod("unstash", ImmutableList.of(String.class), null);
         getHelper().registerAllowedMethod("withEnv", ImmutableList.of(List.class, Closure.class), null);


### PR DESCRIPTION
Using [locks](https://plugins.jenkins.io/lockable-resources) will allow us to control the number of concurrent integration tests for (a) mainline branches (`master`, `release`, `legacy`), (b) other, non-mainline branches and (c) pull requests. Unit tests will not be affected.

When multiple integration tests for a pipeline are delayed by locking, the earlier tests will be aborted by the later tests (using [milestones](https://plugins.jenkins.io/pipeline-milestone-step)), which will reduce the resource requirements considerably.

## Reviewer tasks

The following is based on the
[Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines).
As a reviewer, you should check the guidelines regularly for updates, and just
to refresh your memory.


The reviewer can use this list for reference to make sure
they have considered all the important points.

Use the checkboxes or not, whatever works best for you.

 - Code quality
   - [ ] Code passes style check (checkstyle/eslint)
   - [ ] Code is clear and concise
   - [ ] UI code is internationalised
   - [ ] Code has adequate comments where appropriate
   - Code is in an appropriate place
     - [ ] Classes are in appropriate packages
     - [ ] Code fits with class's responsibilities (SRP)
   - [ ] Configuration files are documented enough
   - If code is removed
     - [ ] No remaining code references the removed code
       - [ ] No orphaned rewrite rules
       - [ ] No orphaned config settings
     - [ ] No remaining comments refer to the removed code
     - [ ] Unused imports and libraries are removed
 - Testing
   - [ ] New code has tests
   - [ ] Changed code has tests
   - [ ] All tests pass
   - [ ] Test coverage stable or increased
 - Documentation
   - [ ] New features are documented
   - [ ] Docs removed for deleted features
   - [ ] Docs updated for all changed features
   - [ ] Developer/sysadmin docs updated if appropriate
 - If there are new dependencies
   - [ ] Does each new dependency pass all the
         [Considerations for new dependencies](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines#new-technologies-and-dependencies)?


----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/268)
<!-- Reviewable:end -->
