### PR TITLE
fix(Jenkinsfile): RejectedAccessException

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -316,7 +316,7 @@ timestamps {
         sh "git clean -fdx"
       } catch (e) {
         echo("Caught exception: " + e)
-        notify.error(e)
+        notify.error(e.toString())
         currentBuild.result = 'FAILURE'
         // abort the rest of the pipeline
         throw e


### PR DESCRIPTION
Fixes error when build fails:

org.jenkinsci.plugins.scriptsecurity.sandbox.RejectedAccessException: Scripts not permitted to use method groovy.lang.GroovyObject invokeMethod java.lang.String java.lang.Object (org.zanata.jenkins.Notifier error hudson.AbortException)

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/505)
<!-- Reviewable:end -->
