### PR TITLE
feat(ZNTA-53) allow copy of translations from Activity Panel in Editor

### DIFF
--- a/server/zanata-frontend/src/frontend/.storybook-editor/__snapshots__/storyshots-editor.test.js.snap
+++ b/server/zanata-frontend/src/frontend/.storybook-editor/__snapshots__/storyshots-editor.test.js.snap
@@ -50,6 +50,32 @@ exports[`Editor Storyshots ActivityFeedItem approved 1`] = `
     className="well-approved well"
   >
     নাম
+    <span
+      className="u-pullRight"
+    >
+      <button
+        className="Link Link--neutral"
+        title="Copy"
+      >
+        <span
+          className="s1"
+        >
+          <svg
+            className={undefined}
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<use xlink:href=\\"#Icon-copy\\" />",
+              }
+            }
+            style={
+              Object {
+                "fill": "currentColor",
+              }
+            }
+          />
+        </span>
+      </button>
+    </span>
   </div>
   <span
     className="u-block small u-sMT-1-2 u-sPB-1-4 u-textMuted u-textSecondary"
@@ -126,6 +152,32 @@ exports[`Editor Storyshots ActivityFeedItem comment 1`] = `
     className="well"
   >
     What in the world does this mean?
+    <span
+      className="u-pullRight"
+    >
+      <button
+        className="Link Link--neutral"
+        title="Copy"
+      >
+        <span
+          className="s1"
+        >
+          <svg
+            className={undefined}
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<use xlink:href=\\"#Icon-copy\\" />",
+              }
+            }
+            style={
+              Object {
+                "fill": "currentColor",
+              }
+            }
+          />
+        </span>
+      </button>
+    </span>
   </div>
   <span
     className="u-block small u-sMT-1-2 u-sPB-1-4 u-textMuted u-textSecondary"
@@ -209,6 +261,32 @@ exports[`Editor Storyshots ActivityFeedItem fuzzy 1`] = `
     className="well-fuzzy well"
   >
     নাম
+    <span
+      className="u-pullRight"
+    >
+      <button
+        className="Link Link--neutral"
+        title="Copy"
+      >
+        <span
+          className="s1"
+        >
+          <svg
+            className={undefined}
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<use xlink:href=\\"#Icon-copy\\" />",
+              }
+            }
+            style={
+              Object {
+                "fill": "currentColor",
+              }
+            }
+          />
+        </span>
+      </button>
+    </span>
   </div>
   <span
     className="u-block small u-sMT-1-2 u-sPB-1-4 u-textMuted u-textSecondary"
@@ -352,6 +430,32 @@ exports[`Editor Storyshots ActivityFeedItem rejected - critical priority 1`] = `
     className="well-rejected well"
   >
     নাম
+    <span
+      className="u-pullRight"
+    >
+      <button
+        className="Link Link--neutral"
+        title="Copy"
+      >
+        <span
+          className="s1"
+        >
+          <svg
+            className={undefined}
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<use xlink:href=\\"#Icon-copy\\" />",
+              }
+            }
+            style={
+              Object {
+                "fill": "currentColor",
+              }
+            }
+          />
+        </span>
+      </button>
+    </span>
   </div>
   <span
     className="u-block small u-sMT-1-2 u-sPB-1-4 u-textMuted u-textSecondary"
@@ -495,6 +599,32 @@ exports[`Editor Storyshots ActivityFeedItem rejected - major priority 1`] = `
     className="well-rejected well"
   >
     নাম
+    <span
+      className="u-pullRight"
+    >
+      <button
+        className="Link Link--neutral"
+        title="Copy"
+      >
+        <span
+          className="s1"
+        >
+          <svg
+            className={undefined}
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<use xlink:href=\\"#Icon-copy\\" />",
+              }
+            }
+            style={
+              Object {
+                "fill": "currentColor",
+              }
+            }
+          />
+        </span>
+      </button>
+    </span>
   </div>
   <span
     className="u-block small u-sMT-1-2 u-sPB-1-4 u-textMuted u-textSecondary"
@@ -638,6 +768,32 @@ exports[`Editor Storyshots ActivityFeedItem rejected - minor priority 1`] = `
     className="well-rejected well"
   >
     নাম
+    <span
+      className="u-pullRight"
+    >
+      <button
+        className="Link Link--neutral"
+        title="Copy"
+      >
+        <span
+          className="s1"
+        >
+          <svg
+            className={undefined}
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<use xlink:href=\\"#Icon-copy\\" />",
+              }
+            }
+            style={
+              Object {
+                "fill": "currentColor",
+              }
+            }
+          />
+        </span>
+      </button>
+    </span>
   </div>
   <span
     className="u-block small u-sMT-1-2 u-sPB-1-4 u-textMuted u-textSecondary"
@@ -721,6 +877,32 @@ exports[`Editor Storyshots ActivityFeedItem translated 1`] = `
     className="well-translated well"
   >
     নাম
+    <span
+      className="u-pullRight"
+    >
+      <button
+        className="Link Link--neutral"
+        title="Copy"
+      >
+        <span
+          className="s1"
+        >
+          <svg
+            className={undefined}
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<use xlink:href=\\"#Icon-copy\\" />",
+              }
+            }
+            style={
+              Object {
+                "fill": "currentColor",
+              }
+            }
+          />
+        </span>
+      </button>
+    </span>
   </div>
   <span
     className="u-block small u-sMT-1-2 u-sPB-1-4 u-textMuted u-textSecondary"

--- a/server/zanata-frontend/src/frontend/app/editor/components/ActivityFeedItem/index.js
+++ b/server/zanata-frontend/src/frontend/app/editor/components/ActivityFeedItem/index.js
@@ -244,7 +244,13 @@ class ActivityFeedItem extends Component {
           {this.getMessage()}
         </p>
         <Well className={isComment ? '' : statusToWellClass[status]}>
-          {content}</Well>
+          {content}
+          <span className="u-pullRight">
+          <button className="Link Link--neutral" title="Copy">
+              <Icon name='copy' className="s1" />
+          </button>
+          </span>
+        </Well>
         <DateAndTimeDisplay dateTime={lastModifiedTime}
           className="u-block small u-sMT-1-2 u-sPB-1-4
           u-textMuted u-textSecondary"/>


### PR DESCRIPTION
Storybook - see Activity Feed Item

JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-53

Should be able to copy translation history/revisions to Editor - this is achieved through adding a copy button to each translation in the Activity Tab

![copy-button](https://user-images.githubusercontent.com/18179401/33694092-ea8ce15a-db41-11e7-8b94-e8199ba96a29.png)


## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/625)
<!-- Reviewable:end -->
