### PR TITLE
Split build commands to a separate file (ZNTA-1829)

### DIFF
--- a/server/zanata-frontend/src/frontend/package.json
+++ b/server/zanata-frontend/src/frontend/package.json
@@ -16,7 +16,7 @@
     "storybook-frontend": "start-storybook -p 9001 -s ./dist --config-dir .storybook-frontend",
     "storybook-build": "build-storybook -s ./dist",
     "icons": "node scripts/createIconsComponent && node scripts/generateIconList",
-    "svg": "svg-sprite -sD app/components/Icons --symbol-dest '' --ss icons.svg --si app/components/Icons/svgs/*.svg",
+    "svg": "node scripts/build-icon-spritesheet",
     "test": "jest --coverage"
   },
   "repository": {

--- a/server/zanata-frontend/src/frontend/package.json
+++ b/server/zanata-frontend/src/frontend/package.json
@@ -5,18 +5,15 @@
   "main": "index.js",
   "scripts": {
     "js": "webpack",
-    "build": "yarn build:icons && webpack -p --config webpack.prod.config.js --bail --display-error-details",
-    "draft": "yarn build:icons && webpack --config webpack.draft.config.js --bail --display-error-details",
+    "build": "node scripts/build",
+    "draft": "node scripts/build --draft",
     "watch": "node scripts/dev-server",
     "watch:editor": "node scripts/dev-server --editor",
-    "build:icons": "yarn svg && yarn icons",
     "styleguide-server": "styleguidist server",
     "styleguide-build": "styleguidist build",
     "storybook-editor": "start-storybook -p 9001 -s ./dist --config-dir .storybook-editor",
     "storybook-frontend": "start-storybook -p 9001 -s ./dist --config-dir .storybook-frontend",
     "storybook-build": "build-storybook -s ./dist",
-    "icons": "node scripts/createIconsComponent && node scripts/generateIconList",
-    "svg": "node scripts/build-icon-spritesheet",
     "test": "jest --coverage"
   },
   "repository": {

--- a/server/zanata-frontend/src/frontend/scripts/build-icon-spritesheet.js
+++ b/server/zanata-frontend/src/frontend/scripts/build-icon-spritesheet.js
@@ -1,0 +1,51 @@
+/* eslint-disable no-console */
+
+/**
+ * Combines svgs in the Icons component to an svg spritesheet.
+ */
+
+const c = require('cli-color')
+const fs = require('fs-extra')
+const path = require('path')
+const SVGSpriter = require('svg-sprite')
+
+// TODO run this as part of icon icon creation scripts
+
+console.log(c.bgCyan(c.black(' Generating icons spritesheet ')))
+
+const spriter = new SVGSpriter({
+  dest: 'app/components/Icons',
+  svg: {},
+  mode: {
+    symbol: {
+      dest: '',
+      sprite: 'icons.svg',
+      inline: true
+    }
+  }
+})
+const svgsPath = path.resolve('app/components/Icons/svgs/')
+console.log(c.magenta('Reading svgs from ' + svgsPath))
+const svgFiles = fs.readdirSync(svgsPath)
+const colWidth = svgFiles.reduce((l, name) => Math.max(l, name.length), 0)
+var count = 0
+svgFiles.map((fileName) => {
+  count++
+  process.stdout.write(c.blue(' ' +
+    (fileName + '                            ').slice(0, colWidth)))
+  if (count % 4 === 0) process.stdout.write('\n')
+  const fullPath = path.join(svgsPath, fileName)
+  spriter.add(fullPath, fileName, fs.readFileSync(fullPath))
+})
+spriter.compile((err, result) => {
+  if (err) {
+    console.error(err)
+    process.exit(1)
+  }
+  for (var type in result.symbol) {
+    console.log(c.cyan('Write ' + type + ': ' + result.symbol[type].path))
+    fs.ensureDirSync(path.dirname(result.symbol[type].path))
+    fs.writeFileSync(result.symbol[type].path, result.symbol[type].contents)
+  }
+})
+console.log(c.green('Done'))

--- a/server/zanata-frontend/src/frontend/scripts/build-icon-spritesheet.js
+++ b/server/zanata-frontend/src/frontend/scripts/build-icon-spritesheet.js
@@ -9,8 +9,6 @@ const fs = require('fs-extra')
 const path = require('path')
 const SVGSpriter = require('svg-sprite')
 
-// TODO run this as part of icon icon creation scripts
-
 console.log(c.bgCyan(c.black(' Generating icons spritesheet ')))
 
 const spriter = new SVGSpriter({
@@ -25,15 +23,10 @@ const spriter = new SVGSpriter({
   }
 })
 const svgsPath = path.resolve('app/components/Icons/svgs/')
-console.log(c.magenta('Reading svgs from ' + svgsPath))
+console.log(c.magenta('Reading svgs from ' + path.relative('', svgsPath)))
 const svgFiles = fs.readdirSync(svgsPath)
-const colWidth = svgFiles.reduce((l, name) => Math.max(l, name.length), 0)
-var count = 0
+printIconFileNames(svgFiles)
 svgFiles.map((fileName) => {
-  count++
-  process.stdout.write(c.blue(' ' +
-    (fileName + '                            ').slice(0, colWidth)))
-  if (count % 4 === 0) process.stdout.write('\n')
   const fullPath = path.join(svgsPath, fileName)
   spriter.add(fullPath, fileName, fs.readFileSync(fullPath))
 })
@@ -43,9 +36,20 @@ spriter.compile((err, result) => {
     process.exit(1)
   }
   for (var type in result.symbol) {
-    console.log(c.cyan('Write ' + type + ': ' + result.symbol[type].path))
-    fs.ensureDirSync(path.dirname(result.symbol[type].path))
-    fs.writeFileSync(result.symbol[type].path, result.symbol[type].contents)
+    const p = result.symbol[type].path
+    console.log(c.cyan('Write ' + type + ': ' + path.relative('', p)))
+    fs.ensureDirSync(path.dirname(p))
+    fs.writeFileSync(p, result.symbol[type].contents)
   }
 })
 console.log(c.green('Done'))
+
+function printIconFileNames (fileNames) {
+  const columnWidth = fileNames.reduce((l, name) => Math.max(l, name.length), 0)
+  fileNames.map((fileName, index) => {
+    process.stdout.write(c.blue(' ' +
+      (fileName + '                            ').slice(0, columnWidth)))
+    if (index % 4 === 3) process.stdout.write('\n')
+  })
+  if (fileNames.length % 4 !== 0) process.stdout.write('\n')
+}

--- a/server/zanata-frontend/src/frontend/scripts/build.js
+++ b/server/zanata-frontend/src/frontend/scripts/build.js
@@ -1,0 +1,47 @@
+/* eslint-disable no-console */
+const c = require('cli-color')
+const webpack = require('webpack')
+const prodConfig = require('../webpack.prod.config.js')
+const draftConfig = require('../webpack.draft.config.js')
+
+// execute icon scripts to generate required files
+require('./createIconsComponent')
+require('./generateIconList')
+
+const isDraft = process.argv.indexOf('--draft') !== -1
+
+console.log(isDraft
+  ? c.bgYellow(' DRAFT BUILD - do not deploy! ')
+  : c.bgCyan(' PRODUCTION BUILD '))
+
+const config = isDraft ? draftConfig : prodConfig
+webpack(config, (err, stats) => {
+  if (err) {
+    console.error(err.stack || err)
+    if (err.details) {
+      console.error(err.details)
+    }
+    return
+  }
+
+  if (stats.hasErrors()) {
+    console.error(stats.toJson().errors)
+  }
+  if (stats.hasWarnings()) {
+    console.warn(stats.toJson().warnings)
+  }
+
+  // stats options: https://webpack.github.io/docs/node.js-api.html#stats
+  // This set of options appears to generate the same output as the CLI with
+  // only the --display-error-details flag set.
+  const statsOptions = {
+    colors: true,
+    cached: false,
+    chunks: false,
+    modules: true,
+    cachedAssets: false,
+    exclude: ['node_modules', 'bower_components', 'components'],
+    errorDetails: true
+  }
+  console.log(stats.toString(statsOptions))
+})

--- a/server/zanata-frontend/src/frontend/scripts/createIconsComponent.js
+++ b/server/zanata-frontend/src/frontend/scripts/createIconsComponent.js
@@ -1,29 +1,23 @@
+/* eslint-disable no-console */
 var fs = require('fs')
+// build spritesheet used in this script (could change to return sheet)
+require('./build-icon-spritesheet')
+
 var svgFile = './app/components/Icons/icons.svg'
 var componentFileSrc = './app/components/Icons/index.jsx.src'
 var componentFile = './app/components/Icons/index.jsx'
 
-function getSVG (cb) {
-  fs.readFile(svgFile, 'utf8', function (err, data) {
-    var result
-    if (err) return console.log(err)
-    result = data.replace(/ style="position:absolute"/g, '')
-    cb(result)
-  })
+function getSVG () {
+  const data = fs.readFileSync(svgFile, 'utf8')
+  return data.replace(/ style="position:absolute"/g, '')
 }
 
-function generateComponent (cb) {
-  fs.readFile(componentFileSrc, 'utf8', function (err, data) {
-    if (err) return console.log(err)
-    getSVG(function (svg) {
-      var component = data.replace(/{{svgFile: 'icons.svg'}}/, '\'' + svg + '\'')
-      cb(component)
-    })
-  })
+function generateComponent () {
+  const data = fs.readFileSync(componentFileSrc, 'utf8')
+  const svg = getSVG()
+  return data.replace(/{{svgFile: 'icons.svg'}}/, '\'' + svg + '\'')
 }
 
-generateComponent(function (component) {
-  fs.writeFile(componentFile, component, 'utf8', function (err) {
-    if (err) return console.log(err)
-  })
-})
+process.stdout.write('Generating Icons component with embedded SVG')
+fs.writeFileSync(componentFile, generateComponent(), 'utf8')
+console.log(' ... Done')

--- a/server/zanata-frontend/src/frontend/scripts/generateIconList.js
+++ b/server/zanata-frontend/src/frontend/scripts/generateIconList.js
@@ -1,21 +1,16 @@
+/* eslint-disable no-console */
 var fs = require('fs')
 var iconsSrc = './app/components/Icons/svgs'
 var iconsFileName = './app/components/Icon/list.js'
 var svgFileRegex = /Icon-(.*).svg/
 
-fs.readdir(iconsSrc, function (err, files) {
-  if (err) {
-    console.error(err)
-    return
-  }
-  const fileNames = files.map(file => {
-    const fileName = file.match(svgFileRegex)
-    return fileName ? fileName[1] : undefined
-  }).filter(file => file)
-  const iconsFile =
-    `module.exports = [${fileNames.map(file => `'${file}'`)}]\r\n`
-  fs.writeFile(iconsFileName, iconsFile, (err) => {
-    if (err) throw err
-    console.log('Icon file list saved')
-  })
-})
+process.stdout.write('Generating list of icon names in Icon/list.js')
+const files = fs.readdirSync(iconsSrc)
+const fileNames = files.map(file => {
+  const fileName = file.match(svgFileRegex)
+  return fileName ? fileName[1] : undefined
+}).filter(file => file)
+const iconsFile =
+  `module.exports = [${fileNames.map(file => `'${file}'`)}]\r\n`
+fs.writeFileSync(iconsFileName, iconsFile)
+console.log(' ... Done')

--- a/server/zanata-frontend/src/frontend/webpack.config.js
+++ b/server/zanata-frontend/src/frontend/webpack.config.js
@@ -84,7 +84,7 @@ module.exports = {
     new ExtractTextPlugin('[name].css'),
     new webpack.optimize.OccurenceOrderPlugin(),
     new webpack.optimize.DedupePlugin(),
-    new webpack.NoErrorsPlugin(),
+    new webpack.NoErrorsPlugin()
   ],
 
   resolve: {

--- a/server/zanata-frontend/src/frontend/webpack.prod.config.js
+++ b/server/zanata-frontend/src/frontend/webpack.prod.config.js
@@ -39,6 +39,9 @@ module.exports = merge.smart(defaultConfig, {
     })
   ],
 
+  // fail on first error
+  bail: true,
+
   eslint: {
     failOnWarning: true
   }


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-1829

Changes `make build` and `make draft` to use separate script files. Some helper scripts are updated and removed from package.json since they can be imported directly to the new build script.

## Testing notes

The commands `make build` and `make draft` are affected. Both should still generate the same files in `dist`. The commands and directory are all from zanata-platform/server/zanata-frontend/src/frontend.

The ultimate test is to run a full build of zanata server (with and without the `optimise` flag) and make sure the editor still works.

## Reviewer tasks

The following is based on the
[Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines).
As a reviewer, you should check the guidelines regularly for updates, and just
to refresh your memory.


The reviewer can use this list for reference to make sure
they have considered all the important points.

Use the checkboxes or not, whatever works best for you.

 - Code quality
   - [ ] Code passes style check (checkstyle/eslint)
   - [ ] Code is clear and concise
   - [ ] UI code is internationalised
   - [ ] Code has adequate comments where appropriate
   - Code is in an appropriate place
     - [ ] Classes are in appropriate packages
     - [ ] Code fits with class's responsibilities (SRP)
   - [ ] Configuration files are documented enough
   - If code is removed
     - [ ] No remaining code references the removed code
       - [ ] No orphaned rewrite rules
       - [ ] No orphaned config settings
     - [ ] No remaining comments refer to the removed code
     - [ ] Unused imports and libraries are removed
 - Testing
   - [ ] New code has tests
   - [ ] Changed code has tests
   - [ ] All tests pass
   - [ ] Test coverage stable or increased
 - Documentation
   - [ ] New features are documented
   - [ ] Docs removed for deleted features
   - [ ] Docs updated for all changed features
   - [ ] Developer/sysadmin docs updated if appropriate
 - If there are new dependencies
   - [ ] Does each new dependency pass all the
         [Considerations for new dependencies](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines#new-technologies-and-dependencies)?


----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/320)
<!-- Reviewable:end -->
