### PR TITLE
quick build also skips checkstyle and animal sniffer

### DIFF
--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -204,6 +204,8 @@
     <enforcer.skip>true</enforcer.skip>
     <findbugs.skip>true</findbugs.skip>
     <mdep.analyze.skip>true</mdep.analyze.skip>
+    <checkstyle.skip>true</checkstyle.skip>
+    <animal.sniffer.skip>true</animal.sniffer.skip>
 
     <hamcrest.version>1.3</hamcrest.version>
     <findbugs.maven.version>3.0.1</findbugs.maven.version>
@@ -921,6 +923,8 @@
         <enforcer.skip>false</enforcer.skip>
         <findbugs.skip>false</findbugs.skip>
         <mdep.analyze.skip>false</mdep.analyze.skip>
+        <checkstyle.skip>false</checkstyle.skip>
+        <animal.sniffer.skip>false</animal.sniffer.skip>
       </properties>
     </profile>
 


### PR DESCRIPTION
When running build -Q --server, it will also skip checkstyle and animal sniffer

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/386)
<!-- Reviewable:end -->
