### PR TITLE
ZNTA-2303 fix single openid provider landing on 404

### DIFF
--- a/server/docker/conf/zanata-config.cli
+++ b/server/docker/conf/zanata-config.cli
@@ -99,6 +99,8 @@ jms-queue add --queue-address=MailsQueue --durable=true --entries=["java:/jms/qu
 ## add zanata.openid security domain
 /subsystem=security/security-domain=zanata.openid:add()
 /subsystem=security/security-domain=zanata.openid/authentication=classic:add()
+# uncomment following line and comment the line below will turn the instance into single OpenID provider mode. Sign in will go straight to the openID provider
+# /subsystem=security/security-domain=zanata.openid/authentication=classic/login-module=ZanataOpenIdLoginModule:add(code="org.zanata.security.OpenIdLoginModule",flag="required",module-options={providerURL="https://id.fedoraproject.org/openid/"})
 /subsystem=security/security-domain=zanata.openid/authentication=classic/login-module=ZanataOpenIdLoginModule:add(code="org.zanata.security.OpenIdLoginModule",flag="required")
 
 # ==== mail session ====

--- a/server/services/src/main/java/org/zanata/servlet/UrlRewriteConfig.java
+++ b/server/services/src/main/java/org/zanata/servlet/UrlRewriteConfig.java
@@ -124,6 +124,7 @@ public class UrlRewriteConfig extends HttpConfigurationProvider {
                 .addRule(Join.path("/account/sign_in").to("/account/login.xhtml"))
                 .addRule(Join.path("/account/register").to("/account/register.xhtml"))
                 .addRule(Join.path("/account/sign_out").to("/account/logout.xhtml"))
+                .addRule(Join.path("/account/singleopenidlogin").to("/account/singleopenidlogin.xhtml"))
                 // open id return url
                 .addRule(Join.path("/openid").to("/account/openid.xhtml"))
                 .addRule(Join.path("/account/validate_email/{key}").to("/account/email_validation.xhtml"))

--- a/server/services/src/test/java/org/zanata/servlet/UrlRewriteConfigTest.kt
+++ b/server/services/src/test/java/org/zanata/servlet/UrlRewriteConfigTest.kt
@@ -1,0 +1,29 @@
+package org.zanata.servlet
+
+import org.assertj.core.api.Assertions
+import org.junit.Before
+import org.junit.Test
+import org.mockito.Mock
+import org.mockito.MockitoAnnotations
+import javax.servlet.ServletContext
+
+class UrlRewriteConfigTest {
+    private lateinit var urlRewriteConfig: UrlRewriteConfig
+    @Mock
+    private lateinit var context: ServletContext
+
+    @Before
+    fun setUp() {
+        MockitoAnnotations.initMocks(this)
+        urlRewriteConfig = UrlRewriteConfig()
+    }
+
+
+    @Test
+    fun hasConfigForSingleOpenIdProvider() {
+        val configuration = urlRewriteConfig.getConfiguration(context)
+        val rulesStrings = configuration.rules.map { it.toString() }
+        val result = rulesStrings.filter { it.contains("/account/singleopenidlogin") }
+        Assertions.assertThat(result).hasSize(1)
+    }
+}


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2303

Instance with single openid provider enabled will land on 404 page instead of dashboard.

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/630)
<!-- Reviewable:end -->
