### PR TITLE
fix(ZNTA-2240) editor sidebar now works as expected

### DIFF
--- a/server/zanata-frontend/src/frontend/app/editor/containers/Sidebar/index.css
+++ b/server/zanata-frontend/src/frontend/app/editor/containers/Sidebar/index.css
@@ -23,7 +23,7 @@
   --Editor-color-rejected: #FFA800;
 }
 
-.SidebarEditor {
+.sidebar-editor {
   border-left: solid 1px var(--Sidebar-border);
   float: right !important;
   height: 99.5% !important;
@@ -34,11 +34,11 @@
   width: 35%;
 }
 
-.SidebarEditor :focus {
+.sidebar-editor :focus {
   outline: 0;
 }
 
-.SidebarEditor .nav-tabs li {
+.sidebar-editor .nav-tabs li {
   width: 50%;
 }
 
@@ -379,7 +379,7 @@ span.loader span div {
   vertical-align: sub;
 }
 
-.SidebarEditor select {
+.sidebar-editor select {
   color: var(--Sidebar-color-text);
 }
 

--- a/server/zanata-frontend/src/frontend/app/editor/containers/Sidebar/index.js
+++ b/server/zanata-frontend/src/frontend/app/editor/containers/Sidebar/index.js
@@ -66,7 +66,7 @@ class Sidebar extends Component {
             overflowY: 'auto'
           }
         }}
-        sidebarClassName="SidebarEditor">
+        sidebarClassName="sidebar-editor">
         {this.props.children}
       </ReactSidebar>
     )


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2240

Changed the css classname of SidebarEditor to 'sidebar-editor' so that the react sidebar component works correctly. I have tested this and it resolves the bug in master

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/584)
<!-- Reviewable:end -->
