### PR TITLE
Move build timings to CSV file

### DIFF
--- a/.mvn/extensions.xml
+++ b/.mvn/extensions.xml
@@ -30,7 +30,7 @@
     <version>0.16.0</version>
   </extension>
   <!-- Enable build profiling.
-       Run mvn with -Dbuildtime.output.log to see timings.
+       Run mvn with -Dbuildtime.output.log to see timings in the Maven log.
        NB: may give odd timings when running multi-threaded
        builds with mvn's -T option, eg smart builder.
   -->

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -186,7 +186,6 @@ timestamps {
 
           // validate translations
           sh """./run-clean.sh ./mvnw -e -V \
-            -Dbuildtime.output.csv -Dbuildtime.output.csv.file=buildtime.csv \
             com.googlecode.l10n-maven-plugin:l10n-maven-plugin:1.8:validate \
             -pl :zanata-war -am -DexcludeFrontend \
           """
@@ -201,7 +200,7 @@ timestamps {
           // -Dmaven.test.failure.ignore: Continue building other modules
           // even after test failures.
           sh """./run-clean.sh ./mvnw -e -V -T 1 \
-            -Dbuildtime.output.log \
+            -Dbuildtime.output.csv -Dbuildtime.output.csv.file=buildtime.csv \
             clean install jxr:aggregate \
             --batch-mode \
             --update-snapshots \
@@ -256,7 +255,7 @@ timestamps {
           // https://philphilphil.wordpress.com/2016/12/28/using-static-code-analysis-tools-with-jenkins-pipeline-jobs/
 
           // archive build artifacts (and cross-referenced source code)
-          archive "**/${jarFiles},**/${warFiles},**/target/site/xref/**,**/target/buildtime.csv"
+          archive "**/${jarFiles},**/${warFiles},**/target/site/xref/**,target/buildtime.csv"
 
           // parse Jacoco test coverage
           step([$class: 'JacocoPublisher'])
@@ -421,7 +420,7 @@ void integrationTests(String appserver) {
 
         def mvnResult = sh returnStatus: true, script: """\
             ./run-clean.sh ./mvnw -e -V -T 1 \
-            -Dbuildtime.output.log \
+            -Dbuildtime.output.csv -Dbuildtime.output.csv.file=buildtime.csv \
             install \
             --batch-mode \
             --update-snapshots \
@@ -438,7 +437,7 @@ void integrationTests(String appserver) {
          */
 
         // retain traceability report and build time info
-        archive(includes: "server/functional-test/target/**/traceability.json,**/target/buildtime.csv")
+        archive(includes: "server/functional-test/target/**/traceability.json,target/buildtime.csv")
 
         if (mvnResult != 0) {
           notify.testResults(appserver, 'UNSTABLE', 'Failed maven build for integration tests')

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -186,7 +186,7 @@ timestamps {
 
           // validate translations
           sh """./run-clean.sh ./mvnw -e -V \
-            -Dbuildtime.output.log \
+            -Dbuildtime.output.csv -Dbuildtime.output.csv.file=buildtime.csv \
             com.googlecode.l10n-maven-plugin:l10n-maven-plugin:1.8:validate \
             -pl :zanata-war -am -DexcludeFrontend \
           """
@@ -256,7 +256,7 @@ timestamps {
           // https://philphilphil.wordpress.com/2016/12/28/using-static-code-analysis-tools-with-jenkins-pipeline-jobs/
 
           // archive build artifacts (and cross-referenced source code)
-          archive "**/${jarFiles},**/${warFiles},**/target/site/xref/**"
+          archive "**/${jarFiles},**/${warFiles},**/target/site/xref/**,**/target/buildtime.csv"
 
           // parse Jacoco test coverage
           step([$class: 'JacocoPublisher'])
@@ -437,8 +437,8 @@ void integrationTests(String appserver) {
         -DskipShade \
          */
 
-        // retain traceability report
-        archive(includes: "server/functional-test/target/**/traceability.json")
+        // retain traceability report and build time info
+        archive(includes: "server/functional-test/target/**/traceability.json,**/target/buildtime.csv")
 
         if (mvnResult != 0) {
           notify.testResults(appserver, 'UNSTABLE', 'Failed maven build for integration tests')


### PR DESCRIPTION
This should help to prevent build timings from pushing important information off the screen when builds fail.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/523)
<!-- Reviewable:end -->
