### PR TITLE
fix(test): Workaround flake in test suite

### DIFF
--- a/server/functional-test/src/test/java/org/zanata/feature/search/comp/GroupSearchCTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/search/comp/GroupSearchCTest.java
@@ -25,7 +25,6 @@ import org.junit.Test;
 import org.junit.experimental.categories.Category;
 import org.zanata.feature.testharness.TestPlan;
 import org.zanata.feature.testharness.ZanataTestCase;
-import org.zanata.page.dashboard.DashboardGroupsTab;
 import org.zanata.page.explore.ExplorePage;
 import org.zanata.page.groups.VersionGroupPage;
 import org.zanata.workflow.BasicWorkFlow;
@@ -40,8 +39,6 @@ import static org.assertj.core.api.Assertions.assertThat;
 @Category(TestPlan.ComprehensiveTest.class)
 public class GroupSearchCTest extends ZanataTestCase {
 
-    private DashboardGroupsTab dashboardGroupsTab;
-
     @Test(timeout = MAX_SHORT_TEST_DURATION)
     public void successfulGroupSearchAndDisplay() throws Exception {
         String groupID = "basic-group";
@@ -49,10 +46,10 @@ public class GroupSearchCTest extends ZanataTestCase {
         assertThat(new LoginWorkFlow().signIn("admin", "admin").loggedInAs())
                 .isEqualTo("admin")
                 .as("Admin is logged in");
-        dashboardGroupsTab =
-                new BasicWorkFlow().goToHome().goToMyDashboard().gotoGroupsTab();
 
-        VersionGroupPage groupPage = dashboardGroupsTab
+        new BasicWorkFlow().goToHome()
+                .goToMyDashboard()
+                .gotoGroupsTab()
                 .createNewGroup()
                 .inputGroupId(groupID)
                 .inputGroupName(groupName)
@@ -80,7 +77,7 @@ public class GroupSearchCTest extends ZanataTestCase {
         ExplorePage explorePage = new BasicWorkFlow()
                 .goToHome()
                 .gotoExplore()
-                .enterSearch("group");
+                .enterSearch("groop");
 
         assertThat(explorePage.getGroupSearchResults().isEmpty())
                 .isTrue()


### PR DESCRIPTION
JIRA issue URL: n/a

Workaround: Sometimes data is not cleared properly. Alter test to search for 'groop' to match nothing.


## Reviewer tasks

The following is based on the
[Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines).
As a reviewer, you should check the guidelines regularly for updates, and just
to refresh your memory.


The reviewer can use this list for reference to make sure
they have considered all the important points.

Use the checkboxes or not, whatever works best for you.

 - Code quality
   - [ ] Code passes style check (checkstyle/eslint)
   - [ ] Code is clear and concise
   - [ ] UI code is internationalised
   - [ ] Code has adequate comments where appropriate
   - Code is in an appropriate place
     - [ ] Classes are in appropriate packages
     - [ ] Code fits with class's responsibilities (SRP)
   - [ ] Configuration files are documented enough
   - If code is removed
     - [ ] No remaining code references the removed code
       - [ ] No orphaned rewrite rules
       - [ ] No orphaned config settings
     - [ ] No remaining comments refer to the removed code
     - [ ] Unused imports and libraries are removed
 - Testing
   - [ ] New code has tests
   - [ ] Changed code has tests
   - [ ] All tests pass
   - [ ] Test coverage stable or increased
 - Documentation
   - [ ] New features are documented
   - [ ] Docs removed for deleted features
   - [ ] Docs updated for all changed features
   - [ ] Developer/sysadmin docs updated if appropriate
 - If there are new dependencies
   - [ ] Does each new dependency pass all the
         [Considerations for new dependencies](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines#new-technologies-and-dependencies)?


----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/419)
<!-- Reviewable:end -->
