### PR TITLE
fix(ZNTA-2100): Gettext "Language" header field inconsistent format

### DIFF
--- a/server/services/src/main/java/org/zanata/rest/service/ResourceUtils.java
+++ b/server/services/src/main/java/org/zanata/rest/service/ResourceUtils.java
@@ -889,7 +889,7 @@ public class ResourceUtils implements Serializable {
      *
      * @param locale
      */
-    private String getLanguage(final HLocale locale) {
+    String getLanguage(HLocale locale) {
         return StringUtils.replace(locale.getLocaleId().toString(), "-", "_");
     }
 

--- a/server/services/src/main/java/org/zanata/rest/service/ResourceUtils.java
+++ b/server/services/src/main/java/org/zanata/rest/service/ResourceUtils.java
@@ -890,7 +890,7 @@ public class ResourceUtils implements Serializable {
      * @param locale
      */
     private String getLanguage(final HLocale locale) {
-        return locale.getLocaleId().toString();
+        return StringUtils.replace(locale.getLocaleId().toString(), "-", "_");
     }
 
     /**

--- a/server/services/src/test/java/org/zanata/rest/service/ResourceUtilsTest.java
+++ b/server/services/src/test/java/org/zanata/rest/service/ResourceUtilsTest.java
@@ -72,6 +72,14 @@ public class ResourceUtilsTest extends ZanataTest {
     }
 
     @Test
+    public void getLanguage() {
+        HLocale en = new HLocale(LocaleId.EN);
+        assertThat(resourceUtils.getLanguage(en)).isEqualTo("en");
+        HLocale enUS = new HLocale(LocaleId.EN_US);
+        assertThat(resourceUtils.getLanguage(enUS)).isEqualTo("en_US");
+    }
+
+    @Test
     public void mergeNoTextFlows() {
         List<TextFlow> from = new ArrayList<>();
         HDocument to = new HDocument();


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2100

Language field locale in gettext file headers should always be underscore-separated.

## Reviewer tasks

The following is based on the
[Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines).
As a reviewer, you should check the guidelines regularly for updates, and just
to refresh your memory.


The reviewer can use this list for reference to make sure
they have considered all the important points.

Use the checkboxes or not, whatever works best for you.

 - Code quality
   - [ ] Code passes style check (checkstyle/eslint)
   - [ ] Code is clear and concise
   - [ ] UI code is internationalised
   - [ ] Code has adequate comments where appropriate
   - Code is in an appropriate place
     - [ ] Classes are in appropriate packages
     - [ ] Code fits with class's responsibilities (SRP)
   - [ ] Configuration files are documented enough
   - If code is removed
     - [ ] No remaining code references the removed code
       - [ ] No orphaned rewrite rules
       - [ ] No orphaned config settings
     - [ ] No remaining comments refer to the removed code
     - [ ] Unused imports and libraries are removed
 - Testing
   - [ ] New code has tests
   - [ ] Changed code has tests
   - [ ] All tests pass
   - [ ] Test coverage stable or increased
 - Documentation
   - [ ] New features are documented
   - [ ] Docs removed for deleted features
   - [ ] Docs updated for all changed features
   - [ ] Developer/sysadmin docs updated if appropriate
 - If there are new dependencies
   - [ ] Does each new dependency pass all the
         [Considerations for new dependencies](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines#new-technologies-and-dependencies)?


----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/499)
<!-- Reviewable:end -->
