### PR TITLE
fix(ZNTA-2241) change css classnames for dropdown buttons 

### DIFF
--- a/server/zanata-frontend/src/frontend/app/editor/components/Button/index.css
+++ b/server/zanata-frontend/src/frontend/app/editor/components/Button/index.css
@@ -33,6 +33,8 @@ not conflict with the other frontend code
   transition: var(--Button-transition);
   min-height: calc(var(--Button-rhythm) * 1.25);
   text-shadow: 1px 1px 0 rgba(0,0,0,0.15);
+  padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 .EditorButton:disabled,

--- a/server/zanata-frontend/src/frontend/app/editor/components/SplitDropdown/index.css
+++ b/server/zanata-frontend/src/frontend/app/editor/components/SplitDropdown/index.css
@@ -24,6 +24,7 @@ not conflict with the other frontend code
   border-top-left-radius: 100px;
   border-bottom-left-radius: 100px;
   padding-left: 1rem;
+  padding-right: 1rem;
 }
 
 .ButtonGroup--round .ButtonGroup-item:last-child .EditorButton {

--- a/server/zanata-frontend/src/frontend/app/editor/components/SplitDropdown/index.css
+++ b/server/zanata-frontend/src/frontend/app/editor/components/SplitDropdown/index.css
@@ -23,9 +23,18 @@ not conflict with the other frontend code
 .ButtonGroup--round .ButtonGroup-item:first-child .EditorButton {
   border-top-left-radius: 100px;
   border-bottom-left-radius: 100px;
+  padding-left: 1rem;
 }
 
 .ButtonGroup--round .ButtonGroup-item:last-child .EditorButton {
   border-top-right-radius: 100px;
   border-bottom-right-radius: 100px;
+}
+
+ul.EditorDropdown-content li button.EditorButton {
+  padding-left: 1rem;
+}
+
+.ButtonGroup--borderCollapse.ButtonGroup--hz > .ButtonGroup-item {
+  margin-right: 0;
 }

--- a/server/zanata-frontend/src/frontend/app/editor/components/SplitDropdown/index.js
+++ b/server/zanata-frontend/src/frontend/app/editor/components/SplitDropdown/index.js
@@ -23,7 +23,7 @@ class SplitDropdown extends React.Component {
   }
 
   render () {
-    const className = cx('Dropdown', this.props.className, {
+    const className = cx('EditorDropdown', this.props.className, {
       'is-active': this.props.isOpen
     })
 
@@ -36,7 +36,7 @@ class SplitDropdown extends React.Component {
       toggleButtonItem = (
         <div className="ButtonGroup-item">
           <div ref="button"
-            className="Dropdown-toggle"
+            className="EditorDropdown-toggle"
             aria-haspopup
             aria-expanded={this.props.isOpen}
             {...buttonClick}>

--- a/server/zanata-frontend/src/frontend/app/editor/components/SuggestionTranslationDetails.js
+++ b/server/zanata-frontend/src/frontend/app/editor/components/SuggestionTranslationDetails.js
@@ -57,7 +57,7 @@ class SuggestionTranslationDetails extends React.Component {
         </div>
         <div className="u-floatRight u-sm-floatNone">
           <ul className="u-listInline u-sizeLineHeight-1">
-            <li>
+            <li className="u-floatRight">
               <SuggestionMatchPercent
                 matchType={matchType}
                 percent={similarityPercent} />
@@ -65,7 +65,7 @@ class SuggestionTranslationDetails extends React.Component {
             <li>
               <Button
                 className="EditorButton Button--small u-rounded Button--primary
-                           u-sizeWidth-6"
+                           u-sizeWidth-4"
                 disabled={copying}
                 onClick={copySuggestion}
                 title={label}>

--- a/server/zanata-frontend/src/frontend/app/editor/components/TransUnitTranslationFooter.js
+++ b/server/zanata-frontend/src/frontend/app/editor/components/TransUnitTranslationFooter.js
@@ -83,7 +83,7 @@ class TransUnitTranslationFooter extends React.Component {
 
   saveButtonElement = (status) => {
     const { phrase, saveAsMode, savePhraseWithStatus } = this.props
-    const className = cx('Button u-sizeHeight-1_1-4',
+    const className = cx('EditorButton u-sizeHeight-1_1-4',
                          'u-sizeFull u-textLeft',
                          buttonClassByStatus[status])
 
@@ -179,7 +179,7 @@ class TransUnitTranslationFooter extends React.Component {
       saveAsMode && statusShortcutKeys[selectedButtonStatus]
     const actionButton = (
       <Button
-        className={cx('Button u-sizeHeight-1_1-4 u-textCapitalize',
+        className={cx('EditorButton u-sizeHeight-1_1-4 u-textCapitalize',
                       buttonClassByStatus[selectedButtonStatus])}
         disabled={isSaving || !translationHasChanged}
         title={selectedButtonTitle}
@@ -199,8 +199,8 @@ class TransUnitTranslationFooter extends React.Component {
 
     const dropdownToggleButton = otherStatuses.length > 0
       ? <Button
-        className={cx('Button Button--snug u-sizeHeight-1_1-4',
-                      'Dropdown-toggle',
+        className={cx('EditorButton Button--snug u-sizeHeight-1_1-4',
+                      'EditorDropdown-toggle',
                       buttonClassByStatus[selectedButtonStatus])}
         title="Save as…">
         <div className="Dropdown-toggleIcon">
@@ -210,7 +210,7 @@ class TransUnitTranslationFooter extends React.Component {
       : undefined
 
     const otherActionButtonList = (
-      <ul className="EditorDropdown-content Dropdown-content--bordered
+      <ul className="EditorDropdown-content EditorDropdown-content--bordered
                      u-rounded">
         {otherActionButtons}
       </ul>


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2241

fix(ZNTA-2241) change css classnames for dropdown buttons in editor which were broken in refactor of editor css

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/588)
<!-- Reviewable:end -->
