### PR TITLE
ZNTA-2227 auto merge saml user to existing account

### DIFF
--- a/server/docker/conf/zanata-config.cli
+++ b/server/docker/conf/zanata-config.cli
@@ -12,6 +12,7 @@ batch
 /system-property="zanata.home":add(value="${user.home}/zanata")
 /system-property="javamelody.storage-directory":add(value="${zanata.home}/stats")
 /system-property="hibernate.search.default.indexBase":add(value="${zanata.home}/indexes")
+/system-property="zanata.file.directory":add(value="${zanata.home}/files")
 /system-property="jboss.as.management.blocking.timeout":add(value="1000")
 /system-property="zanata.security.authpolicy.internal":add(value="zanata.internal")
 /system-property="zanata.security.authpolicy.openid":add(value="zanata.openid")

--- a/server/services/src/main/java/org/zanata/security/AuthenticationManager.java
+++ b/server/services/src/main/java/org/zanata/security/AuthenticationManager.java
@@ -359,6 +359,9 @@ public class AuthenticationManager implements Serializable {
             return credentialsDAO.findByUser(
                     zanataOpenId.getAuthResult().getAuthenticatedId()) == null;
         }
+        if (credentials.getAuthType() == SAML2 && saml2Enabled) {
+            return credentialsDAO.findByUser(samlIdentity.getUniqueName()) == null;
+        }
         return isNewUser(credentials.getUsername());
     }
 

--- a/server/services/src/main/java/org/zanata/security/SamlAccountService.kt
+++ b/server/services/src/main/java/org/zanata/security/SamlAccountService.kt
@@ -1,0 +1,65 @@
+/*
+ * Copyright 2017, Red Hat, Inc. and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.zanata.security
+
+import org.apache.deltaspike.jpa.api.transaction.Transactional
+import org.slf4j.Logger
+import org.slf4j.LoggerFactory
+import org.zanata.dao.AccountDAO
+import org.zanata.dao.CredentialsDAO
+import org.zanata.model.HAccount
+import org.zanata.model.security.HSaml2Credentials
+import org.zanata.security.annotations.SAML
+import org.zanata.security.annotations.SAMLAttribute
+import org.zanata.security.annotations.SAMLAttribute.AttributeName.EMAIL
+import java.security.Principal
+import javax.enterprise.context.RequestScoped
+import javax.inject.Inject
+
+/**
+ * Merge saml credentials to existing account if email matches.
+ */
+@RequestScoped
+class SamlAccountService @Inject constructor(
+        @SAMLAttribute(EMAIL) private val email: String,
+        @SAML private val principal: Principal,
+        private val accountDAO: AccountDAO,
+        private val credentialsDAO: CredentialsDAO) {
+
+    private fun isFirstSignIn(uniqueId: String): Boolean = credentialsDAO.findByUser(uniqueId) == null
+
+    @Transactional
+    fun tryMergeToExistingAccount() {
+        val uniqueId = principal.name
+        if (isFirstSignIn(uniqueId)) {
+            val hAccount: HAccount? = accountDAO.getByEmail(email)
+            hAccount?.let {
+                log.info("found existing account with matching email [{}]. Will reuse the account.", email)
+                val credentials = HSaml2Credentials(it, uniqueId, email)
+                it.credentials.add(credentials)
+            }
+        }
+    }
+
+    companion object {
+        private val log: Logger = LoggerFactory.getLogger(SamlAccountService::class.java)
+    }
+}

--- a/server/services/src/test/java/org/zanata/security/SamlAccountServiceTest.kt
+++ b/server/services/src/test/java/org/zanata/security/SamlAccountServiceTest.kt
@@ -1,0 +1,56 @@
+package org.zanata.security
+
+import com.nhaarman.mockito_kotlin.given
+import com.nhaarman.mockito_kotlin.verifyZeroInteractions
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import org.zanata.dao.AccountDAO
+import org.zanata.dao.CredentialsDAO
+import org.zanata.model.HAccount
+import org.zanata.model.security.HSaml2Credentials
+
+class SamlAccountServiceTest {
+    @Mock
+    private lateinit var accountDAO: AccountDAO
+    @Mock
+    private lateinit var credentialsDAO: CredentialsDAO
+
+    private val uniqueId = "abc-123"
+    private val email = "admin@example.com"
+
+    private lateinit var service: SamlAccountService
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.initMocks(this)
+        service = SamlAccountService(email, SimplePrincipal(uniqueId), accountDAO, credentialsDAO)
+    }
+
+    @Test
+    fun willNotMergeAccountIfItIsNotFirstSamlSignIn() {
+        given(credentialsDAO.findByUser(uniqueId)).willReturn(HSaml2Credentials(HAccount(), uniqueId, email))
+
+        service.tryMergeToExistingAccount()
+
+        verifyZeroInteractions(accountDAO)
+    }
+
+    @Test
+    fun willMergeAccountIfMatchedAccountFoundOnFirstSamlSignIn() {
+        given(credentialsDAO.findByUser(uniqueId)).willReturn(null)
+        val existAccount = HAccount()
+        given(accountDAO.getByEmail(email)).willReturn(existAccount)
+
+        service.tryMergeToExistingAccount()
+
+        assertThat(existAccount.credentials).isNotEmpty
+        val hCredentials = existAccount.credentials.first()
+        assertThat(hCredentials).isInstanceOf(HSaml2Credentials::class.java)
+        assertThat(hCredentials.account).isSameAs(existAccount)
+        assertThat(hCredentials.email).isEqualTo(email)
+        assertThat(hCredentials.user).isEqualTo(uniqueId)
+    }
+}

--- a/server/services/src/test/java/org/zanata/servlet/SAMLFilterTest.kt
+++ b/server/services/src/test/java/org/zanata/servlet/SAMLFilterTest.kt
@@ -12,6 +12,7 @@ import org.mockito.Mock
 import org.mockito.Mockito
 import org.mockito.MockitoAnnotations
 import org.zanata.security.AuthenticationManager
+import org.zanata.security.SamlAccountService
 import org.zanata.security.SamlAttributes
 import org.zanata.util.UrlUtil
 import javax.servlet.FilterChain
@@ -34,12 +35,13 @@ class SAMLFilterTest {
     private lateinit var authenticationManager: AuthenticationManager
     @Mock
     private lateinit var urlUtil: UrlUtil
-
+    @Mock
+    private lateinit var samlAccountService: SamlAccountService
 
     @Before
     fun setUp() {
         MockitoAnnotations.initMocks(this)
-        filter = SAMLFilter(authenticationManager, urlUtil, samlAttributes)
+        filter = SAMLFilter(authenticationManager, urlUtil, samlAttributes, samlAccountService)
     }
 
 
@@ -74,5 +76,6 @@ class SAMLFilterTest {
         filter.doFilter(request, response, chain)
 
         verify(response).sendRedirect("/dashboard")
+        verify(samlAccountService).tryMergeToExistingAccount()
     }
 }


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2227

If you have an internal account already, when you choose to sign in using Single Sign On, it will try to match existing account with email. If there is a match, the SSO process will reuse that account (e.g. you won't need to create a new user and do the activation email thing)

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/599)
<!-- Reviewable:end -->
