### PR TITLE
ZNTA-2022 - change HTextFlowTarget index strategy

### DIFF
--- a/server/zanata-model/src/main/java/org/zanata/hibernate/search/ContainingWorkspaceBridge.java
+++ b/server/zanata-model/src/main/java/org/zanata/hibernate/search/ContainingWorkspaceBridge.java
@@ -40,9 +40,10 @@ public class ContainingWorkspaceBridge extends AbstractFieldBridge {
         HProjectIteration iteration = doc.getProjectIteration();
         HProject project = iteration.getProject();
 
-        addStringField(IndexFieldLabels.PROJECT_FIELD, project.getSlug(),
+        addStringField(IndexFieldLabels.PROJECT_FIELD, project.getId().toString(),
                 luceneDocument, luceneOptions);
-        addStringField(IndexFieldLabels.PROJECT_VERSION_FIELD, iteration.getSlug(),
+        addStringField(IndexFieldLabels.PROJECT_VERSION_FIELD,
+                iteration.getId().toString(),
                 luceneDocument, luceneOptions);
         addStringField(IndexFieldLabels.DOCUMENT_ID_FIELD, doc.getDocId(),
                 luceneDocument, luceneOptions);

--- a/server/zanata-model/src/main/java/org/zanata/hibernate/search/ContainingWorkspaceBridge.java
+++ b/server/zanata-model/src/main/java/org/zanata/hibernate/search/ContainingWorkspaceBridge.java
@@ -14,8 +14,8 @@ import org.zanata.model.HTextFlow;
  *
  * The provided field name is not used
  * <ul>
- * <li>Project slug is indexed as 'project'</li>
- * <li>Iteration slug is indexed as 'projectVersion'</li>
+ * <li>Project id is indexed as 'project'</li>
+ * <li>Iteration id is indexed as 'projectVersion'</li>
  * <li>Document full path + name is indexed as 'documentId'</li>
  * </ul>
  *
@@ -40,9 +40,9 @@ public class ContainingWorkspaceBridge extends AbstractFieldBridge {
         HProjectIteration iteration = doc.getProjectIteration();
         HProject project = iteration.getProject();
 
-        addStringField(IndexFieldLabels.PROJECT_FIELD, project.getId().toString(),
+        addStringField(IndexFieldLabels.PROJECT_ID_FIELD, project.getId().toString(),
                 luceneDocument, luceneOptions);
-        addStringField(IndexFieldLabels.PROJECT_VERSION_FIELD,
+        addStringField(IndexFieldLabels.PROJECT_VERSION_ID_FIELD,
                 iteration.getId().toString(),
                 luceneDocument, luceneOptions);
         addStringField(IndexFieldLabels.DOCUMENT_ID_FIELD, doc.getDocId(),

--- a/server/zanata-model/src/main/java/org/zanata/hibernate/search/EntityStatusIndexingInterceptor.java
+++ b/server/zanata-model/src/main/java/org/zanata/hibernate/search/EntityStatusIndexingInterceptor.java
@@ -1,0 +1,84 @@
+/*
+ * Copyright 2017, Red Hat, Inc. and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.zanata.hibernate.search;
+
+import org.hibernate.search.indexes.interceptor.EntityIndexingInterceptor;
+import org.hibernate.search.indexes.interceptor.IndexingOverride;
+import org.zanata.common.EntityStatus;
+import org.zanata.model.HProjectIteration;
+import org.zanata.model.HTextFlowTarget;
+
+/**
+ * @author Patrick Huang <a href="mailto:pahuang@redhat.com">pahuang@redhat.com</a>
+ */
+public class EntityStatusIndexingInterceptor implements
+        EntityIndexingInterceptor<HTextFlowTarget> {
+    @Override
+    public IndexingOverride onAdd(HTextFlowTarget hTextFlowTarget) {
+        if (hTextFlowTarget.getTextFlow().isObsolete()) {
+            return IndexingOverride.SKIP;
+        }
+        if (hTextFlowTarget.getTextFlow().getDocument().isObsolete()) {
+            return IndexingOverride.SKIP;
+        }
+        HProjectIteration projectIteration =
+                hTextFlowTarget.getTextFlow().getDocument()
+                        .getProjectIteration();
+        if (projectIteration.getStatus() == EntityStatus.OBSOLETE) {
+            return IndexingOverride.SKIP;
+        }
+        if (projectIteration.getProject().getStatus() == EntityStatus.OBSOLETE) {
+            return IndexingOverride.SKIP;
+        }
+        return IndexingOverride.APPLY_DEFAULT;
+    }
+
+    @Override
+    public IndexingOverride onUpdate(HTextFlowTarget hTextFlowTarget) {
+        if (hTextFlowTarget.getTextFlow().isObsolete()) {
+            return IndexingOverride.REMOVE;
+        }
+        if (hTextFlowTarget.getTextFlow().getDocument().isObsolete()) {
+            return IndexingOverride.REMOVE;
+        }
+        HProjectIteration projectIteration =
+                hTextFlowTarget.getTextFlow().getDocument()
+                        .getProjectIteration();
+        if (projectIteration.getStatus() == EntityStatus.OBSOLETE) {
+            return IndexingOverride.REMOVE;
+        }
+        if (projectIteration.getProject().getStatus() == EntityStatus.OBSOLETE) {
+            return IndexingOverride.REMOVE;
+        }
+        return IndexingOverride.UPDATE;
+    }
+
+    @Override
+    public IndexingOverride onDelete(HTextFlowTarget hTextFlowTarget) {
+        return IndexingOverride.APPLY_DEFAULT;
+    }
+
+    @Override
+    public IndexingOverride onCollectionUpdate(
+            HTextFlowTarget hTextFlowTarget) {
+        return onUpdate(hTextFlowTarget);
+    }
+}

--- a/server/zanata-model/src/main/java/org/zanata/hibernate/search/IndexFieldLabels.java
+++ b/server/zanata-model/src/main/java/org/zanata/hibernate/search/IndexFieldLabels.java
@@ -7,7 +7,7 @@ package org.zanata.hibernate.search;
  * @author David Mason, damason@redhat.com
  */
 public interface IndexFieldLabels {
-    public static final String PROJECT_FIELD = "project";
+    public static final String PROJECT_ID_FIELD = "project";
     public static final String ENTITY_STATUS = "status";
 
     /**
@@ -35,5 +35,5 @@ public interface IndexFieldLabels {
 
     public static final String GLOSSARY_QUALIFIED_NAME = "glossaryEntry.glossary.qualifiedName";
 
-    String PROJECT_VERSION_FIELD = "projectVersion";
+    String PROJECT_VERSION_ID_FIELD = "projectVersion";
 }

--- a/server/zanata-model/src/main/java/org/zanata/hibernate/search/IndexFieldLabels.java
+++ b/server/zanata-model/src/main/java/org/zanata/hibernate/search/IndexFieldLabels.java
@@ -7,7 +7,7 @@ package org.zanata.hibernate.search;
  * @author David Mason, damason@redhat.com
  */
 public interface IndexFieldLabels {
-    public static final String PROJECT_ID_FIELD = "project";
+    public static final String PROJECT_ID_FIELD = "projectId";
     public static final String ENTITY_STATUS = "status";
 
     /**
@@ -35,5 +35,5 @@ public interface IndexFieldLabels {
 
     public static final String GLOSSARY_QUALIFIED_NAME = "glossaryEntry.glossary.qualifiedName";
 
-    String PROJECT_VERSION_ID_FIELD = "projectVersion";
+    String PROJECT_VERSION_ID_FIELD = "projectVersionId";
 }

--- a/server/zanata-model/src/main/java/org/zanata/hibernate/search/TextFlowTargetEntityIndexingInterceptor.java
+++ b/server/zanata-model/src/main/java/org/zanata/hibernate/search/TextFlowTargetEntityIndexingInterceptor.java
@@ -29,7 +29,7 @@ import org.zanata.model.HTextFlowTarget;
 /**
  * @author Patrick Huang <a href="mailto:pahuang@redhat.com">pahuang@redhat.com</a>
  */
-public class EntityStatusIndexingInterceptor implements
+public class TextFlowTargetEntityIndexingInterceptor implements
         EntityIndexingInterceptor<HTextFlowTarget> {
     @Override
     public IndexingOverride onAdd(HTextFlowTarget hTextFlowTarget) {

--- a/server/zanata-model/src/main/java/org/zanata/model/HTextFlowTarget.java
+++ b/server/zanata-model/src/main/java/org/zanata/model/HTextFlowTarget.java
@@ -60,7 +60,7 @@ import org.zanata.common.ContentState;
 import org.zanata.common.HasContents;
 import org.zanata.common.LocaleId;
 import org.zanata.hibernate.search.ContentStateBridge;
-import org.zanata.hibernate.search.EntityStatusIndexingInterceptor;
+import org.zanata.hibernate.search.TextFlowTargetEntityIndexingInterceptor;
 import org.zanata.hibernate.search.IndexFieldLabels;
 import org.zanata.hibernate.search.LocaleIdBridge;
 import org.zanata.hibernate.search.StringListBridge;
@@ -87,7 +87,7 @@ import org.zanata.model.type.TranslationSourceTypeType;
         @TypeDef(name = "sourceType",
                 typeClass = TranslationSourceTypeType.class),
         @TypeDef(name = "entityType", typeClass = EntityTypeType.class) })
-@Indexed(interceptor = EntityStatusIndexingInterceptor.class)
+@Indexed(interceptor = TextFlowTargetEntityIndexingInterceptor.class)
 public class HTextFlowTarget extends ModelEntityBase
         implements HasContents, HasSimpleComment, ITextFlowTargetHistory,
         Serializable, ITextFlowTarget, IsEntityWithType {

--- a/server/zanata-model/src/main/java/org/zanata/model/HTextFlowTarget.java
+++ b/server/zanata-model/src/main/java/org/zanata/model/HTextFlowTarget.java
@@ -60,6 +60,7 @@ import org.zanata.common.ContentState;
 import org.zanata.common.HasContents;
 import org.zanata.common.LocaleId;
 import org.zanata.hibernate.search.ContentStateBridge;
+import org.zanata.hibernate.search.EntityStatusIndexingInterceptor;
 import org.zanata.hibernate.search.IndexFieldLabels;
 import org.zanata.hibernate.search.LocaleIdBridge;
 import org.zanata.hibernate.search.StringListBridge;
@@ -86,7 +87,7 @@ import org.zanata.model.type.TranslationSourceTypeType;
         @TypeDef(name = "sourceType",
                 typeClass = TranslationSourceTypeType.class),
         @TypeDef(name = "entityType", typeClass = EntityTypeType.class) })
-@Indexed
+@Indexed(interceptor = EntityStatusIndexingInterceptor.class)
 public class HTextFlowTarget extends ModelEntityBase
         implements HasContents, HasSimpleComment, ITextFlowTargetHistory,
         Serializable, ITextFlowTarget, IsEntityWithType {

--- a/server/zanata-war/src/main/java/org/zanata/events/TransMemoryMergeEvent.java
+++ b/server/zanata-war/src/main/java/org/zanata/events/TransMemoryMergeEvent.java
@@ -93,6 +93,6 @@ public class TransMemoryMergeEvent {
     }
 
     public Date getEndTime() {
-        return new Date(endTime.getTime());
+        return endTime == null ? null : new Date(endTime.getTime());
     }
 }

--- a/server/zanata-war/src/main/java/org/zanata/search/HTextFlowTargetIndexingStrategy.java
+++ b/server/zanata-war/src/main/java/org/zanata/search/HTextFlowTargetIndexingStrategy.java
@@ -59,7 +59,7 @@ public class HTextFlowTargetIndexingStrategy
             FullTextSession session) {
         // TODO move this query into something like HTextFlowTargetStreamingDAO
         Query query = session.createQuery(
-                "from HTextFlowTarget tft join fetch tft.locale join fetch tft.textFlow join fetch tft.textFlow.document join fetch tft.textFlow.document.locale join fetch tft.textFlow.document.projectIteration join fetch tft.textFlow.document.projectIteration.project");
+                "from HTextFlowTarget tft join fetch tft.locale join fetch tft.textFlow join fetch tft.textFlow.document join fetch tft.textFlow.document.locale join fetch tft.textFlow.document.projectIteration version join fetch tft.textFlow.document.projectIteration.project project where project.status <> 'O' and version.status <> 'O'");
         query.setFetchSize(Integer.MIN_VALUE);
         return query.scroll(ScrollMode.FORWARD_ONLY);
     }

--- a/server/zanata-war/src/main/java/org/zanata/search/HTextFlowTargetIndexingStrategy.java
+++ b/server/zanata-war/src/main/java/org/zanata/search/HTextFlowTargetIndexingStrategy.java
@@ -27,6 +27,7 @@ import org.hibernate.ScrollMode;
 import org.hibernate.ScrollableResults;
 import org.hibernate.search.FullTextSession;
 import org.zanata.async.AsyncTaskHandle;
+import org.zanata.common.EntityStatus;
 import org.zanata.dao.HTextFlowTargetStreamingDAO;
 import org.zanata.model.HProject;
 import org.zanata.model.HProjectIteration;
@@ -59,8 +60,9 @@ public class HTextFlowTargetIndexingStrategy
             FullTextSession session) {
         // TODO move this query into something like HTextFlowTargetStreamingDAO
         Query query = session.createQuery(
-                "from HTextFlowTarget tft join fetch tft.locale join fetch tft.textFlow join fetch tft.textFlow.document join fetch tft.textFlow.document.locale join fetch tft.textFlow.document.projectIteration version join fetch tft.textFlow.document.projectIteration.project project where project.status <> 'O' and version.status <> 'O'");
-        query.setFetchSize(Integer.MIN_VALUE);
+                "from HTextFlowTarget tft join fetch tft.locale join fetch tft.textFlow join fetch tft.textFlow.document join fetch tft.textFlow.document.locale join fetch tft.textFlow.document.projectIteration version join fetch tft.textFlow.document.projectIteration.project project where project.status <> :state and version.status <> :state");
+        query.setFetchSize(Integer.MIN_VALUE)
+                .setParameter("state", EntityStatus.OBSOLETE);
         return query.scroll(ScrollMode.FORWARD_ONLY);
     }
 

--- a/server/zanata-war/src/main/java/org/zanata/service/impl/EntityListenerUtil.java
+++ b/server/zanata-war/src/main/java/org/zanata/service/impl/EntityListenerUtil.java
@@ -45,7 +45,7 @@ final class EntityListenerUtil {
      * @param entityField field name to look up in entity
      * @return looked up index for a given field for the entity
      */
-    static Integer getFieldIndex(Integer slugFieldIndex,
+    static int getFieldIndex(Integer slugFieldIndex,
             PostUpdateEvent event, String entityField) {
         if (slugFieldIndex != null) {
             return slugFieldIndex;

--- a/server/zanata-war/src/main/java/org/zanata/service/impl/EntityListenerUtil.java
+++ b/server/zanata-war/src/main/java/org/zanata/service/impl/EntityListenerUtil.java
@@ -1,0 +1,67 @@
+/*
+ * Copyright 2017, Red Hat, Inc. and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.zanata.service.impl;
+
+import org.hibernate.event.spi.PostUpdateEvent;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import com.google.common.collect.Lists;
+
+/**
+ * @author Patrick Huang <a href="mailto:pahuang@redhat.com">pahuang@redhat.com</a>
+ */
+final class EntityListenerUtil {
+    private static final Logger log =
+            LoggerFactory.getLogger(EntityListenerUtil.class);
+    /**
+     * Try to locate index for field in the entity. We try to optimize a
+     * bit here since the index should be consistent and only need to be looked
+     * up once. If the given index is not null, it means it has been looked up
+     * and set already so we just return that value. Otherwise it will look it
+     * up in hibernate persister and return the index value.
+     *
+     * @param slugFieldIndex
+     *            if not null it will be the index to use
+     * @param event
+     *            post update event for an entity
+     * @param entityField field name to look up in entity
+     * @return looked up index for a given field for the entity
+     */
+    static Integer getFieldIndex(Integer slugFieldIndex,
+            PostUpdateEvent event, String entityField) {
+        if (slugFieldIndex != null) {
+            return slugFieldIndex;
+        }
+        String[] propertyNames = event.getPersister().getPropertyNames();
+        int i;
+        for (i = 0; i < propertyNames.length; i++) {
+            String propertyName = propertyNames[i];
+            if (propertyName.equals(entityField)) {
+                return i;
+            }
+        }
+        log.error("can not find {} index in entity [{}] properties [{}]",
+                entityField, event.getEntity(),
+                Lists.newArrayList(propertyNames));
+        throw new IllegalStateException(
+                "can not find " + entityField + " index in entity properties");
+    }
+}

--- a/server/zanata-war/src/main/java/org/zanata/service/impl/ReindexChildrenEntityEventListener.java
+++ b/server/zanata-war/src/main/java/org/zanata/service/impl/ReindexChildrenEntityEventListener.java
@@ -56,17 +56,13 @@ public class ReindexChildrenEntityEventListener
 
     @Override
     public boolean requiresPostCommitHanding(EntityPersister persister) {
+        // We must return true otherwise hibernate will not treat this as post commit event
         return true;
     }
 
     @Override
     public void onPostUpdate(PostUpdateEvent event) {
         Object entity = event.getEntity();
-        Class<?> entityClass = entity.getClass();
-        if (!entityClass.equals(HProject.class)
-                && !entityClass.equals(HProjectIteration.class)) {
-            return;
-        }
         if (entity instanceof HProject) {
             HProject project = (HProject) entity;
 

--- a/server/zanata-war/src/main/java/org/zanata/service/impl/ReindexChildrenEntityEventListener.java
+++ b/server/zanata-war/src/main/java/org/zanata/service/impl/ReindexChildrenEntityEventListener.java
@@ -1,0 +1,140 @@
+/*
+ * Copyright 2017, Red Hat, Inc. and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.zanata.service.impl;
+
+import static org.zanata.service.impl.EntityListenerUtil.getFieldIndex;
+
+import org.hibernate.event.spi.PostCommitUpdateEventListener;
+import org.hibernate.event.spi.PostUpdateEvent;
+import org.hibernate.persister.entity.EntityPersister;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+import org.zanata.async.AsyncTaskHandle;
+import org.zanata.async.AsyncTaskHandleManager;
+import org.zanata.common.EntityStatus;
+import org.zanata.model.HProject;
+import org.zanata.model.HProjectIteration;
+import org.zanata.service.IndexingService;
+import org.zanata.util.ServiceLocator;
+
+/**
+ * This class is a hibernate event listener which listens on post commit events
+ * for HProject and HProjectIteration. If it detects a status change from/to
+ * obsolete, it will perform re-indexing for all HTextFlowTargets under that
+ * project/version.
+ *
+ * @see org.zanata.webtrans.server.HibernateIntegrator
+ * @see IndexingServiceImpl
+ * @author Patrick Huang
+ *         <a href="mailto:pahuang@redhat.com">pahuang@redhat.com</a>
+ */
+public class ReindexChildrenEntityEventListener
+        implements PostCommitUpdateEventListener {
+    private static final Logger log =
+            LoggerFactory.getLogger(ReindexChildrenEntityEventListener.class);
+    private static final long serialVersionUID = 771080602386793595L;
+    private Integer statusFieldIndexInProject;
+    private Integer statusFieldIndexInIteration;
+
+    @Override
+    public boolean requiresPostCommitHanding(EntityPersister persister) {
+        return true;
+    }
+
+    @Override
+    public void onPostUpdate(PostUpdateEvent event) {
+        Object entity = event.getEntity();
+        Class<?> entityClass = entity.getClass();
+        if (!entityClass.equals(HProject.class)
+                && !entityClass.equals(HProjectIteration.class)) {
+            return;
+        }
+        if (entity instanceof HProject) {
+            HProject project = (HProject) entity;
+
+            statusFieldIndexInProject =
+                    getFieldIndex(statusFieldIndexInProject, event, "status");
+
+            EntityStatus oldStatus = (EntityStatus) event
+                    .getOldState()[statusFieldIndexInProject];
+
+            reindexIfStatusChangeInvolvesObsolete(project, oldStatus);
+
+        } else if (entity instanceof HProjectIteration) {
+            HProjectIteration iteration = (HProjectIteration) entity;
+
+            statusFieldIndexInIteration =
+                    getFieldIndex(statusFieldIndexInIteration, event, "status");
+
+            EntityStatus oldStatus = (EntityStatus) event
+                    .getOldState()[statusFieldIndexInIteration];
+
+            reindexIfStatusChangeInvolvesObsolete(iteration, oldStatus);
+        }
+    }
+
+    private void reindexIfStatusChangeInvolvesObsolete(HProject project,
+            EntityStatus oldStatus) {
+        if (project.getStatus() == EntityStatus.OBSOLETE
+                || oldStatus == EntityStatus.OBSOLETE) {
+            log.debug("HProject [{}] status changed from/to obsolete");
+            AsyncTaskHandle<Void> handle = new AsyncTaskHandle<>();
+            getAsyncTaskHandleManager().registerTaskHandle(handle);
+            try {
+                getIndexingServiceImpl()
+                        .reindexHTextFlowTargetsForProject(project, handle);
+            } catch (Exception e) {
+                log.error("exception happen in async framework", e);
+            }
+        }
+    }
+
+    private void reindexIfStatusChangeInvolvesObsolete(
+            HProjectIteration iteration, EntityStatus oldStatus) {
+        if (iteration.getStatus() == EntityStatus.OBSOLETE
+                || oldStatus == EntityStatus.OBSOLETE) {
+            log.debug("HProjectIteration [{}] changed from/to obsolete");
+            AsyncTaskHandle<Void> handle = new AsyncTaskHandle<>();
+            getAsyncTaskHandleManager().registerTaskHandle(handle);
+            try {
+                getIndexingServiceImpl()
+                        .reindexHTextFlowTargetsForProjectIteration(iteration,
+                                handle);
+            } catch (Exception e) {
+                log.error("exception happen in async framework", e);
+            }
+        }
+    }
+
+    public AsyncTaskHandleManager getAsyncTaskHandleManager() {
+        return ServiceLocator.instance()
+                .getInstance(AsyncTaskHandleManager.class);
+    }
+
+    public IndexingService getIndexingServiceImpl() {
+        return ServiceLocator.instance().getInstance(IndexingService.class);
+    }
+
+    @Override
+    public void onPostUpdateCommitFailed(PostUpdateEvent event) {
+        // nothing
+    }
+}

--- a/server/zanata-war/src/main/java/org/zanata/service/impl/SlugEntityUpdatedListener.java
+++ b/server/zanata-war/src/main/java/org/zanata/service/impl/SlugEntityUpdatedListener.java
@@ -35,15 +35,10 @@ public class SlugEntityUpdatedListener implements
 
     @Override
     public void onPostUpdate(PostUpdateEvent event) {
-        Class<?> entityClass = event.getEntity().getClass();
-        if (!entityClass.equals(HProject.class)
-                && !entityClass.equals(HProjectIteration.class)) {
-            return;
-        }
-        SlugEntityBase slugEntityBase =
-                SlugEntityBase.class.cast(event.getEntity());
-        if (slugEntityBase instanceof HProject) {
-            HProject project = (HProject) slugEntityBase;
+        Object entity = event.getEntity();
+
+        if (entity instanceof HProject) {
+            HProject project = (HProject) entity;
             slugFieldIndexInProject =
                     getFieldIndex(slugFieldIndexInProject, event, "slug");
 
@@ -53,8 +48,8 @@ public class SlugEntityUpdatedListener implements
 
             fireProjectUpdateEvent(project, oldSlug);
 
-        } else if (slugEntityBase instanceof HProjectIteration) {
-            HProjectIteration iteration = (HProjectIteration) slugEntityBase;
+        } else if (entity instanceof HProjectIteration) {
+            HProjectIteration iteration = (HProjectIteration) entity;
             slugFieldIndexInIteration =
                     getFieldIndex(slugFieldIndexInIteration, event, "slug");
 
@@ -68,6 +63,7 @@ public class SlugEntityUpdatedListener implements
 
     @Override
     public boolean requiresPostCommitHanding(EntityPersister persister) {
+        // We must return true otherwise hibernate will not treat this as post commit event
         return true;
     }
 

--- a/server/zanata-war/src/main/java/org/zanata/service/impl/SlugEntityUpdatedListener.java
+++ b/server/zanata-war/src/main/java/org/zanata/service/impl/SlugEntityUpdatedListener.java
@@ -1,28 +1,22 @@
 package org.zanata.service.impl;
 
+import static org.zanata.service.impl.EntityListenerUtil.getFieldIndex;
+
 import org.apache.deltaspike.core.api.provider.BeanManagerProvider;
+import org.hibernate.event.spi.PostCommitUpdateEventListener;
 import org.hibernate.event.spi.PostUpdateEvent;
-import org.hibernate.event.spi.PostUpdateEventListener;
 import org.hibernate.persister.entity.EntityPersister;
-import org.zanata.async.AsyncTaskHandle;
-import org.zanata.async.AsyncTaskHandleManager;
-import org.zanata.common.EntityStatus;
 import org.zanata.events.ProjectIterationUpdate;
 import org.zanata.events.ProjectUpdate;
 import org.zanata.model.HProject;
 import org.zanata.model.HProjectIteration;
 import org.zanata.model.SlugEntityBase;
-import org.zanata.service.IndexingService;
-import org.zanata.util.ServiceLocator;
-
-import com.google.common.collect.Lists;
 
 /**
  * This class is a hibernate event listener which listens on post commit events
- * for HProject and HProjectIteration. If it detects the status becoming
- * obsolete, it will perform re-indexing for all HTextFlowTargets under that
- * project/version. It will also fire update event for HProject and
- * HProjectIteration with their old slug in payload.
+ * for HProject and HProjectIteration. If it detects the slug has changed, it
+ * will fire update event for HProject and HProjectIteration with their old slug
+ * in payload.
  *
  * @see org.zanata.webtrans.server.HibernateIntegrator
  * @see org.zanata.webtrans.server.TranslationWorkspaceManagerImpl
@@ -31,15 +25,13 @@ import com.google.common.collect.Lists;
  * @author Patrick Huang
  *         <a href="mailto:pahuang@redhat.com">pahuang@redhat.com</a>
  */
-public class SlugEntityUpdatedListener implements PostUpdateEventListener {
-    private static final org.slf4j.Logger log =
-            org.slf4j.LoggerFactory.getLogger(SlugEntityUpdatedListener.class);
+public class SlugEntityUpdatedListener implements
+        PostCommitUpdateEventListener {
 
     private static final long serialVersionUID = -1L;
     private Integer slugFieldIndexInProject;
     private Integer slugFieldIndexInIteration;
-    private Integer statusFieldIndexInProject;
-    private Integer statusFieldIndexInIteration;
+
 
     @Override
     public void onPostUpdate(PostUpdateEvent event) {
@@ -54,67 +46,29 @@ public class SlugEntityUpdatedListener implements PostUpdateEventListener {
             HProject project = (HProject) slugEntityBase;
             slugFieldIndexInProject =
                     getFieldIndex(slugFieldIndexInProject, event, "slug");
-            statusFieldIndexInProject = getFieldIndex(
-                    statusFieldIndexInProject, event, "status");
+
             String oldSlug =
                     event.getOldState()[slugFieldIndexInProject].toString();
-            EntityStatus oldStatus = (EntityStatus) event
-                    .getOldState()[statusFieldIndexInProject];
+
 
             fireProjectUpdateEvent(project, oldSlug);
-            reindexIfStatusChange(project, oldStatus);
 
         } else if (slugEntityBase instanceof HProjectIteration) {
             HProjectIteration iteration = (HProjectIteration) slugEntityBase;
             slugFieldIndexInIteration =
                     getFieldIndex(slugFieldIndexInIteration, event, "slug");
-            statusFieldIndexInIteration =
-                    getFieldIndex(statusFieldIndexInIteration, event, "status");
+
             String oldSlug =
                     event.getOldState()[slugFieldIndexInIteration].toString();
-            EntityStatus oldStatus = (EntityStatus) event
-                    .getOldState()[statusFieldIndexInIteration];
+
 
             fireProjectIterationUpdateEvent(iteration, oldSlug);
-            reindexIfStatusChange(iteration, oldStatus);
-        }
-    }
-
-    private void reindexIfStatusChange(HProjectIteration iteration, EntityStatus oldStatus) {
-        if (iteration.getStatus() == EntityStatus.OBSOLETE
-                || oldStatus == EntityStatus.OBSOLETE) {
-            log.debug("HProjectIteration [{}] changed from/to obsolete");
-            AsyncTaskHandle<Void> handle = new AsyncTaskHandle<>();
-            getAsyncTaskHandleManager().registerTaskHandle(handle);
-            try {
-                getIndexingServiceImpl()
-                        .reindexHTextFlowTargetsForProjectIteration(iteration, handle);
-            } catch (Exception e) {
-                log.error("exception happen in async framework", e);
-            }
-        }
-    }
-
-    private void reindexIfStatusChange(HProject project,
-            EntityStatus oldStatus) {
-        if (project.getStatus() == EntityStatus.OBSOLETE
-                || oldStatus == EntityStatus.OBSOLETE) {
-            log.debug("HProject [{}] status changed from/to obsolete");
-            AsyncTaskHandle<Void> handle = new AsyncTaskHandle<>();
-            getAsyncTaskHandleManager().registerTaskHandle(handle);
-            try {
-                getIndexingServiceImpl()
-                        .reindexHTextFlowTargetsForProject(project, handle);
-            } catch (Exception e) {
-                log.error("exception happen in async framework", e);
-            }
         }
     }
 
     @Override
     public boolean requiresPostCommitHanding(EntityPersister persister) {
-        // TODO um, no?
-        return false;
+        return true;
     }
 
     private void fireProjectIterationUpdateEvent(HProjectIteration iteration,
@@ -130,46 +84,8 @@ public class SlugEntityUpdatedListener implements PostUpdateEventListener {
                 .fireEvent(new ProjectUpdate(project, oldSlug));
     }
 
-    /**
-     * Try to locate index for field in the entity. We try to optimize a
-     * bit here since the index should be consistent and only need to be looked
-     * up once. If the given index is not null, it means it has been looked up
-     * and set already so we just return that value. Otherwise it will look it
-     * up in hibernate persister and return the index value.
-     *
-     * @param slugFieldIndex
-     *            if not null it will be the index to use
-     * @param event
-     *            post update event for an entity
-     * @param entityField field name to look up in entity
-     * @return looked up index for a given field for the entity
-     */
-    private static Integer getFieldIndex(Integer slugFieldIndex,
-            PostUpdateEvent event, String entityField) {
-        if (slugFieldIndex != null) {
-            return slugFieldIndex;
-        }
-        String[] propertyNames = event.getPersister().getPropertyNames();
-        int i;
-        for (i = 0; i < propertyNames.length; i++) {
-            String propertyName = propertyNames[i];
-            if (propertyName.equals(entityField)) {
-                return i;
-            }
-        }
-        log.error("can not find {} index in entity [{}] properties [{}]",
-                entityField, event.getEntity(),
-                Lists.newArrayList(propertyNames));
-        throw new IllegalStateException(
-                "can not find " + entityField + " index in entity properties");
-    }
-
-    public AsyncTaskHandleManager getAsyncTaskHandleManager() {
-        return ServiceLocator.instance()
-                .getInstance(AsyncTaskHandleManager.class);
-    }
-
-    public IndexingService getIndexingServiceImpl() {
-        return ServiceLocator.instance().getInstance(IndexingService.class);
+    @Override
+    public void onPostUpdateCommitFailed(PostUpdateEvent event) {
+        // nothing
     }
 }

--- a/server/zanata-war/src/main/java/org/zanata/service/impl/SlugEntityUpdatedListener.java
+++ b/server/zanata-war/src/main/java/org/zanata/service/impl/SlugEntityUpdatedListener.java
@@ -157,10 +157,11 @@ public class SlugEntityUpdatedListener implements PostUpdateEventListener {
                 return i;
             }
         }
-        log.error("can not find slug index in entity [{}] properties [{}]",
-                event.getEntity(), Lists.newArrayList(propertyNames));
+        log.error("can not find {} index in entity [{}] properties [{}]",
+                entityField, event.getEntity(),
+                Lists.newArrayList(propertyNames));
         throw new IllegalStateException(
-                "can not find slug index in entity properties");
+                "can not find " + entityField + " index in entity properties");
     }
 
     public AsyncTaskHandleManager getAsyncTaskHandleManager() {

--- a/server/zanata-war/src/main/java/org/zanata/service/impl/TranslationMemoryServiceImpl.java
+++ b/server/zanata-war/src/main/java/org/zanata/service/impl/TranslationMemoryServiceImpl.java
@@ -752,7 +752,7 @@ public class TranslationMemoryServiceImpl implements TranslationMemoryService {
             TransMemoryQuery queryParams) {
         if (queryParams.getProject() != null) {
             TermQuery projectQuery =
-                    new TermQuery(new Term(IndexFieldLabels.PROJECT_FIELD,
+                    new TermQuery(new Term(IndexFieldLabels.PROJECT_ID_FIELD,
                             queryParams.getProject().getValue()));
             if (queryParams.getProject().isCheck()) {
                 query.add(projectQuery, BooleanClause.Occur.MUST);

--- a/server/zanata-war/src/main/java/org/zanata/service/impl/TranslationMemoryServiceImpl.java
+++ b/server/zanata-war/src/main/java/org/zanata/service/impl/TranslationMemoryServiceImpl.java
@@ -251,7 +251,7 @@ public class TranslationMemoryServiceImpl implements TranslationMemoryService {
             boolean includeOwnTranslation) {
         TransMemoryQuery.Condition project = new TransMemoryQuery.Condition(
                 checkProject, textFlow.getDocument().getProjectIteration()
-                        .getProject().getSlug());
+                        .getProject().getId().toString());
         TransMemoryQuery.Condition document = new TransMemoryQuery.Condition(
                 checkDocument, textFlow.getDocument().getDocId());
         TransMemoryQuery.Condition res = new TransMemoryQuery.Condition(

--- a/server/zanata-war/src/main/java/org/zanata/webtrans/server/HibernateIntegrator.java
+++ b/server/zanata-war/src/main/java/org/zanata/webtrans/server/HibernateIntegrator.java
@@ -8,6 +8,7 @@ import org.hibernate.event.service.spi.EventListenerRegistry;
 import org.hibernate.event.spi.EventType;
 import org.hibernate.integrator.spi.Integrator;
 import org.hibernate.service.spi.SessionFactoryServiceRegistry;
+import org.zanata.service.impl.ReindexChildrenEntityEventListener;
 import org.zanata.service.impl.SlugEntityUpdatedListener;
 
 /**
@@ -40,7 +41,7 @@ public class HibernateIntegrator implements Integrator {
         SlugEntityUpdatedListener slugEntityUpdatedListener =
                 new SlugEntityUpdatedListener();
         eventListenerRegistry.appendListeners(EventType.POST_COMMIT_UPDATE,
-                slugEntityUpdatedListener);
+                slugEntityUpdatedListener, new ReindexChildrenEntityEventListener());
     }
 
     @Override


### PR DESCRIPTION
- exclude HTextFlowTargets from obsolete project or version
- index project id instead of slug (so it's immutable)
- index version id instead of slug (so it's immutable)
- reindex when project or version become obsolete

JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2022

note to QA:
- need to perform re-index HTextFlowTarget in administration-> manage search
- if a project or version is deleted (status become obsolete in database), there should be a re-index log message in console. It should be transparent to user
- TM merge should still work as before. Need to make sure when rejecting TM from different project, it does what it says. e.g. when you choose reject TM from different project, you should not get TM from different project

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/362)
<!-- Reviewable:end -->
