### PR TITLE
fixes:(ZNTA-2159) version-group dropdown now showing correctly (ZNTA-2158) words no longer breaking over multiple lines in GWT

### DIFF
--- a/server/zanata-frontend/src/frontend/app/styles/style.less
+++ b/server/zanata-frontend/src/frontend/app/styles/style.less
@@ -6035,7 +6035,7 @@ i.i--left.i--lock, i.i--left.i--trash {
   padding-bottom:@spacing-base-and-a-half;
 }
 
-.translationContainer pre{
+.translationContainer pre {
   word-wrap: normal;
   word-break: normal;
   word-break: break-word; /*Chrome specific*/

--- a/server/zanata-frontend/src/frontend/app/styles/style.less
+++ b/server/zanata-frontend/src/frontend/app/styles/style.less
@@ -6035,13 +6035,18 @@ i.i--left.i--lock, i.i--left.i--trash {
   padding-bottom:@spacing-base-and-a-half;
 }
 
-.translationContainer pre.cm-s-default {
+.translationContainer pre{
   word-wrap: normal;
   word-break: normal;
   word-break: break-word; /*Chrome specific*/
   -webkit-hyphens: initial;
   -moz-hyphens: initial;
   hyphens: initial;
+}
+
+.new-zanata #versionAutocomplete .autocomplete__results {
+  position: relative;
+  margin-top: -1rem;
 }
 
 // @screen-xs variable depreciated


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2159
Other issue needing urgent fix in release: https://zanata.atlassian.net/browse/ZNTA-2158

Added css to make sure the version-group dropdown shows the entire list of options instead of being cut off in the parent container.

Before:
<img width="1255" alt="before" src="https://user-images.githubusercontent.com/18179401/28948567-ddee5fdc-78f9-11e7-94a7-df85cd8a363b.png">

After:
<img width="1275" alt="after" src="https://user-images.githubusercontent.com/18179401/28948576-e523ebf0-78f9-11e7-818e-b576cd51f855.png">

Another issue (ZNTA-2158) which I have fixed in master but not in release correctly has been resolved in this issue since it only involved removing one word from a css rule. This is to make sure the GWT editor does not break words across multiple lines in the TM panel.

It now looks like this:
<img width="1268" alt="line-wrap-after" src="https://user-images.githubusercontent.com/18179401/28948595-0b069d0e-78fa-11e7-99aa-e78730ada6dc.png">



## Reviewer tasks

The following is based on the
[Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines).
As a reviewer, you should check the guidelines regularly for updates, and just
to refresh your memory.


The reviewer can use this list for reference to make sure
they have considered all the important points.

Use the checkboxes or not, whatever works best for you.

 - Code quality
   - [ ] Code passes style check (checkstyle/eslint)
   - [ ] Code is clear and concise
   - [ ] UI code is internationalised
   - [ ] Code has adequate comments where appropriate
   - Code is in an appropriate place
     - [ ] Classes are in appropriate packages
     - [ ] Code fits with class's responsibilities (SRP)
   - [ ] Configuration files are documented enough
   - If code is removed
     - [ ] No remaining code references the removed code
       - [ ] No orphaned rewrite rules
       - [ ] No orphaned config settings
     - [ ] No remaining comments refer to the removed code
     - [ ] Unused imports and libraries are removed
 - Testing
   - [ ] New code has tests
   - [ ] Changed code has tests
   - [ ] All tests pass
   - [ ] Test coverage stable or increased
 - Documentation
   - [ ] New features are documented
   - [ ] Docs removed for deleted features
   - [ ] Docs updated for all changed features
   - [ ] Developer/sysadmin docs updated if appropriate
 - If there are new dependencies
   - [ ] Does each new dependency pass all the
         [Considerations for new dependencies](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines#new-technologies-and-dependencies)?


----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/468)
<!-- Reviewable:end -->
