### PR TITLE
chore: shorten HTML for test logs (dino game)

### DIFF
--- a/server/functional-test/src/main/java/org/zanata/page/AbstractPage.java
+++ b/server/functional-test/src/main/java/org/zanata/page/AbstractPage.java
@@ -28,11 +28,11 @@ import org.openqa.selenium.support.PageFactory;
 import org.openqa.selenium.support.pagefactory.AjaxElementLocatorFactory;
 import org.openqa.selenium.support.ui.ExpectedConditions;
 import org.openqa.selenium.support.ui.FluentWait;
-import org.zanata.util.ShortString;
 import org.zanata.util.WebElementUtil;
 import com.google.common.base.Function;
 import com.google.common.base.Predicate;
 import static org.assertj.core.api.Assertions.assertThat;
+import static org.zanata.page.utility.PageSourceKt.shortenPageSource;
 
 /**
  * The base class for the page driver. Contains functionality not generally of a
@@ -193,8 +193,7 @@ public class AbstractPage {
                     if (outstanding == null) {
                         if (log.isWarnEnabled()) {
                             String url = getDriver().getCurrentUrl();
-                            String pageSource = ShortString
-                                    .shorten(getDriver().getPageSource(), 2000);
+                            String pageSource = shortenPageSource(getDriver());
                             log.warn(
                                     "XMLHttpRequest.active is null. Is zanata-testing-extension installed? URL: {}\nPartial page source follows:\n{}",
                                     url, pageSource);

--- a/server/functional-test/src/main/java/org/zanata/page/WebDriverFactory.java
+++ b/server/functional-test/src/main/java/org/zanata/page/WebDriverFactory.java
@@ -64,10 +64,10 @@ import org.zanata.util.ScreenshotDirForTest;
 import org.zanata.util.TestEventForScreenshotListener;
 
 import javax.annotation.CheckForNull;
-import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 import javax.annotation.ParametersAreNonnullByDefault;
 import static java.lang.reflect.Proxy.newProxyInstance;
+import static org.zanata.page.utility.PageSourceKt.shortenPageSource;
 import static org.zanata.util.Constants.webDriverType;
 import static org.zanata.util.Constants.webDriverWait;
 import static org.zanata.util.Constants.zanataInstance;
@@ -234,17 +234,19 @@ public enum WebDriverFactory {
                 // If firstException was a warning, replace it with this error.
                 if ((firstException == null || !firstException.isErrorLog())
                         && !ignorable(msg)) {
+                    String pageSource = shortenPageSource(getDriver());
                     // We only throw this if throwIfWarn is true
                     firstException = new WebDriverLogException(level, logString,
-                            driver.getPageSource());
+                            pageSource);
                 }
             } else if (level.intValue() >= Level.WARNING.intValue()) {
                 log.warn(logString);
                 if ((firstException == null) && !ignorable(msg)) {
+                    String pageSource = shortenPageSource(getDriver());
                     // We only throw this if throwIfWarn is true
                     firstException =
                             new WebDriverLogException(logEntry.getLevel(),
-                                    logString, driver.getPageSource());
+                                    logString, pageSource);
                 }
             } else if (level.intValue() >= Level.INFO.intValue()) {
                 log.info(logString);

--- a/server/functional-test/src/main/java/org/zanata/page/utility/PageSource.kt
+++ b/server/functional-test/src/main/java/org/zanata/page/utility/PageSource.kt
@@ -1,0 +1,47 @@
+/*
+ * Copyright 2017, Red Hat, Inc. and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.zanata.page.utility
+
+import org.openqa.selenium.WebDriver
+import org.zanata.util.ShortString.shorten
+
+/**
+ * Summarises the HTML for a page.
+ * @param pageSource HTML to be summarised
+ * @return a summary of the HTML
+ * @author Sean Flanigan [sflaniga@redhat.com](mailto:sflaniga@redhat.com)
+ */
+fun shortenPageSource(pageSource: String): String {
+    // Chrome's dinosaur game puts lots of binary data into the DOM
+    if (pageSource.contains("data:image/png;base64") && pageSource.contains("ERR_INTERNET_DISCONNECTED")) {
+        return "ERR_INTERNET_DISCONNECTED"
+    }
+    return shorten(pageSource, 2000)
+}
+
+/**
+ * Extension function to summarise the HTML for WebDriver's current page.
+ * @return a summary of the HTML
+ * @author Sean Flanigan [sflaniga@redhat.com](mailto:sflaniga@redhat.com)
+ */
+fun WebDriver.shortenPageSource(): String {
+    return shortenPageSource(pageSource)
+}


### PR DESCRIPTION

## Reviewer tasks

The following is based on the
[Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines).
As a reviewer, you should check the guidelines regularly for updates, and just
to refresh your memory.


The reviewer can use this list for reference to make sure
they have considered all the important points.

Use the checkboxes or not, whatever works best for you.

 - Code quality
   - [ ] Code passes style check (checkstyle/eslint)
   - [ ] Code is clear and concise
   - [ ] UI code is internationalised
   - [ ] Code has adequate comments where appropriate
   - Code is in an appropriate place
     - [ ] Classes are in appropriate packages
     - [ ] Code fits with class's responsibilities (SRP)
   - [ ] Configuration files are documented enough
   - If code is removed
     - [ ] No remaining code references the removed code
       - [ ] No orphaned rewrite rules
       - [ ] No orphaned config settings
     - [ ] No remaining comments refer to the removed code
     - [ ] Unused imports and libraries are removed
 - Testing
   - [ ] New code has tests
   - [ ] Changed code has tests
   - [ ] All tests pass
   - [ ] Test coverage stable or increased
 - Documentation
   - [ ] New features are documented
   - [ ] Docs removed for deleted features
   - [ ] Docs updated for all changed features
   - [ ] Developer/sysadmin docs updated if appropriate
 - If there are new dependencies
   - [ ] Does each new dependency pass all the
         [Considerations for new dependencies](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines#new-technologies-and-dependencies)?


----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/311)
<!-- Reviewable:end -->
