### PR TITLE
externalize jest config so that tests can be run in IDE

### DIFF
--- a/server/zanata-frontend/src/frontend/jest.config.json
+++ b/server/zanata-frontend/src/frontend/jest.config.json
@@ -1,0 +1,31 @@
+{
+  "collectCoverageFrom": [
+    "app/**/*.{js,jsx}",
+    "!**/node_modules/**",
+    "!app/**/*.story.js"
+  ],
+  "coverageReporters": [
+    "cobertura",
+    "html",
+    "lcov",
+    "text"
+  ],
+  "moduleNameMapper": {
+    "^.+\\.(css)$": "./__tests__/mock/mockCss.js"
+  },
+  "transform": {
+    ".*": "./node_modules/babel-jest"
+  },
+  "testPathIgnorePatterns": [
+    "/node_modules/",
+    "/__tests__/mock"
+  ],
+  "unmockedModulePathPatterns": [
+    "/node_modules",
+    "/app"
+  ],
+  "moduleFileExtensions": [
+    "js",
+    "jsx"
+  ]
+}

--- a/server/zanata-frontend/src/frontend/package.json
+++ b/server/zanata-frontend/src/frontend/package.json
@@ -14,8 +14,8 @@
     "storybook-editor": "start-storybook -p 9001 -s ./dist --config-dir .storybook-editor",
     "storybook-frontend": "start-storybook -p 9001 -s ./dist --config-dir .storybook-frontend",
     "storybook-build": "build-storybook -s ./dist",
-    "test": "jest --coverage",
-    "test:watch": "jest --watch --coverage"
+    "test": "jest --coverage --config jest.config.json",
+    "test:watch": "jest --watch --coverage --config jest.config.json"
   },
   "repository": {
     "type": "git",
@@ -133,36 +133,5 @@
     "svg-sprite": "1.3.6",
     "text-diff": "1.0.1",
     "webfontloader": "1.6.24"
-  },
-  "jest": {
-    "collectCoverageFrom": [
-      "app/**/*.{js,jsx}",
-      "!**/node_modules/**",
-      "!app/**/*.story.js"
-    ],
-    "coverageReporters": [
-      "cobertura",
-      "html",
-      "lcov",
-      "text"
-    ],
-    "moduleNameMapper": {
-      "^.+\\.(css)$": "./__tests__/mock/mockCss.js"
-    },
-    "transform": {
-      ".*": "./node_modules/babel-jest"
-    },
-    "testPathIgnorePatterns": [
-      "/node_modules/",
-      "/__tests__/mock"
-    ],
-    "unmockedModulePathPatterns": [
-      "/node_modules",
-      "/app"
-    ],
-    "moduleFileExtensions": [
-      "js",
-      "jsx"
-    ]
   }
 }


### PR DESCRIPTION
Right click on a test and choose "Create ... test" (with jest icon next to it). Then all you need to do is fill in jest.config.json file path as Configuration file , node path as Node interpreter (if it can't find it)

![jest-ide-config](https://user-images.githubusercontent.com/1005842/28404464-c888b9a0-6d6c-11e7-8df4-4e19f13f903b.png)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/432)
<!-- Reviewable:end -->
