### PR TITLE
Reduce verbosity at tail of build log

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -177,7 +177,7 @@ timestamps {
           checkout scm
 
           // Clean the workspace
-          sh "git clean -fdx"
+          sh "git clean -dfqx"
         }
 
         // Build and Unit Tests
@@ -314,7 +314,7 @@ timestamps {
                   includes: '**/target/**, **/src/main/resources/**,**/.zanata-cache/**'
         }
         // Reduce workspace size
-        sh "git clean -fdx"
+        sh "git clean -dfqx"
       } catch (e) {
         echo("Caught exception: " + e)
         notify.error(e.toString())
@@ -379,7 +379,7 @@ void integrationTests(String appserver) {
     echo "WORKSPACE=${env.WORKSPACE}"
     checkout scm
     // Clean the workspace
-    sh "git clean -fdx"
+    sh "git clean -dfqx"
 
     unstash 'generated-files'
 
@@ -461,7 +461,7 @@ void integrationTests(String appserver) {
                   testDataPublishers: [[$class: 'StabilityTestDataPublisher']]
           )
           // Reduce workspace size
-          sh "git clean -fdx"
+          sh "git clean -dfqx"
         } else {
           notify.error("No integration test result for $appserver")
           currentBuild.result = 'FAILURE'
@@ -491,9 +491,10 @@ void withPorts(Closure wrapped) {
 // from https://issues.jenkins-ci.org/browse/JENKINS-27395?focusedCommentId=256459&page=com.atlassian.jira.plugin.system.issuetabpanels:comment-tabpanel#comment-256459
 boolean setJUnitPrefix(prefix, files) {
   // add prefix to qualified classname
-  def reportFiles = findFiles glob: "**/${files}"
+  def fileGlob = "**/${files}"
+  def reportFiles = findFiles glob: fileGlob
   if (reportFiles.size() > 0) {
-    sh "sed -i \"s/\\(<testcase .*classname=['\\\"]\\)\\([a-z]\\)/\\1${prefix.toUpperCase()}.\\2/g\" ${reportFiles.join(" ")}"
+    sh "set +x; echo 'Using sed to edit classnames in ${fileGlob}'; sed -i \"s/\\(<testcase .*classname=['\\\"]\\)\\([a-z]\\)/\\1${prefix.toUpperCase()}.\\2/g\" ${reportFiles.join(" ")}"
     return true
   } else {
     echo "[WARNING] Failed to find JUnit report files **/${files}"


### PR DESCRIPTION
This should make it easier to find the cause if build fails.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/532)
<!-- Reviewable:end -->
