### PR TITLE
Minimise use of draft Babel plugins

### DIFF
--- a/server/zanata-frontend/src/frontend/.babelrc
+++ b/server/zanata-frontend/src/frontend/.babelrc
@@ -1,6 +1,6 @@
 {
   // Allows use of modern JavaScript syntax and JSX
-  "presets": ["flow", "react", "es2015", "stage-0"],
+  "presets": ["react", "env", "stage-3"],
 
   // Extracts strings for translation.
   // Strings are output to .json files in the specified messagesDir
@@ -8,6 +8,12 @@
     ["react-intl", {
       "messagesDir": "./build/messages/",
       "enforceDescriptions": true
-    }]
+    }],
+    // stage-0 plugins: (TODO remove them first)
+    "transform-function-bind",
+    // stage-1 plugins: (TODO remove them second if practical)
+    "transform-export-extensions",
+    // stage-2 plugins: (TODO remove them third if practical)
+    "transform-class-properties"
   ]
 }


### PR DESCRIPTION
We shouldn't be using Stage 0/1/2 features unless we have a good reason for accepting the risk; in my opinion anything less than Stage 3 is too unstable for our maintenance requirements. Even with Stage 3 there's a certain risk of breakage.

- https://babeljs.io/docs/plugins#presets-stage-x-experimental-presets-
- https://thefeedbackloop.xyz/tc39-process-sketch-stage-2/

This change replaces the Babel preset `stage-0` with `stage-3`. Those plugins from Stages 0, 1 and 2 which we currently use have then been added back in (for now). 

This change also replaces the preset `es2015` with [`env`](https://babeljs.io/docs/plugins/preset-env/), which will pick up new versions as they are standardised (currently up to `es2017`).

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/637)
<!-- Reviewable:end -->
