### PR TITLE
chore(Jenkinsfile): use more locks, more concurrent builds

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -136,10 +136,13 @@ String getLockName() {
     // Each mainline branch pipeline will have its own lock.
     return jobName
   } else if (env.BRANCH_NAME.startsWith('PR-')) {
-    // All pull requests (in any repo) will share the same lock/locks.
-    // It probably makes sense to define 2 or 3 locks with the name
-    // PullRequest for more concurrency.
-    return 'GitHubPullRequest'
+    // Pull requests 1, 101, 201, xx01 will all share the same lock name.
+    // Barring collisions, this means each PR gets its own lock, with a
+    // maximum of 100 lock names. This is a workaround for
+    // https://issues.jenkins-ci.org/browse/JENKINS-38906
+    String digits = '00' + env.BRANCH_NAME.substring('PR-'.length())
+    String last2Digits = digits.substring(digits.length() - 2)
+    return 'zanata-platform-PR-x' + last2Digits
   } else {
     // All miscellaneous branches (across all repos) will share the same lock.
     return 'GitHubMiscBranch'


### PR DESCRIPTION

## Reviewer tasks

The following is based on the
[Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines).
As a reviewer, you should check the guidelines regularly for updates, and just
to refresh your memory.


The reviewer can use this list for reference to make sure
they have considered all the important points.

Use the checkboxes or not, whatever works best for you.

 - Code quality
   - [ ] Code passes style check (checkstyle/eslint)
   - [ ] Code is clear and concise
   - [ ] UI code is internationalised
   - [ ] Code has adequate comments where appropriate
   - Code is in an appropriate place
     - [ ] Classes are in appropriate packages
     - [ ] Code fits with class's responsibilities (SRP)
   - [ ] Configuration files are documented enough
   - If code is removed
     - [ ] No remaining code references the removed code
       - [ ] No orphaned rewrite rules
       - [ ] No orphaned config settings
     - [ ] No remaining comments refer to the removed code
     - [ ] Unused imports and libraries are removed
 - Testing
   - [ ] New code has tests
   - [ ] Changed code has tests
   - [ ] All tests pass
   - [ ] Test coverage stable or increased
 - Documentation
   - [ ] New features are documented
   - [ ] Docs removed for deleted features
   - [ ] Docs updated for all changed features
   - [ ] Developer/sysadmin docs updated if appropriate
 - If there are new dependencies
   - [ ] Does each new dependency pass all the
         [Considerations for new dependencies](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines#new-technologies-and-dependencies)?


----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/344)
<!-- Reviewable:end -->
