### PR TITLE
fix(ZNTA-2061) corrected colour of translation history rejected text

### DIFF
--- a/server/gwt-editor/src/main/java/org/zanata/webtrans/client/util/ContentStateToStyleUtil.java
+++ b/server/gwt-editor/src/main/java/org/zanata/webtrans/client/util/ContentStateToStyleUtil.java
@@ -39,7 +39,7 @@ public class ContentStateToStyleUtil {
             case Approved:
                 return "txt--state-highlight";
             case Rejected:
-                return "txt--state-danger";
+                return "txt--state-warning";
         }
         return styleNames;
     }

--- a/server/zanata-war/src/test/java/org/zanata/webtrans/client/util/ContentStateToStyleUtilTest.java
+++ b/server/zanata-war/src/test/java/org/zanata/webtrans/client/util/ContentStateToStyleUtilTest.java
@@ -16,7 +16,7 @@ public class ContentStateToStyleUtilTest {
         assertThat(stateToStyle(NeedReview)).contains("unsure");
         assertThat(stateToStyle(Translated)).contains("success");
         assertThat(stateToStyle(Approved)).contains("highlight");
-        assertThat(stateToStyle(Rejected)).contains("danger");
+        assertThat(stateToStyle(Rejected)).contains("warning");
     }
 
     @Test


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2061

Change colour of rejected text in translation history modal of GWT editor to be orange instead of red.

<img width="859" alt="tm-history-rejected" src="https://user-images.githubusercontent.com/18179401/27620468-34c8daee-5c0d-11e7-8e4d-233ae471d254.png">



## Reviewer tasks

The following is based on the
[Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines).
As a reviewer, you should check the guidelines regularly for updates, and just
to refresh your memory.


The reviewer can use this list for reference to make sure
they have considered all the important points.

Use the checkboxes or not, whatever works best for you.

 - Code quality
   - [ ] Code passes style check (checkstyle/eslint)
   - [ ] Code is clear and concise
   - [ ] UI code is internationalised
   - [ ] Code has adequate comments where appropriate
   - Code is in an appropriate place
     - [ ] Classes are in appropriate packages
     - [ ] Code fits with class's responsibilities (SRP)
   - [ ] Configuration files are documented enough
   - If code is removed
     - [ ] No remaining code references the removed code
       - [ ] No orphaned rewrite rules
       - [ ] No orphaned config settings
     - [ ] No remaining comments refer to the removed code
     - [ ] Unused imports and libraries are removed
 - Testing
   - [ ] New code has tests
   - [ ] Changed code has tests
   - [ ] All tests pass
   - [ ] Test coverage stable or increased
 - Documentation
   - [ ] New features are documented
   - [ ] Docs removed for deleted features
   - [ ] Docs updated for all changed features
   - [ ] Developer/sysadmin docs updated if appropriate
 - If there are new dependencies
   - [ ] Does each new dependency pass all the
         [Considerations for new dependencies](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines#new-technologies-and-dependencies)?


----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/409)
<!-- Reviewable:end -->
