### PR TITLE
fix(ZNTA-2219: glossary count in editor now uses badge styling

### DIFF
--- a/server/zanata-frontend/src/frontend/.storybook-editor/__snapshots__/storyshots-editor.test.js.snap
+++ b/server/zanata-frontend/src/frontend/.storybook-editor/__snapshots__/storyshots-editor.test.js.snap
@@ -5603,7 +5603,7 @@ exports[`Editor Storyshots GlossaryTerm Without translations 1`] = `
   <tbody>
     <tr>
       <td
-        className="GlossaryText long-string"
+        className="GlossaryText StringLong"
         data-filetype="text"
       >
         <button
@@ -5627,7 +5627,7 @@ exports[`Editor Storyshots GlossaryTerm Without translations 1`] = `
         </button>
       </td>
       <td
-        className="GlossaryText long-string"
+        className="GlossaryText StringLong"
         data-filetype="text"
       >
         <button
@@ -5694,7 +5694,7 @@ exports[`Editor Storyshots GlossaryTerm Without translations 1`] = `
     </tr>
     <tr>
       <td
-        className="GlossaryText long-string"
+        className="GlossaryText StringLong"
         data-filetype="text"
       >
         <button
@@ -5718,7 +5718,7 @@ exports[`Editor Storyshots GlossaryTerm Without translations 1`] = `
         </button>
       </td>
       <td
-        className="GlossaryText long-string"
+        className="GlossaryText StringLong"
         data-filetype="text"
       >
         <button
@@ -5785,7 +5785,7 @@ exports[`Editor Storyshots GlossaryTerm Without translations 1`] = `
     </tr>
     <tr>
       <td
-        className="GlossaryText long-string"
+        className="GlossaryText StringLong"
         data-filetype="text"
       >
         <button
@@ -5809,7 +5809,7 @@ exports[`Editor Storyshots GlossaryTerm Without translations 1`] = `
         </button>
       </td>
       <td
-        className="GlossaryText long-string"
+        className="GlossaryText StringLong"
         data-filetype="text"
       >
         <button
@@ -5901,7 +5901,7 @@ exports[`Editor Storyshots GlossaryTerm in a table 1`] = `
   <tbody>
     <tr>
       <td
-        className="GlossaryText long-string"
+        className="GlossaryText StringLong"
         data-filetype="text"
       >
         <button
@@ -5925,7 +5925,7 @@ exports[`Editor Storyshots GlossaryTerm in a table 1`] = `
         </button>
       </td>
       <td
-        className="GlossaryText long-string"
+        className="GlossaryText StringLong"
         data-filetype="text"
       >
         <button
@@ -5992,7 +5992,7 @@ exports[`Editor Storyshots GlossaryTerm in a table 1`] = `
     </tr>
     <tr>
       <td
-        className="GlossaryText long-string"
+        className="GlossaryText StringLong"
         data-filetype="text"
       >
         <button
@@ -6016,7 +6016,7 @@ exports[`Editor Storyshots GlossaryTerm in a table 1`] = `
         </button>
       </td>
       <td
-        className="GlossaryText long-string"
+        className="GlossaryText StringLong"
         data-filetype="text"
       >
         <button
@@ -6083,7 +6083,7 @@ exports[`Editor Storyshots GlossaryTerm in a table 1`] = `
     </tr>
     <tr>
       <td
-        className="GlossaryText long-string"
+        className="GlossaryText StringLong"
         data-filetype="text"
       >
         <button
@@ -6107,7 +6107,7 @@ exports[`Editor Storyshots GlossaryTerm in a table 1`] = `
         </button>
       </td>
       <td
-        className="GlossaryText long-string"
+        className="GlossaryText StringLong"
         data-filetype="text"
       >
         <button
@@ -6183,7 +6183,7 @@ exports[`Editor Storyshots GlossaryTerm simple term on its own 1`] = `
   <tbody>
     <tr>
       <td
-        className="GlossaryText long-string"
+        className="GlossaryText StringLong"
         data-filetype="text"
       >
         <button
@@ -6207,7 +6207,7 @@ exports[`Editor Storyshots GlossaryTerm simple term on its own 1`] = `
         </button>
       </td>
       <td
-        className="GlossaryText long-string"
+        className="GlossaryText StringLong"
         data-filetype="text"
       >
         <button

--- a/server/zanata-frontend/src/frontend/app/editor/components/GlossaryTerm/index.js
+++ b/server/zanata-frontend/src/frontend/app/editor/components/GlossaryTerm/index.js
@@ -42,7 +42,7 @@ class GlossaryTerm extends React.Component {
 
     return (
       <tr key={index}>
-        <td data-filetype="text" className="GlossaryText long-string">
+        <td data-filetype="text" className="GlossaryText StringLong">
           <OverlayTrigger placement="top" overlay={sourceTip}>
             <Button bsStyle="link">
               <span>
@@ -54,7 +54,7 @@ class GlossaryTerm extends React.Component {
             </Button>
           </OverlayTrigger>
         </td>
-        <td data-filetype="text" className="GlossaryText long-string">
+        <td data-filetype="text" className="GlossaryText StringLong">
           <OverlayTrigger placement="top" overlay={targetTip}>
             <Button bsStyle="link">
               <span>

--- a/server/zanata-frontend/src/frontend/app/editor/containers/ActivityTab.js
+++ b/server/zanata-frontend/src/frontend/app/editor/containers/ActivityTab.js
@@ -45,7 +45,7 @@ class ActivityTab extends React.Component {
 
     return (
       <Tab eventKey={eventKey} title="">
-        <div className="SidebarEditor-wrapper" id="tab2">
+        <div className="SidebarEditor-wrapper" id="SidebarEditorTabs-pane2">
           <ActivitySelectList selectItem={selectActivityTypeFilter}
             selected={selectedActivites} />
         </div>

--- a/server/zanata-frontend/src/frontend/app/editor/containers/Root/index.css
+++ b/server/zanata-frontend/src/frontend/app/editor/containers/Root/index.css
@@ -13,6 +13,24 @@
   --Editor-color-light: #90b8c5;
   --Editor-color-dark: #20718a;
   --Editor-color-bright: #1ba7d9;
+  --Editor-badge-radius: 4px;
+}
+
+.sidebar-editor .badge {
+  font-size: 0.875rem;
+  display: inline-block;
+  min-width: 1rem;
+  text-align: center;
+  vertical-align: middle;
+  white-space: nowrap;
+  color: #fff;
+  margin-left: 0.375rem;
+  border-radius: var(--Editor-badge-radius);
+  background-color: var(--Editor-color-dark);
+}
+
+.gloss-tab-svg {
+  vertical-align: sub;
 }
 
 /* need to keep syntax for logoLoader so this overrides correctly */

--- a/server/zanata-frontend/src/frontend/app/editor/containers/Sidebar/index.css
+++ b/server/zanata-frontend/src/frontend/app/editor/containers/Sidebar/index.css
@@ -65,8 +65,8 @@ ul.SidebarEditor-details {
   word-wrap: break-word;
 }
 
-#SidebarEditor-tabsPane1-pane-1 table {
-  padding-bottom: 1rem;
+#SidebarEditor-tabsPane1-pane-1 {
+  padding-bottom: 1.5rem;
 }
 
 #SidebarEditor-tabsPane1.tab-pane.active {

--- a/server/zanata-frontend/src/frontend/app/editor/containers/Sidebar/index.css
+++ b/server/zanata-frontend/src/frontend/app/editor/containers/Sidebar/index.css
@@ -65,6 +65,10 @@ ul.SidebarEditor-details {
   word-wrap: break-word;
 }
 
+#SidebarEditor-tabsPane1-pane-1 table {
+  padding-bottom: 1rem;
+}
+
 #SidebarEditor-tabsPane1.tab-pane.active {
   height: inherit;
 }

--- a/server/zanata-frontend/src/frontend/app/editor/containers/TranslationInfoPanel/index.js
+++ b/server/zanata-frontend/src/frontend/app/editor/containers/TranslationInfoPanel/index.js
@@ -113,7 +113,7 @@ class TranslationInfoPanel extends React.Component {
     const glossaryTitle = (
       <span>
         <Icon name="glossary" className="s1 gloss-tab-svg" />
-        <span className="hide-md">Glossary{glossaryCountDisplay}</span>
+        <span className="hide-md">Glossary</span>{glossaryCountDisplay}
       </span>
     )
 

--- a/server/zanata-frontend/src/frontend/app/editor/containers/TranslationInfoPanel/index.js
+++ b/server/zanata-frontend/src/frontend/app/editor/containers/TranslationInfoPanel/index.js
@@ -108,7 +108,7 @@ class TranslationInfoPanel extends React.Component {
     const { glossaryCount } = this.props
     const glossaryCountDisplay = glossaryCount > 0
       // TODO kgough display as a badge instead of text in parens
-      ? <span>({this.props.glossaryCount})</span>
+      ? <span className="badge">{this.props.glossaryCount}</span>
       : undefined
     const glossaryTitle = (
       <span>
@@ -139,7 +139,7 @@ class TranslationInfoPanel extends React.Component {
         <div className="SidebarEditor-wrapper">
           {this.sidebarDetails()}
         </div>
-        <Tabs id="sidebartabs" defaultActiveKey={1}>
+        <Tabs id="SidebarEditor-tabsPane1" defaultActiveKey={1}>
           { /* <Tab eventKey={2} title={activityTitle}>
             <div className="sidebar-wrapper" id="tab1">
               Tab 1 content


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2219

Alongside changing to a badge (which required adding badge css to the editor css files), padding has been added to the bottom of the glossary table to improve spacing + minor tweaks to improve mobile view (show count).
 
![g1](https://user-images.githubusercontent.com/18179401/31921710-2c9298d4-b8b4-11e7-9d20-a04d9c758bd2.png)

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/594)
<!-- Reviewable:end -->

