### PR TITLE
feat(ZNTA-68): Implement highlighting words in source text that match filter text in editor.

### DIFF
--- a/server/zanata-frontend/src/frontend/app/editor/app.css
+++ b/server/zanata-frontend/src/frontend/app/editor/app.css
@@ -65,5 +65,5 @@
 }
 
 .highlight {
-  background-color: yellow;
+  background-color: #ff6;
 }

--- a/server/zanata-frontend/src/frontend/app/editor/app.css
+++ b/server/zanata-frontend/src/frontend/app/editor/app.css
@@ -63,3 +63,7 @@
 .fade.in {
   opacity: 1;
 }
+
+.highlight {
+  background-color: yellow;
+}

--- a/server/zanata-frontend/src/frontend/app/editor/components/TransUnitSourcePanel.js
+++ b/server/zanata-frontend/src/frontend/app/editor/components/TransUnitSourcePanel.js
@@ -64,11 +64,22 @@ class TransUnitSourcePanel extends React.Component {
               {copyButton}
             </div>
             : undefined
-
+          // TODO: pass search as Prop to TransUnitSourcePanel @efloden
+          const search = 'Containers'
+          const getHighlightedText = (text, higlight) => {
+            // Split on higlight term and include term into parts, ignore case
+            const parts = text.split(new RegExp(`(${higlight})`, 'gi'))
+            return parts.map((part, index) =>
+              part.toLowerCase() === higlight.toLowerCase()
+                ? <span key={index} className="highlight">{part}</span>
+                : <span key={index}>{part}</span>
+            )
+          }
+          const final = search ? getHighlightedText(source, search) : source
           return (
             <div className="TransUnit-item" key={index}>
               {itemHeader}
-              <pre className="TransUnit-text">{source}</pre>
+              <pre className="TransUnit-text">{final}</pre>
             </div>
           )
         })

--- a/server/zanata-frontend/src/frontend/app/editor/components/TransUnitSourcePanel.js
+++ b/server/zanata-frontend/src/frontend/app/editor/components/TransUnitSourcePanel.js
@@ -3,6 +3,8 @@ import PropTypes from 'prop-types'
 import TransUnitSourceHeader from './TransUnitSourceHeader'
 import { LoaderText } from '../../components'
 import IconButton from './IconButton'
+import { getFilterString } from '../selectors'
+import { connect } from 'react-redux'
 
 /**
  * Panel for the source of the selected phrase
@@ -16,10 +18,13 @@ class TransUnitSourcePanel extends React.Component {
     sourceLocale: PropTypes.shape({
       id: PropTypes.string.isRequired,
       name: PropTypes.string.isRequired
-    }).isRequired
+    }).isRequired,
+    filterString: PropTypes.string
   }
 
   render () {
+    const filterString = this.props.filterString
+
     const isPlural = this.props.phrase.plural
 
     const header = this.props.selected
@@ -64,8 +69,6 @@ class TransUnitSourcePanel extends React.Component {
               {copyButton}
             </div>
             : undefined
-          // TODO: pass search as Prop to TransUnitSourcePanel @efloden
-          const search = 'Containers'
           const getHighlightedText = (text, higlight) => {
             // Split on higlight term and include term into parts, ignore case
             const parts = text.split(new RegExp(`(${higlight})`, 'gi'))
@@ -75,11 +78,12 @@ class TransUnitSourcePanel extends React.Component {
                 : <span key={index}>{part}</span>
             )
           }
-          const final = search ? getHighlightedText(source, search) : source
+          const finalSource = filterString
+            ? getHighlightedText(source, filterString) : source
           return (
             <div className="TransUnit-item" key={index}>
               {itemHeader}
-              <pre className="TransUnit-text">{final}</pre>
+              <pre className="TransUnit-text">{finalSource}</pre>
             </div>
           )
         })
@@ -115,4 +119,11 @@ class TransUnitSourcePanel extends React.Component {
   }
 }
 
-export default TransUnitSourcePanel
+function mapStateToProps (state) {
+  return {
+    state,
+    filterString: getFilterString(state)
+  }
+}
+
+export default connect(mapStateToProps)(TransUnitSourcePanel)

--- a/server/zanata-frontend/src/frontend/app/editor/selectors/index.js
+++ b/server/zanata-frontend/src/frontend/app/editor/selectors/index.js
@@ -55,6 +55,11 @@ const getCurrentDocPhrases = createSelector(
   }
 )
 
+export const getFilterString = createSelectorCreator(defaultMemoize, isEqual)(
+  getFilter,
+  (filter) => filter.advanced.searchString
+)
+
 export const getFilteredPhrases = createSelector(
   getCurrentDocPhrases, getFilter,
   (phrases, { status }) => {


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-68

When a filter is active and the "text" key is one of the keys in the filter, highlight the appropriate matching parts of text in the search results. Text in the source text that matches the value for "text" should be highlighted.
Highlighting of the translation text may not be possible due to this text being editable as part of a text-area.

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/647)
<!-- Reviewable:end -->
