### PR TITLE
chore(Jenkinsfile): compare PR coverage

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -255,6 +255,12 @@ timestamps {
           // parse Jacoco test coverage
           step([$class: 'JacocoPublisher'])
 
+          if (env.BRANCH_NAME == 'master') {
+            step([$class: 'MasterCoverageAction'])
+          } else if (env.BRANCH_NAME.startsWith('PR-')) {
+            step([$class: 'CompareCoverageAction'])
+          }
+
           // ref: https://philphilphil.wordpress.com/2016/12/28/using-static-code-analysis-tools-with-jenkins-pipeline-jobs/
           step([$class: 'CheckStylePublisher',
                 pattern: '**/target/checkstyle-result.xml',


### PR DESCRIPTION
https://github.com/jenkinsci/github-pr-coverage-status-plugin

## Reviewer tasks

The following is based on the
[Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines).
As a reviewer, you should check the guidelines regularly for updates, and just
to refresh your memory.


The reviewer can use this list for reference to make sure
they have considered all the important points.

Use the checkboxes or not, whatever works best for you.

 - Code quality
   - [ ] Code passes style check (checkstyle/eslint)
   - [ ] Code is clear and concise
   - [ ] UI code is internationalised
   - [ ] Code has adequate comments where appropriate
   - Code is in an appropriate place
     - [ ] Classes are in appropriate packages
     - [ ] Code fits with class's responsibilities (SRP)
   - [ ] Configuration files are documented enough
   - If code is removed
     - [ ] No remaining code references the removed code
       - [ ] No orphaned rewrite rules
       - [ ] No orphaned config settings
     - [ ] No remaining comments refer to the removed code
     - [ ] Unused imports and libraries are removed
 - Testing
   - [ ] New code has tests
   - [ ] Changed code has tests
   - [ ] All tests pass
   - [ ] Test coverage stable or increased
 - Documentation
   - [ ] New features are documented
   - [ ] Docs removed for deleted features
   - [ ] Docs updated for all changed features
   - [ ] Developer/sysadmin docs updated if appropriate
 - If there are new dependencies
   - [ ] Does each new dependency pass all the
         [Considerations for new dependencies](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines#new-technologies-and-dependencies)?


----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/356)
<!-- Reviewable:end -->
