### PR TITLE
Add .gitattributes for scripts and JS files

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -5,7 +5,7 @@
 # converted to the OS's native line endings.
 * text
 
-# Explicitly declare text files we want to always be normalized and converted 
+# Explicitly declare text files we want to always be normalized and converted
 # to native line endings on checkout.
 *.c text
 *.css text
@@ -28,6 +28,10 @@
 
 # Declare files that will always have CRLF line endings on checkout.
 *.sln text eol=crlf
+
+# Declare files that will always have LF line endings on checkout.
+build text eol=lf
+mvnw text eol=lf
 
 # Denote all files that are truly binary and should not be modified.
 *.gif binary

--- a/server/zanata-frontend/.gitattributes
+++ b/server/zanata-frontend/.gitattributes
@@ -1,0 +1,3 @@
+*.js text eol=lf
+*.jsx text eol=lf
+*.jsx.src text eol=lf


### PR DESCRIPTION
Otherwise the linter complains about CR-LF when building on Windows.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/422)
<!-- Reviewable:end -->
