### PR TITLE
fix(ZNTA-1668): Allow translator to see untranslated glossary entries

### DIFF
--- a/server/gwt-editor/src/main/java/org/zanata/webtrans/client/presenter/GlossaryDetailsPresenter.java
+++ b/server/gwt-editor/src/main/java/org/zanata/webtrans/client/presenter/GlossaryDetailsPresenter.java
@@ -82,7 +82,9 @@ public class GlossaryDetailsPresenter extends
         display.setDescription(selectedDetailEntry.getDescription());
         display.setPos(selectedDetailEntry.getPos());
         display.setTargetComment(selectedDetailEntry.getTargetComment());
-        display.setLastModifiedDate(selectedDetailEntry.getLastModifiedDate());
+        if (selectedDetailEntry.getLastModifiedDate() != null) {
+            display.setLastModifiedDate(selectedDetailEntry.getLastModifiedDate());
+        }
         display.setUrl(selectedDetailEntry.getUrl());
     }
 

--- a/server/gwt-editor/src/main/java/org/zanata/webtrans/client/resources/UiMessages.java
+++ b/server/gwt-editor/src/main/java/org/zanata/webtrans/client/resources/UiMessages.java
@@ -58,7 +58,7 @@ public interface UiMessages extends Messages {
     @DefaultMessage("Source Term")
     String srcTermLabel();
 
-    @DefaultMessage("Target Term")
+    @DefaultMessage("Translation")
     String targetTermLabel();
 
     @DefaultMessage("Project glossary")
@@ -82,8 +82,11 @@ public interface UiMessages extends Messages {
     @DefaultMessage("Source Term [{0}]:")
     String glossarySourceTermLabel(String locale);
 
-    @DefaultMessage("Target Term [{0}]:")
+    @DefaultMessage("Translation [{0}]:")
     String glossaryTargetTermLabel(String locale);
+
+    @DefaultMessage("-none-")
+    String noGlossaryTranslationLabel();
 
     @DefaultMessage("Send")
     String sendLabel();

--- a/server/gwt-editor/src/main/java/org/zanata/webtrans/client/view/GlossaryView.java
+++ b/server/gwt-editor/src/main/java/org/zanata/webtrans/client/view/GlossaryView.java
@@ -196,12 +196,21 @@ public class GlossaryView extends Composite implements GlossaryDisplay {
 
             resultTable.setWidget(i + 1, SOURCE_COL,
                     new HighlightingLabel(item.getSource()));
-            resultTable.setWidget(i + 1, TARGET_COL,
-                    new HighlightingLabel(item.getTarget()));
+
+            HighlightingLabel targetLabel = new HighlightingLabel();
+            boolean targetEmpty = item.getTarget().isEmpty();
+            if (targetEmpty) {
+                targetLabel.setText(messages.noGlossaryTranslationLabel());
+                targetLabel.setStyleName("u-textItalic");
+            } else {
+                 targetLabel.setText(item.getTarget());
+            }
+            resultTable.setWidget(i + 1, TARGET_COL, targetLabel);
 
             Button copyButton = new Button(messages.copy());
             copyButton.setTitle(messages.copyTooltip());
             copyButton.addStyleName("button--small");
+            copyButton.setEnabled(!targetEmpty);
             copyButton.addClickHandler(new ClickHandler() {
                 @Override
                 public void onClick(ClickEvent event) {

--- a/server/services/src/main/java/org/zanata/service/impl/GlossarySearchServiceImpl.java
+++ b/server/services/src/main/java/org/zanata/service/impl/GlossarySearchServiceImpl.java
@@ -157,12 +157,12 @@ public class GlossarySearchServiceImpl implements GlossarySearchService {
                                String qualifiedName) {
         for (Object[] match : matches) {
             HGlossaryTerm sourceTerm = (HGlossaryTerm) match[1];
-            HGlossaryTerm targetTerm = null;
-            if (sourceTerm != null) {
-                targetTerm = glossaryDAO.getTermByEntryAndLocale(
-                        sourceTerm.getGlossaryEntry().getId(), localeId,
-                        qualifiedName);
+            if (sourceTerm == null) {
+                continue;
             }
+            HGlossaryTerm targetTerm = glossaryDAO.getTermByEntryAndLocale(
+                    sourceTerm.getGlossaryEntry().getId(), localeId,
+                    qualifiedName);
             String srcTermContent = sourceTerm.getContent();
             String targetTermContent = targetTerm == null ? "" : targetTerm.getContent();
             GlossaryResultItem item = getOrCreateGlossaryResultItem(matchesMap,

--- a/server/services/src/main/java/org/zanata/service/impl/GlossarySearchServiceImpl.java
+++ b/server/services/src/main/java/org/zanata/service/impl/GlossarySearchServiceImpl.java
@@ -163,11 +163,8 @@ public class GlossarySearchServiceImpl implements GlossarySearchService {
                         sourceTerm.getGlossaryEntry().getId(), localeId,
                         qualifiedName);
             }
-            if (targetTerm == null) {
-                continue;
-            }
             String srcTermContent = sourceTerm.getContent();
-            String targetTermContent = targetTerm.getContent();
+            String targetTermContent = targetTerm == null ? "" : targetTerm.getContent();
             GlossaryResultItem item = getOrCreateGlossaryResultItem(matchesMap,
                     qualifiedName, srcTermContent, targetTermContent,
                     (Float) match[0], searchText);
@@ -233,12 +230,16 @@ public class GlossarySearchServiceImpl implements GlossarySearchService {
             String qualifiedName = entry.getGlossary().getQualifiedName();
             String url = glossaryUrl(qualifiedName, srcContent,
                     hLocale.getLocaleId());
+            boolean isTargetNull = hGlossaryTerm == null;
             items.add(new GlossaryDetails(entry.getId(), srcContent,
-                    hGlossaryTerm.getContent(), entry.getDescription(),
-                    entry.getPos(), hGlossaryTerm.getComment(),
+                    isTargetNull ? null : hGlossaryTerm.getContent(),
+                    entry.getDescription(),
+                    entry.getPos(),
+                    isTargetNull ? null : hGlossaryTerm.getComment(),
                     entry.getSourceRef(), entry.getSrcLocale().getLocaleId(),
-                    hLocale.getLocaleId(), url, hGlossaryTerm.getVersionNum(),
-                    hGlossaryTerm.getLastChanged()));
+                    hLocale.getLocaleId(), url,
+                    isTargetNull ? null : hGlossaryTerm.getVersionNum(),
+                    isTargetNull ? null : hGlossaryTerm.getLastChanged()));
         }
         return items;
     }

--- a/server/zanata-frontend/src/frontend/.storybook-editor/__snapshots__/storyshots-editor.test.js.snap
+++ b/server/zanata-frontend/src/frontend/.storybook-editor/__snapshots__/storyshots-editor.test.js.snap
@@ -5644,16 +5644,18 @@ exports[`Editor Storyshots GlossaryTerm Without translations 1`] = `
           onMouseOver={[Function]}
           type="button"
         >
-          <span>
+          <span
+            className="u-textMuted"
+          >
             <span
               className="hide-mdplus u-textMeta"
             >
-              Target
+              Translation
             </span>
             <span
               className={undefined}
             >
-              
+              -none-
             </span>
           </span>
         </button>
@@ -5743,16 +5745,18 @@ exports[`Editor Storyshots GlossaryTerm Without translations 1`] = `
           onMouseOver={[Function]}
           type="button"
         >
-          <span>
+          <span
+            className="u-textMuted"
+          >
             <span
               className="hide-mdplus u-textMeta"
             >
-              Target
+              Translation
             </span>
             <span
               className={undefined}
             >
-              
+              -none-
             </span>
           </span>
         </button>
@@ -5842,16 +5846,18 @@ exports[`Editor Storyshots GlossaryTerm Without translations 1`] = `
           onMouseOver={[Function]}
           type="button"
         >
-          <span>
+          <span
+            className="u-textMuted"
+          >
             <span
               className="hide-mdplus u-textMeta"
             >
-              Target
+              Translation
             </span>
             <span
               className={undefined}
             >
-              
+              -none-
             </span>
           </span>
         </button>
@@ -5966,11 +5972,13 @@ exports[`Editor Storyshots GlossaryTerm in a table 1`] = `
           onMouseOver={[Function]}
           type="button"
         >
-          <span>
+          <span
+            className=""
+          >
             <span
               className="hide-mdplus u-textMeta"
             >
-              Target
+              Translation
             </span>
             <span
               className={undefined}
@@ -6065,11 +6073,13 @@ exports[`Editor Storyshots GlossaryTerm in a table 1`] = `
           onMouseOver={[Function]}
           type="button"
         >
-          <span>
+          <span
+            className=""
+          >
             <span
               className="hide-mdplus u-textMeta"
             >
-              Target
+              Translation
             </span>
             <span
               className={undefined}
@@ -6164,11 +6174,13 @@ exports[`Editor Storyshots GlossaryTerm in a table 1`] = `
           onMouseOver={[Function]}
           type="button"
         >
-          <span>
+          <span
+            className=""
+          >
             <span
               className="hide-mdplus u-textMeta"
             >
-              Target
+              Translation
             </span>
             <span
               className={undefined}
@@ -6272,11 +6284,13 @@ exports[`Editor Storyshots GlossaryTerm simple term on its own 1`] = `
           onMouseOver={[Function]}
           type="button"
         >
-          <span>
+          <span
+            className=""
+          >
             <span
               className="hide-mdplus u-textMeta"
             >
-              Target
+              Translation
             </span>
             <span
               className={undefined}

--- a/server/zanata-frontend/src/frontend/.storybook-editor/__snapshots__/storyshots-editor.test.js.snap
+++ b/server/zanata-frontend/src/frontend/.storybook-editor/__snapshots__/storyshots-editor.test.js.snap
@@ -5590,7 +5590,7 @@ exports[`Editor Storyshots GlossaryTerm Without translations 1`] = `
         Source
       </th>
       <th>
-        Target
+        Translation
       </th>
       <th />
       <th
@@ -5912,7 +5912,7 @@ exports[`Editor Storyshots GlossaryTerm in a table 1`] = `
         Source
       </th>
       <th>
-        Target
+        Translation
       </th>
       <th />
       <th

--- a/server/zanata-frontend/src/frontend/app/editor/components/GlossaryTerm/GlossaryTerm.story.js
+++ b/server/zanata-frontend/src/frontend/app/editor/components/GlossaryTerm/GlossaryTerm.story.js
@@ -28,7 +28,7 @@ storiesOf('GlossaryTerm', module)
       <thead>
         <tr>
           <th>Source</th>
-          <th>Target</th>
+          <th>Translation</th>
           <th></th>
           <th className="align-right hide-md">Details</th>
         </tr>
@@ -63,7 +63,7 @@ storiesOf('GlossaryTerm', module)
       <thead>
         <tr>
           <th>Source</th>
-          <th>Target</th>
+          <th>Translation</th>
           <th></th>
           <th className="align-right hide-md">Details</th>
         </tr>

--- a/server/zanata-frontend/src/frontend/app/editor/components/GlossaryTerm/index.js
+++ b/server/zanata-frontend/src/frontend/app/editor/components/GlossaryTerm/index.js
@@ -7,6 +7,7 @@ import PropTypes from 'prop-types'
 import { Button, Tooltip, OverlayTrigger } from 'react-bootstrap'
 import IconButton from '../IconButton'
 import { isEmpty } from 'lodash'
+import cx from 'classnames'
 
 class GlossaryTerm extends React.Component {
   static propTypes = {
@@ -59,11 +60,14 @@ class GlossaryTerm extends React.Component {
         <td data-filetype="text" className="GlossaryText StringLong">
           <OverlayTrigger placement="top" overlay={targetTip}>
             <Button bsStyle="link">
-              <span>
+              <span className={
+                cx({'u-textMuted': isEmpty(term.target)})}>
                 <span className="hide-mdplus u-textMeta">
-                  Target
+                  Translation
                 </span>
-                <span className={directionClassTarget}>{term.target}</span>
+                <span className={directionClassTarget}>
+                  {isEmpty(term.target) ? '-none-' : term.target}
+                </span>
               </span>
             </Button>
           </OverlayTrigger>

--- a/server/zanata-frontend/src/frontend/app/editor/components/GlossaryTermModal/component.js
+++ b/server/zanata-frontend/src/frontend/app/editor/components/GlossaryTermModal/component.js
@@ -48,9 +48,18 @@ class GlossaryTermModal extends React.Component {
     const selectedDetail = 0
     const detail = details[selectedDetail]
 
-    const lastModifiedTime = detail
-      ? new Date(detail.lastModifiedDate) : new Date()
+    const lastModifiedTime = detail && detail.lastModifiedDate
+      ? new Date(detail.lastModifiedDate) : undefined
 
+    const lastModifiedRow = lastModifiedTime ? (<Row>
+      <Icon name="history" className="s0 history-icon" />
+      <span className="u-sML-1-4">
+      Last modified on&nbsp;
+        <FormattedDate value={lastModifiedTime} format="medium" />&nbsp;
+        <Icon name="clock" className="s0 history-icon" />&nbsp;
+        <FormattedTime value={lastModifiedTime} />
+      </span>
+    </Row>) : undefined
     const detailsDisplay = details.map(
       (detail, index) => {
         if (!detail) {
@@ -113,15 +122,7 @@ class GlossaryTermModal extends React.Component {
           </Panel>
 
           <span className="u-pullRight u-textMeta">
-            <Row>
-              <Icon name="history" className="s0 history-icon" />
-              <span className="u-sML-1-4">
-                Last modified on&nbsp;
-                <FormattedDate value={lastModifiedTime} format="medium" />&nbsp;
-                <Icon name="clock" className="s0 history-icon" />&nbsp;
-                <FormattedTime value={lastModifiedTime} />
-              </span>
-            </Row>
+          {lastModifiedRow}
           </span>
         </Modal.Body>
       </Modal>

--- a/server/zanata-frontend/src/frontend/app/editor/components/GlossaryTermModal/component.js
+++ b/server/zanata-frontend/src/frontend/app/editor/components/GlossaryTermModal/component.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types'
 import { Panel, Row, Table } from 'react-bootstrap'
 import { FormattedDate, FormattedTime } from 'react-intl'
 import { Icon, LoaderText, Modal } from '../../../components'
+import { isEmpty } from 'lodash'
+import cx from 'classnames'
 
 /**
  * Modal to show detail for a single glossary term
@@ -88,8 +90,11 @@ class GlossaryTermModal extends React.Component {
             <span className="modal-term">{term.source}</span>
           </Panel>
           <Panel className={directionClassTarget + ' split-panel'}>
-            <h3>Target Term : {targetLocale}</h3>
-            <span className="modal-term">{term.target}</span>
+            <h3>Translation : {targetLocale}</h3>
+            <span className={
+              cx('modal-term', {'u-textMuted': isEmpty(term.target)})}>
+                {isEmpty(term.target) ? '-none-' : term.target}
+            </span>
           </Panel>
           <br />
           <Panel className="gloss-details-panel">

--- a/server/zanata-frontend/src/frontend/app/editor/containers/GlossaryTab.js
+++ b/server/zanata-frontend/src/frontend/app/editor/containers/GlossaryTab.js
@@ -93,7 +93,7 @@ class GlossaryTab extends React.Component {
         <thead className="hide-small">
           <tr>
             <th>Source</th>
-            <th>Target</th>
+            <th>Translation</th>
             <th></th>
             <th></th>
           </tr>


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-1668

Glossary entries have value, even if they are not translated. Show all
matching entries with translations if available.

Tester notes:
- Entries in system and project glossary that match the source, or search term, will show
- Entries that have a translation for the current language will show it
- Entries that do not have a translation for the current language show `-none-` in lighter text and a disabled copy button
- Source / Target in glossary search now shows Source / Translation

## Reviewer tasks

The following is based on the
[Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines).
As a reviewer, you should check the guidelines regularly for updates, and just
to refresh your memory.


The reviewer can use this list for reference to make sure
they have considered all the important points.

Use the checkboxes or not, whatever works best for you.

 - Code quality
   - [ ] Code passes style check (checkstyle/eslint)
   - [ ] Code is clear and concise
   - [ ] UI code is internationalised
   - [ ] Code has adequate comments where appropriate
   - Code is in an appropriate place
     - [ ] Classes are in appropriate packages
     - [ ] Code fits with class's responsibilities (SRP)
   - [ ] Configuration files are documented enough
   - If code is removed
     - [ ] No remaining code references the removed code
       - [ ] No orphaned rewrite rules
       - [ ] No orphaned config settings
     - [ ] No remaining comments refer to the removed code
     - [ ] Unused imports and libraries are removed
 - Testing
   - [ ] New code has tests
   - [ ] Changed code has tests
   - [ ] All tests pass
   - [ ] Test coverage stable or increased
 - Documentation
   - [ ] New features are documented
   - [ ] Docs removed for deleted features
   - [ ] Docs updated for all changed features
   - [ ] Developer/sysadmin docs updated if appropriate
 - If there are new dependencies
   - [ ] Does each new dependency pass all the
         [Considerations for new dependencies](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines#new-technologies-and-dependencies)?


----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/541)
<!-- Reviewable:end -->
