### PR TITLE
chore(Jenkinsfile) add workaround for JENKINS-38813

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -9,6 +9,7 @@
 @Library('zanata-pipeline-library@master')
 import org.zanata.jenkins.Notifier
 import org.zanata.jenkins.PullRequests
+import static org.zanata.jenkins.StackTraces.getStackTrace
 
 import groovy.transform.Field
 
@@ -68,10 +69,25 @@ node {
 }
 
 String getLabel() {
-  if (params.LABEL == null) {
+  def labelParam = null
+  try {
+    labelParam = params.LABEL
+  } catch (e1) {
+    // workaround for https://issues.jenkins-ci.org/browse/JENKINS-38813
+    echo '[WARNING] unable to access `params`'
+    echo getStackTrace(e1)
+    try {
+      labelParam = LABEL
+    } catch (e2) {
+      echo '[WARNING] unable to access `LABEL`'
+      echo getStackTrace(e2)
+    }
+  }
+
+  if (labelParam == null) {
     echo "LABEL param is null; using default value."
   }
-  def result =  params.LABEL ?: defaultNodeLabel
+  def result = labelParam ?: defaultNodeLabel
   echo "Using build node label: $result"
   return result
 }


### PR DESCRIPTION
## Reviewer tasks

The following is based on the
[Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines).
As a reviewer, you should check the guidelines regularly for updates, and just
to refresh your memory.


The reviewer can use this list for reference to make sure
they have considered all the important points.

Use the checkboxes or not, whatever works best for you.

 - Code quality
   - [ ] Code passes style check (checkstyle/eslint)
   - [ ] Code is clear and concise
   - [ ] UI code is internationalised
   - [ ] Code has adequate comments where appropriate
   - Code is in an appropriate place
     - [ ] Classes are in appropriate packages
     - [ ] Code fits with class's responsibilities (SRP)
   - [ ] Configuration files are documented enough
   - If code is removed
     - [ ] No remaining code references the removed code
       - [ ] No orphaned rewrite rules
       - [ ] No orphaned config settings
     - [ ] No remaining comments refer to the removed code
     - [ ] Unused imports and libraries are removed
 - Testing
   - [ ] New code has tests
   - [ ] Changed code has tests
   - [ ] All tests pass
   - [ ] Test coverage stable or increased
 - Documentation
   - [ ] New features are documented
   - [ ] Docs removed for deleted features
   - [ ] Docs updated for all changed features
   - [ ] Developer/sysadmin docs updated if appropriate
 - If there are new dependencies
   - [ ] Does each new dependency pass all the
         [Considerations for new dependencies](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines#new-technologies-and-dependencies)?


----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/273)
<!-- Reviewable:end -->
