### PR TITLE
fix(ZNTA-1786): just warn if lock files are found on NFS

### DIFF
--- a/server/services/src/main/java/org/zanata/ZanataInit.java
+++ b/server/services/src/main/java/org/zanata/ZanataInit.java
@@ -235,23 +235,22 @@ public class ZanataInit {
                 log.warn("Could not create lucene index directory");
             }
         }
-        // TODO switch between native and simple locks based on this check?
-        if (mightUseNFS(indexDir)) {
+        boolean mightUseNFS = mightUseNFS(indexDir);
+        if (mightUseNFS) {
             // we don't trust Lucene's NativeFSLockFactory for NFS locks
             String docURL =
                     "http://docs.jboss.org/hibernate/search/4.4/reference/en-US/html/search-configuration.html#search-configuration-directory-lockfactories";
             log.info("The Hibernate Search index dir \'{}\' might be NFS. ",
-                    "Using NativeFSLockFactory would not be safe: See {}",
+                    "Native locks may not be reliable. See {}",
                     indexDir, docURL);
-        }
-        Collection<File> lockFiles =
-                FileUtils.listFiles(indexDir, new String[] { "lock" }, true);
-        if (!lockFiles.isEmpty()) {
-            String msg =
-                    "Lucene lock files found. Check if Zanata is already running. Otherwise, Zanata was not shut down cleanly: delete the lock files: "
-                            + lockFiles;
-            // TODO just log a warning if using native locks
-            throw new ZanataInitializationException(msg);
+            Collection<File> lockFiles =
+                    FileUtils.listFiles(indexDir, new String[] { "lock" }, true);
+            if (!lockFiles.isEmpty()) {
+                log.warn("Lucene lock files found. Lucene will attempt to " +
+                        "determine if the locks are stale, but this is not " +
+                        "fully reliable on NFS, so please make sure only one " +
+                        "copy of Zanata is running.");
+            }
         }
     }
 


### PR DESCRIPTION
This avoids the need to manually delete lock files, which is nearly
always too paranoid for a non-clustered application. Until we set up
clustering, it should be safe to delete the lock files, even on NFS, as
long as there are other ways of avoiding multiple instances of Zanata
(eg some sort of native process/service management). But we log a
warning just in case.

https://zanata.atlassian.net/browse/ZNTA-1786

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/513)
<!-- Reviewable:end -->
