### PR TITLE
chore: split frontend URL config to multiple URLs

### DIFF
--- a/server/gwt-editor/src/main/webapp/webtrans/Application.xhtml
+++ b/server/gwt-editor/src/main/webapp/webtrans/Application.xhtml
@@ -54,8 +54,9 @@
   <h:body styleClass="new-zanata-body">
     <ds:windowId/>
     <div id="config"
-      data-base-url="#{request.contextPath}"
-      data-api-root="/rest"
+      data-app-url="#{request.contextPath}"
+      data-server-url="#{request.contextPath}"
+      data-api-server-url="#{request.contextPath}/rest"
       data-user="#{authenticatedAccountHome.getUser()}"
       data-permission="#{authenticatedAccountHome.getUserPermission().getJSON()}"
       data-links='{"loginUrl": "#{applicationConfigurationAction.getLoginUrl(request)}",
@@ -84,4 +85,3 @@
   </h:body>
   </html>
 </f:view>
-

--- a/server/zanata-frontend/src/frontend/app/actions/common-actions.js
+++ b/server/zanata-frontend/src/frontend/app/actions/common-actions.js
@@ -1,4 +1,5 @@
 import { createAction } from 'redux-actions'
+import { auth } from '../config'
 
 export const CLEAR_MESSAGE = 'CLEAR_MESSAGE'
 export const clearMessage = createAction(CLEAR_MESSAGE)
@@ -20,9 +21,9 @@ export const DEFAULT_LOCALE = {
 
 export const getHeaders = () => {
   let headers = {}
-  if (window.config.auth) {
-    headers['x-auth-token'] = window.config.auth.token
-    headers['x-auth-user'] = window.config.auth.user
+  if (auth) {
+    headers['x-auth-token'] = auth.token
+    headers['x-auth-user'] = auth.user
   }
   return headers
 }

--- a/server/zanata-frontend/src/frontend/app/actions/explore-actions.js
+++ b/server/zanata-frontend/src/frontend/app/actions/explore-actions.js
@@ -2,6 +2,7 @@ import { CALL_API } from 'redux-api-middleware'
 import { replaceRouteQuery } from '../utils/RoutingHelpers'
 import { getJsonHeaders, buildAPIRequest } from './common-actions'
 import { isEmpty, includes, clamp } from 'lodash'
+import { apiUrl } from '../config'
 
 export const SEARCH_PROJECT_REQUEST = 'SEARCH_PROJECT_REQUEST'
 export const SEARCH_PROJECT_SUCCESS = 'SEARCH_PROJECT_SUCCESS'
@@ -22,7 +23,7 @@ export const SEARCH_GROUP_FAILURE = 'SEARCH_GROUP_FAILURE'
 export const SIZE_PER_PAGE = 20
 
 const getEndpoint = (type, page, searchText) => {
-  return window.config.baseUrl + window.config.apiRoot + '/search/' +
+  return apiUrl + '/search/' +
     type + '?' +
     'sizePerPage=' + SIZE_PER_PAGE +
     '&page=' + (page || '1') +

--- a/server/zanata-frontend/src/frontend/app/actions/glossary-actions.js
+++ b/server/zanata-frontend/src/frontend/app/actions/glossary-actions.js
@@ -12,6 +12,7 @@ import {
   getHeaders,
   buildAPIRequest
 } from './common-actions'
+import { apiUrl } from '../config'
 
 export const FILE_TYPES = ['csv', 'po']
 export const PAGE_SIZE_SELECTION = [20, 50, 100, 300, 500]
@@ -120,8 +121,7 @@ const getGlossaryTerms = (state) => {
   const sortQuery = sort
     ? `&sort=${GlossaryHelper.convertSortToParam(sort)}` : ''
   const qualifiedNameQuery = '&qualifiedName=' + qualifiedName
-  const endpoint = window.config.baseUrl + window.config.apiRoot +
-    '/glossary/entries' + srcQuery +
+  const endpoint = apiUrl + '/glossary/entries' + srcQuery +
     localeQuery + pageQuery + filterQuery + sortQuery + qualifiedNameQuery
 
   const apiTypes = [
@@ -149,8 +149,7 @@ const getGlossaryTerms = (state) => {
 }
 
 const getGlossaryStats = (dispatch, qualifiedName, resetTerms) => {
-  const endpoint = window.config.baseUrl + window.config.apiRoot +
-    '/glossary/info?qualifiedName=' + qualifiedName
+  const endpoint = apiUrl + '/glossary/info?qualifiedName=' + qualifiedName
   const apiTypes = [
     GLOSSARY_STATS_REQUEST,
     {
@@ -170,8 +169,8 @@ const getGlossaryStats = (dispatch, qualifiedName, resetTerms) => {
 }
 
 const getPermission = (dispatch, qualifiedName) => {
-  const endpoint = window.config.baseUrl + window.config.apiRoot +
-    '/user/permission/glossary?qualifiedName=' + qualifiedName
+  const endpoint =
+    apiUrl + '/user/permission/glossary?qualifiedName=' + qualifiedName
   const apiTypes = [
     GLOSSARY_PERMISSION_REQUEST,
     {
@@ -191,7 +190,7 @@ const getPermission = (dispatch, qualifiedName) => {
 }
 
 const getQualifiedName = (dispatch, projectSlug) => {
-  const endpoint = window.config.baseUrl + window.config.apiRoot +
+  const endpoint = apiUrl +
     (projectSlug ? '/projects/p/' + projectSlug + '/glossary/qualifiedName'
       : '/glossary/qualifiedName')
 
@@ -215,8 +214,7 @@ const getQualifiedName = (dispatch, projectSlug) => {
 }
 
 const getProjectDetails = (projectSlug) => {
-  const endpoint = window.config.baseUrl + window.config.apiRoot +
-    '/projects/p/' + projectSlug
+  const endpoint = apiUrl + '/projects/p/' + projectSlug
 
   const apiTypes = [
     PROJECT_GET_DETAILS_REQUEST,
@@ -236,7 +234,7 @@ const getProjectDetails = (projectSlug) => {
 }
 
 const importGlossaryFile = (dispatch, data, qualifiedName, srcLocaleId) => {
-  const endpoint = window.config.baseUrl + window.config.apiRoot + '/glossary'
+  const endpoint = apiUrl + '/glossary'
   let formData = new FormData()
   formData.append('file', data.file, data.file.name)
   formData.append('fileName', data.file.name)
@@ -268,8 +266,7 @@ const importGlossaryFile = (dispatch, data, qualifiedName, srcLocaleId) => {
 const createGlossaryTerm = (dispatch, qualifiedName, term) => {
   let headers = getJsonHeaders()
   headers['Content-Type'] = 'application/json'
-  const endpoint = window.config.baseUrl + window.config.apiRoot +
-    '/glossary/entries?locale=' + term.srcTerm.locale +
+  const endpoint = apiUrl + '/glossary/entries?locale=' + term.srcTerm.locale +
     '&qualifiedName=' + qualifiedName
   const entryDTO = GlossaryHelper.convertToDTO(term, qualifiedName)
   const apiTypes = [
@@ -301,8 +298,7 @@ const updateGlossaryTerm = (dispatch, qualifiedName, term, localeId,
   let headers = getJsonHeaders()
   headers['Content-Type'] = 'application/json'
 
-  const endpoint = window.config.baseUrl + window.config.apiRoot +
-    '/glossary/entries?locale=' + localeId +
+  const endpoint = apiUrl + '/glossary/entries?locale=' + localeId +
     '&qualifiedName=' + qualifiedName
   const entryDTO = GlossaryHelper.convertToDTO(term, qualifiedName)
 
@@ -332,8 +328,8 @@ const updateGlossaryTerm = (dispatch, qualifiedName, term, localeId,
 }
 
 const deleteGlossaryTerm = (dispatch, id, qualifiedName) => {
-  const endpoint = window.config.baseUrl + window.config.apiRoot +
-    '/glossary/entries/' + id + '?qualifiedName=' + qualifiedName
+  const endpoint =
+    apiUrl + '/glossary/entries/' + id + '?qualifiedName=' + qualifiedName
   const apiTypes = [
     {
       type: GLOSSARY_DELETE_REQUEST,
@@ -359,8 +355,7 @@ const deleteGlossaryTerm = (dispatch, id, qualifiedName) => {
 }
 
 const deleteAllGlossaryEntry = (dispatch, qualifiedName) => {
-  const endpoint = window.config.baseUrl + window.config.apiRoot +
-    '/glossary?qualifiedName=' + qualifiedName
+  const endpoint = apiUrl + '/glossary?qualifiedName=' + qualifiedName
   const apiTypes = [
     {
       type: GLOSSARY_DELETE_ALL_REQUEST,
@@ -382,8 +377,8 @@ const deleteAllGlossaryEntry = (dispatch, qualifiedName) => {
 }
 
 const glossaryExport = (type, qualifiedName) => {
-  const endpoint = window.config.baseUrl + window.config.apiRoot +
-    '/glossary/file?fileType=' + type + '&qualifiedName=' + qualifiedName
+  const endpoint = apiUrl + '/glossary/file?fileType=' + type +
+    '&qualifiedName=' + qualifiedName
   let headers = getJsonHeaders()
   headers['Content-Type'] = 'application/octet-stream'
   const apiTypes = [

--- a/server/zanata-frontend/src/frontend/app/actions/languages-actions.js
+++ b/server/zanata-frontend/src/frontend/app/actions/languages-actions.js
@@ -9,6 +9,7 @@ import {
   LOAD_USER_SUCCESS,
   LOAD_USER_FAILURE
 } from './common-actions'
+import { apiUrl, isLoggedIn } from '../config'
 
 export const LOAD_LANGUAGES_REQUEST = 'LOAD_LANGUAGES_REQUEST'
 export const LOAD_LANGUAGES_SUCCESS = 'LOAD_LANGUAGES_SUCCESS'
@@ -56,7 +57,7 @@ const getLocalesList = (state) => {
   if (query.sort) {
     queries.push('sort=' + query.sort)
   }
-  const endpoint = window.config.baseUrl + window.config.apiRoot + '/locales' +
+  const endpoint = apiUrl + '/locales' +
     (!isEmpty(queries) ? '?' + queries.join('&') : '')
 
   const apiTypes = [
@@ -83,8 +84,7 @@ const getLocalesList = (state) => {
 }
 
 const searchLocales = (query) => {
-  const endpoint = window.config.baseUrl + window.config.apiRoot +
-    '/locales/new?filter=' + encodeURIComponent(query)
+  const endpoint = apiUrl + '/locales/new?filter=' + encodeURIComponent(query)
 
   const apiTypes = [
     LOAD_LANGUAGES_SUGGESTION_REQUEST,
@@ -110,8 +110,7 @@ const searchLocales = (query) => {
 }
 
 const getLocalesPermission = (dispatch) => {
-  const endpoint = window.config.baseUrl + window.config.apiRoot +
-    '/user/permission/locales'
+  const endpoint = apiUrl + '/user/permission/locales'
 
   const apiTypes = [
     LANGUAGE_PERMISSION_REQUEST,
@@ -138,7 +137,7 @@ const getLocalesPermission = (dispatch) => {
 }
 
 const getUserInfo = (dispatch) => {
-  const endpoint = window.config.baseUrl + window.config.apiRoot + '/user'
+  const endpoint = apiUrl + '/user'
 
   const apiTypes = [
     LOAD_USER_REQUEST,
@@ -165,9 +164,7 @@ const getUserInfo = (dispatch) => {
 }
 
 const deleteLanguage = (dispatch, localeId) => {
-  const endpoint = window.config.baseUrl + window.config.apiRoot +
-    '/locales/locale/' + localeId
-
+  const endpoint = apiUrl + '/locales/locale/' + localeId
   const apiTypes = [
     LANGUAGE_DELETE_REQUEST,
     {
@@ -188,9 +185,7 @@ const deleteLanguage = (dispatch, localeId) => {
 }
 
 const createNewLanguage = (details, dispatch) => {
-  const endpoint = window.config.baseUrl + window.config.apiRoot +
-    '/locales/locale'
-
+  const endpoint = apiUrl + '/locales/locale'
   let headers = getJsonHeaders()
   headers['Content-Type'] = 'application/json'
 
@@ -236,7 +231,7 @@ export const initialLoad = () => {
         size: pageSizeOption[0]
       })
     }
-    if (!window.config.permission.isLoggedIn) {
+    if (!isLoggedIn) {
       dispatch(getLocalesList(getState()))
     } else {
       dispatch(getUserInfo(dispatch))

--- a/server/zanata-frontend/src/frontend/app/actions/profile-actions.js
+++ b/server/zanata-frontend/src/frontend/app/actions/profile-actions.js
@@ -10,6 +10,7 @@ import {
   LOAD_USER_SUCCESS,
   LOAD_USER_FAILURE
 } from './common-actions'
+import { apiUrl, isLoggedIn, links, serverUrl } from '../config'
 
 export const FILTER_UPDATE = 'FILTER_UPDATE'
 export const DATE_RANGE_UPDATE = 'DATE_RANGE_UPDATE'
@@ -28,8 +29,7 @@ export const updateFilter = createAction(FILTER_UPDATE)
 export const updateSelectDay = createAction(SELECT_DAY_UPDATE)
 
 const getStatsEndPoint = (username, fromDate, toDate) => {
-  return window.config.baseUrl + window.config.apiRoot +
-    '/stats/user/' + username + '/' + fromDate + '..' + toDate
+  return apiUrl + '/stats/user/' + username + '/' + fromDate + '..' + toDate
 }
 
 const getUserStatistics = (username, fromDate, toDate) => {
@@ -65,8 +65,7 @@ const loadUserStats = (username, dateRangeOption) => {
 }
 
 const getLocaleDetail = (localeId) => {
-  const endpoint = window.config.baseUrl + window.config.apiRoot +
-    '/locales/locale/' + localeId
+  const endpoint = apiUrl + '/locales/locale/' + localeId
 
   const apiTypes = [
     GET_LOCALE_REQUEST,
@@ -92,8 +91,7 @@ const getLocaleDetail = (localeId) => {
 }
 
 const getUserInfo = (dispatch, username, dateRangeOption) => {
-  const endpoint = window.config.baseUrl + window.config.apiRoot + '/user' +
-    (isEmpty(username) ? '' : '/' + username)
+  const endpoint = apiUrl + '/user' + (isEmpty(username) ? '' : '/' + username)
 
   const apiTypes = [
     LOAD_USER_REQUEST,
@@ -124,11 +122,10 @@ const getUserInfo = (dispatch, username, dateRangeOption) => {
 
 export const profileInitialLoad = (username) => {
   return (dispatch, getState) => {
-    const config = window.config
-    if (isEmpty(username) && !config.permission.isLoggedIn) {
+    if (isEmpty(username) && !isLoggedIn) {
       // redirect to login screen if no username is found url
       // and user is not logged in
-      window.location = config.baseUrl + config.links.loginUrl
+      window.location = serverUrl + links.loginUrl
     } else {
       dispatch(getUserInfo(dispatch, username,
         getState().profile.dateRange))

--- a/server/zanata-frontend/src/frontend/app/components/Nav/index.jsx
+++ b/server/zanata-frontend/src/frontend/app/components/Nav/index.jsx
@@ -1,7 +1,8 @@
 import React, { PropTypes } from 'react'
 import NavItem from './NavItem'
 import { getDswid } from '../../utils/UrlHelper'
-import {remove} from 'lodash'
+import { remove } from 'lodash'
+import { allowRegister, isLoggedIn, isAdmin, user } from '../../config'
 
 const dswid = getDswid()
 
@@ -122,14 +123,12 @@ const Nav = ({
   ...props
 }) => {
   let auth = 'loggedout'
-  if (window.config.permission.isLoggedIn === true) {
-    auth = window.config.permission.isAdmin === true ? 'admin' : 'loggedin'
+  if (isLoggedIn) {
+    auth = isAdmin ? 'admin' : 'loggedin'
   }
   const admin = (auth === 'admin')
-
-  const username = window.config.user ? window.config.user.username : ''
-
-  if (!window.config.allowRegister) {
+  const username = user ? user.username : ''
+  if (!allowRegister) {
     // we don't allow public registration
     remove(items, item => item.id === 'nav_sign_up')
   }

--- a/server/zanata-frontend/src/frontend/app/config.js
+++ b/server/zanata-frontend/src/frontend/app/config.js
@@ -22,7 +22,7 @@ export const isLoggedIn = config.permission
   ? config.permission.isLoggedIn
   : false
 export const isAdmin = config.permission
-  ? config.isAdmin
+  ? config.permission.isAdmin
   : false
 export const user = config.user
 export const allowRegister = config.allowRegister || false

--- a/server/zanata-frontend/src/frontend/app/config.js
+++ b/server/zanata-frontend/src/frontend/app/config.js
@@ -1,0 +1,28 @@
+/* Responsible for reading config to present to other modules. */
+
+import { mapValues } from 'lodash'
+import { isJsonString } from './utils/StringUtils'
+
+const rawConfig = window.config
+const config = mapValues(rawConfig || {}, (value) =>
+  isJsonString(value) ? JSON.parse(value) : value)
+
+// URL this app is deployed to
+export const appUrl = config.appUrl || ''
+
+// Base URL for API requests
+export const apiUrl = config.apiServerUrl || '/rest'
+
+// Base URL for links to pages that are not part of this app
+export const serverUrl = config.serverUrl || ''
+
+export const links = config.links || {}
+export const auth = config.auth
+export const isLoggedIn = config.permission
+  ? config.permission.isLoggedIn
+  : false
+export const isAdmin = config.permission
+  ? config.isAdmin
+  : false
+export const user = config.user
+export const allowRegister = config.allowRegister || false

--- a/server/zanata-frontend/src/frontend/app/containers/App.js
+++ b/server/zanata-frontend/src/frontend/app/containers/App.js
@@ -6,7 +6,7 @@ import React, { PropTypes, Component } from 'react'
 import { connect } from 'react-redux'
 import Helmet from 'react-helmet'
 import { Nav, Icons } from '../components'
-import { getContextPath } from '../utils/UrlHelper'
+import { serverUrl, links as configLinks } from '../config'
 
 /**
  * TODO: use react-ally to identify accessibility issue in dev mode
@@ -28,9 +28,9 @@ class App extends Component {
     } = this.props
 
     const links = {
-      'context': getContextPath(),
-      '/login': window.config.links.loginUrl,
-      '/signup': window.config.links.registerUrl
+      'context': serverUrl,
+      '/login': configLinks.loginUrl,
+      '/signup': configLinks.registerUrl
     }
     return (
       <div className='view H(100vh)! Fld(c) Fld(r)--sm'>

--- a/server/zanata-frontend/src/frontend/app/containers/Explore/GroupTeaser.jsx
+++ b/server/zanata-frontend/src/frontend/app/containers/Explore/GroupTeaser.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react'
 import { Link, Icon } from '../../components'
+import { serverUrl } from '../../config'
 
 const statusIcons = {
   ACTIVE: '',
@@ -29,7 +30,7 @@ const GroupTeaser = ({
       <Icon name='users' className='usersicon-muted n1' />
     </div>
   ) : undefined
-  const link = window.config.baseUrl + '/version-group/view/' + details.id
+  const link = serverUrl + '/version-group/view/' + details.id
   const className = status !== statusIcons.ACTIVE
                   ? 'text-muted-bold'
                   : 'text-bold'

--- a/server/zanata-frontend/src/frontend/app/containers/Explore/LanguageTeamTeaser.jsx
+++ b/server/zanata-frontend/src/frontend/app/containers/Explore/LanguageTeamTeaser.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react'
 import { Link, Icon } from '../../components'
+import { serverUrl } from '../../config'
 
 /**
  * Entry of Language team search results
@@ -9,7 +10,7 @@ const LanguageTeamTeaser = ({
   details,
   ...props
 }) => {
-  const link = window.config.baseUrl + '/language/view/' + details.id
+  const link = serverUrl + '/language/view/' + details.id
   return (
     <div className='team-teaser-view' name={name}>
       <div className='flex-row'>

--- a/server/zanata-frontend/src/frontend/app/containers/Explore/ProjectTeaser.jsx
+++ b/server/zanata-frontend/src/frontend/app/containers/Explore/ProjectTeaser.jsx
@@ -1,5 +1,6 @@
 import React, { PropTypes } from 'react'
 import { Link, Icon } from '../../components'
+import { serverUrl } from '../../config'
 
 const statusIcons = {
   ACTIVE: '',
@@ -33,7 +34,7 @@ const ProjectTeaser = ({
       </Link>
     </div>
   )
-  const link = window.config.baseUrl + '/project/view/' + details.id
+  const link = serverUrl + '/project/view/' + details.id
   const className = status !== statusIcons.ACTIVE
     ? 'text-muted-bold'
     : 'text-bold'

--- a/server/zanata-frontend/src/frontend/app/containers/Root.js
+++ b/server/zanata-frontend/src/frontend/app/containers/Root.js
@@ -6,6 +6,7 @@ import Glossary from '../containers/Glossary'
 import Languages from '../containers/Languages'
 import Explore from '../containers/Explore'
 import UserProfile from '../containers/UserProfile'
+import { user } from '../config'
 
 export default class Root extends Component {
   static propTypes = {
@@ -14,7 +15,7 @@ export default class Root extends Component {
   }
 
   render () {
-    const username = window.config.user.username
+    const username = user.username
     const {
       store,
       history

--- a/server/zanata-frontend/src/frontend/app/containers/UserProfile/index.jsx
+++ b/server/zanata-frontend/src/frontend/app/containers/UserProfile/index.jsx
@@ -11,6 +11,7 @@ import {
 import RecentContributions from './RecentContributions'
 import { Notification, Icon, LoaderText } from '../../components'
 import { getLanguageUrl } from '../../utils/UrlHelper'
+import { isLoggedIn } from '../../config'
 
 /**
  * Root component for user profile page
@@ -71,8 +72,6 @@ class UserProfile extends Component {
         )
       })
       : undefined
-
-    const isLoggedIn = window.config.permission.isLoggedIn
 
     return (
       <div className='page'>

--- a/server/zanata-frontend/src/frontend/app/history.js
+++ b/server/zanata-frontend/src/frontend/app/history.js
@@ -20,6 +20,7 @@
  */
 import { useRouterHistory } from 'react-router'
 import { createHistory } from 'history'
+import { appUrl } from './config'
 
 /**
  * Creates a history object used by the router.
@@ -28,5 +29,5 @@ import { createHistory } from 'history'
  * extend it.
  */
 export const history = useRouterHistory(createHistory)({
-  basename: window.config.baseUrl
+  basename: appUrl
 })

--- a/server/zanata-frontend/src/frontend/app/index.js
+++ b/server/zanata-frontend/src/frontend/app/index.js
@@ -2,7 +2,6 @@ import 'babel-polyfill'
 import 'es6-symbol/implement'
 import React from 'react'
 import { render } from 'react-dom'
-import { mapValues } from 'lodash'
 import { createStore, applyMiddleware, compose } from 'redux'
 import thunk from 'redux-thunk'
 import createLogger from 'redux-logger'
@@ -12,7 +11,6 @@ import WebFont from 'webfontloader'
 import { apiMiddleware } from 'redux-api-middleware'
 import rootReducer from './reducers'
 import Root from './containers/Root'
-import { isJsonString } from './utils/StringUtils'
 
 import './styles/style.less'
 
@@ -54,11 +52,6 @@ const store = ((initialState) => {
   }
   return store
 })()
-
-window.config = mapValues(window.config, (value) =>
-  isJsonString(value) ? JSON.parse(value) : value)
-// baseUrl should be /zanata or ''
-window.config.baseUrl = window.config.baseUrl || ''
 
 render(
   <Root store={store} history={history} />,

--- a/server/zanata-frontend/src/frontend/app/legacy.js
+++ b/server/zanata-frontend/src/frontend/app/legacy.js
@@ -22,11 +22,9 @@
 import 'babel-polyfill'
 import React from 'react'
 import { render } from 'react-dom'
-import { mapValues } from 'lodash'
 import { Nav, Icons } from './components'
 import WebFont from 'webfontloader'
-import { isJsonString } from './utils/StringUtils'
-import { getContextPath } from './utils/UrlHelper'
+import { serverUrl, links as configLinks } from './config'
 
 import './styles/style.less'
 
@@ -44,15 +42,10 @@ WebFont.load({
   timeout: 2000
 })
 
-window.config = mapValues(window.config, (value) =>
-  isJsonString(value) ? JSON.parse(value) : value)
-
-window.config.baseUrl = getContextPath()
-
 const links = {
-  'context': window.config.baseUrl,
-  '/login': window.config.links.loginUrl,
-  '/signup': window.config.links.registerUrl
+  'context': serverUrl,
+  '/login': configLinks.loginUrl,
+  '/signup': configLinks.registerUrl
 }
 
 const activePath = window.location.pathname.replace(/\/$/, '')

--- a/server/zanata-frontend/src/frontend/app/utils/UrlHelper.js
+++ b/server/zanata-frontend/src/frontend/app/utils/UrlHelper.js
@@ -1,3 +1,5 @@
+import { serverUrl } from '../config'
+
 /**
  * @returns dswid from url query
  */
@@ -8,20 +10,11 @@ export function getDswid () {
 }
 
 /**
- * @returns context path
- *
- * Should be /zanata or ''
- */
-export function getContextPath () {
-  return window.config.baseUrl || ''
-}
-
-/**
  * @returns string of project url
  * e.g. https://translate.zanata.org/project/view/zanata-server?dswid=-805
  */
 export function getProjectUrl (project) {
-  return getContextPath() + '/project/view/' + project.id + getDswid()
+  return serverUrl + '/project/view/' + project.id + getDswid()
 }
 
 /**
@@ -29,11 +22,10 @@ export function getProjectUrl (project) {
  *
  */
 export function getLanguageUrl (localeId) {
-  return window.config.baseUrl + '/language/view/' + localeId
+  return serverUrl + '/language/view/' + localeId
 }
 
 export default {
   getDswid,
-  getContextPath,
   getProjectUrl
 }

--- a/server/zanata-frontend/src/frontend/index.html
+++ b/server/zanata-frontend/src/frontend/index.html
@@ -14,10 +14,15 @@
     <title>Zanata</title>
   </head>
   <body class="bodystyle">
-  <!-- Test data for dev mode -->
+  <!-- Test data for dev mode
+    app-url: where this app is deployed
+    server-url: base URL for pages that are not part of the app
+    api-server-url: base URL for all API requests -->
     <div id="config"
-      data-base-url="http://localhost:8080"
-      data-api-root="/rest"
+      data-app-url="http://localhost:8000"
+      data-server-url="http://localhost:8080"
+      data-api-server-url="http://localhost:8080/rest"
+
       data-user='{"username": "admin", "email":"zanata@zanata.org", "name": "admin-name", "imageUrl":"//www.gravatar.com/avatar/dda6e90e3f2a615fb8b31205e8b4894b?d=mm&r=g&s=115", "languageTeams": ["English, French, German, Yodish (Yoda English)"]}'
       data-permission='{"updateGlossary":true, "insertGlossary":true, "deleteGlossary":true, "downloadGlossary":true, "isAdmin": true, "isLoggedIn": true}'
       data-dev='false'

--- a/server/zanata-war/src/main/webapp/WEB-INF/template/template.xhtml
+++ b/server/zanata-war/src/main/webapp/WEB-INF/template/template.xhtml
@@ -85,8 +85,9 @@
     </a4j:outputPanel>
 
     <div id="config"
-      data-base-url="#{request.contextPath}"
-      data-api-root="/rest"
+      data-app-url="#{request.contextPath}"
+      data-server-url="#{request.contextPath}"
+      data-api-server-url="#{request.contextPath}/rest"
       data-user="#{authenticatedAccountHome.getUser()}"
       data-permission="#{authenticatedAccountHome.getUserPermission().getJSON()}"
       data-links='{"loginUrl": "#{applicationConfigurationAction.getLoginUrl(request)}",

--- a/server/zanata-war/src/main/webapp/a/index.xhtml
+++ b/server/zanata-war/src/main/webapp/a/index.xhtml
@@ -28,8 +28,9 @@
   <h:body class="bodystyle">
     <ds:windowId/>
     <div id="config"
-      data-base-url="#{request.contextPath}"
-      data-api-root="/rest"
+      data-app-url="#{request.contextPath}"
+      data-server-url="#{request.contextPath}"
+      data-api-server-url="#{request.contextPath}/rest"
       data-user="#{authenticatedAccountHome.getUser()}"
       data-permission="#{authenticatedAccountHome.getUserPermission().getJSON()}"
       data-links='{"loginUrl": "#{applicationConfigurationAction.getLoginUrl(request)}",


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2004

This also splits the base URL config into 3 separate URLs to allow finer control, such as allowing search and navigation in the watch mode (`make watch`) by passing in the relevant URLs.

There were many places accessing `window.config`, which makes this a bigger change than it should have been. This moves config loading to a single place (`config.js`), which will make it far easier to change the config in future, and easier to mock in testing.

## Testing Notes

This could impact API requests and navigation from the frontend app pages:

 - /explore
 - /glossary
 - /glossary/project/{projectSlug}
 - /languages
 - /profile/view/{username}

Check that those pages can do all their operations that load data from the server (such as searching, opening details, etc.), and check that all the navigation links on the left point to the right place.

Plus the main point of this PR:

 - run Zanata server at `localhost:8080`
 - open `zanata-platform/server/zanata-frontend/src/frontend`
 - run `make watch` and wait for it to build
 - open `localhost:8000/explore`

Expected:

 - search should now work (used to fail)
 - should be able to navigate to any of the links in the nav menu on the left
   - but links that are not part of frontend app will put you on the real server at port 8080. This is expected.
 - navigation to all the other paths shown in `make watch` output should all correctly navigate within localhost:8000

## Reviewer tasks

The following is based on the
[Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines).
As a reviewer, you should check the guidelines regularly for updates, and just
to refresh your memory.


The reviewer can use this list for reference to make sure
they have considered all the important points.

Use the checkboxes or not, whatever works best for you.

 - Code quality
   - [ ] Code passes style check (checkstyle/eslint)
   - [ ] Code is clear and concise
   - [ ] UI code is internationalised
   - [ ] Code has adequate comments where appropriate
   - Code is in an appropriate place
     - [ ] Classes are in appropriate packages
     - [ ] Code fits with class's responsibilities (SRP)
   - [ ] Configuration files are documented enough
   - If code is removed
     - [ ] No remaining code references the removed code
       - [ ] No orphaned rewrite rules
       - [ ] No orphaned config settings
     - [ ] No remaining comments refer to the removed code
     - [ ] Unused imports and libraries are removed
 - Testing
   - [ ] New code has tests
   - [ ] Changed code has tests
   - [ ] All tests pass
   - [ ] Test coverage stable or increased
 - Documentation
   - [ ] New features are documented
   - [ ] Docs removed for deleted features
   - [ ] Docs updated for all changed features
   - [ ] Developer/sysadmin docs updated if appropriate
 - If there are new dependencies
   - [ ] Does each new dependency pass all the
         [Considerations for new dependencies](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines#new-technologies-and-dependencies)?


----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/359)
<!-- Reviewable:end -->
