### PR TITLE
ZNTA-2325 Implement Syntax Highlighting as an option in the React Editor

### DIFF
--- a/server/zanata-frontend/src/frontend/app/editor/components/TransUnitTranslationPanel.js
+++ b/server/zanata-frontend/src/frontend/app/editor/components/TransUnitTranslationPanel.js
@@ -9,7 +9,7 @@ import { pick } from 'lodash'
 import { phraseTextSelectionRange } from '../actions/phrases-actions'
 import { getSyntaxHighlighting } from '../reducers'
 import SyntaxHighlighter from 'react-syntax-highlighter'
-import { monoBlue } from 'react-syntax-highlighter/styles/hljs'
+import { atelierLakesideLight } from 'react-syntax-highlighter/styles/hljs'
 /**
  * Panel to display and edit translations of a phrase.
  */
@@ -261,7 +261,7 @@ class TranslationItem extends React.Component {
     const syntaxHighlighter = this.props.syntaxOn
       ? <SyntaxHighlighter
         language='html'
-        style={monoBlue}
+        style={atelierLakesideLight}
         wrapLines
         lineStyle={syntaxStyle}>
         {translation}

--- a/server/zanata-frontend/src/frontend/app/editor/components/TransUnitTranslationPanel.js
+++ b/server/zanata-frontend/src/frontend/app/editor/components/TransUnitTranslationPanel.js
@@ -7,7 +7,9 @@ import TransUnitTranslationFooter from './TransUnitTranslationFooter'
 import { LoaderText } from '../../components'
 import { pick } from 'lodash'
 import { phraseTextSelectionRange } from '../actions/phrases-actions'
-
+import { getSyntaxHighlighting } from '../reducers'
+import SyntaxHighlighter from 'react-syntax-highlighter'
+import { monoBlue } from 'react-syntax-highlighter/styles/hljs'
 /**
  * Panel to display and edit translations of a phrase.
  */
@@ -40,7 +42,8 @@ class TransUnitTranslationPanel extends React.Component {
     toggleGlossary: PropTypes.func.isRequired,
     toggleSuggestionPanel: PropTypes.func.isRequired,
     suggestionSearchType: PropTypes.oneOf(['phrase', 'text']).isRequired,
-    isRTL: PropTypes.bool.isRequired
+    isRTL: PropTypes.bool.isRequired,
+    syntaxOn: PropTypes.bool.isRequired
   }
 
   componentWillMount () {
@@ -98,7 +101,8 @@ class TransUnitTranslationPanel extends React.Component {
       phrase,
       selected,
       selectPhrasePluralIndex,
-      isRTL
+      isRTL,
+      syntaxOn
     } = this.props
     var header, footer
     const isPlural = phrase.plural
@@ -168,7 +172,8 @@ class TransUnitTranslationPanel extends React.Component {
               setTextArea={this.setTextArea}
               textChanged={textChanged}
               translation={translation}
-              directionClass={directionClass} />
+              directionClass={directionClass}
+              syntaxOn={syntaxOn} />
           )
         })
     }
@@ -201,7 +206,8 @@ class TranslationItem extends React.Component {
     setTextArea: PropTypes.func.isRequired,
     textChanged: PropTypes.func.isRequired,
     translation: PropTypes.string,
-    directionClass: PropTypes.string
+    directionClass: PropTypes.string,
+    syntaxOn: PropTypes.bool.isRequired
   }
 
   setTextArea = (ref) => {
@@ -246,7 +252,21 @@ class TranslationItem extends React.Component {
           {headerLabel}
         </span>
       </div>
-
+    const syntaxStyle = {
+      padding: '0.5rem',
+      width: '90%',
+      whiteSpace: 'pre-wrap',
+      wordWrap: 'break-word'
+    }
+    const syntaxHighlighter = this.props.syntaxOn
+      ? <SyntaxHighlighter
+        language='html'
+        style={monoBlue}
+        wrapLines
+        lineStyle={syntaxStyle}>
+        {translation}
+      </SyntaxHighlighter>
+      : ''
     return (
       <div className="TransUnit-item" key={index}>
         {itemHeader}
@@ -262,6 +282,7 @@ class TranslationItem extends React.Component {
           onFocus={this.setFocusedPlural}
           onChange={this._onChange}
           onSelect={onSelectionChange} />
+        {syntaxHighlighter}
       </div>
     )
   }
@@ -270,8 +291,8 @@ class TranslationItem extends React.Component {
 function mapStateToProps (state) {
   const {ui, context} = state
   const targetLocaleDetails = ui.uiLocales[context.lang]
-
   return {
+    syntaxOn: getSyntaxHighlighting(state),
     isRTL: targetLocaleDetails ? targetLocaleDetails.isRTL || false
         : false
   }

--- a/server/zanata-frontend/src/frontend/app/editor/containers/SettingsPanel.js
+++ b/server/zanata-frontend/src/frontend/app/editor/containers/SettingsPanel.js
@@ -6,11 +6,18 @@ import { updateSetting } from '../actions/settings-actions'
 import { Button } from 'react-bootstrap'
 import Icon from '../../components/Icon'
 import SettingsOptions from '../components/SettingsOptions'
-import { getEnterSavesImmediately } from '../reducers'
-import { ENTER_SAVES_IMMEDIATELY } from '../reducers/settings-reducer'
+import {
+  getEnterSavesImmediately,
+  getSyntaxHighlighting
+ } from '../reducers'
+import {
+  ENTER_SAVES_IMMEDIATELY,
+  SYNTAX_HIGHLIGTING
+} from '../reducers/settings-reducer'
 
 export const SettingsPanel = ({
   enterSavesImmediately,
+  syntaxHighligting,
   hideSettings,
   updateSetting,
   isRTL
@@ -35,6 +42,11 @@ export const SettingsPanel = ({
                 id: ENTER_SAVES_IMMEDIATELY,
                 label: 'Enter key saves immediately',
                 active: enterSavesImmediately
+              },
+              {
+                id: SYNTAX_HIGHLIGTING,
+                label: 'Syntax Highlighting',
+                active: syntaxHighligting
               }
             ]}
             updateSetting={updateSetting} />
@@ -46,6 +58,7 @@ export const SettingsPanel = ({
 
 SettingsPanel.propTypes = {
   enterSavesImmediately: PropTypes.bool.isRequired,
+  syntaxHighligting: PropTypes.bool.isRequired,
   hideSettings: PropTypes.func.isRequired,
   updateSetting: PropTypes.func.isRequired,
   isRTL: PropTypes.bool.isRequired
@@ -57,6 +70,7 @@ const mapStateToProps = (state) => {
 
   return {
     enterSavesImmediately: getEnterSavesImmediately(state),
+    syntaxHighligting: getSyntaxHighlighting(state),
     isRTL: targetLocaleDetails ? targetLocaleDetails.isRTL || false
         : false
   }

--- a/server/zanata-frontend/src/frontend/app/editor/reducers/index.js
+++ b/server/zanata-frontend/src/frontend/app/editor/reducers/index.js
@@ -32,6 +32,8 @@ export const getSuggestionsPanelVisible = createSelector(
   getSettings, settingsSelectors.getSuggestionsPanelVisible)
 export const getEnterSavesImmediately = createSelector(
   getSettings, settingsSelectors.getEnterSavesImmediately)
+export const getSyntaxHighlighting = createSelector(
+  getSettings, settingsSelectors.getSyntaxHighlighting)
 export const getShortcuts = createSelector(
   getSettings, settingsSelectors.getShortcuts)
 

--- a/server/zanata-frontend/src/frontend/app/editor/reducers/settings-reducer.js
+++ b/server/zanata-frontend/src/frontend/app/editor/reducers/settings-reducer.js
@@ -14,6 +14,7 @@ import {
 import { SHORTCUTS } from '../actions/key-shortcuts-actions'
 
 export const ENTER_SAVES_IMMEDIATELY = 'enter-saves-immediately'
+export const SYNTAX_HIGHLIGTING = 'syntax-highlighting'
 export const KEY_SUGGESTIONS_VISIBLE = 'suggestions-visible'
 
 /* Parse values of known settings to appropriate types */
@@ -22,6 +23,7 @@ function parseKnownSettings (settings) {
     try {
       switch (key) {
         case ENTER_SAVES_IMMEDIATELY:
+        case SYNTAX_HIGHLIGTING:
         case KEY_SUGGESTIONS_VISIBLE:
           return JSON.parse(value)
         default:
@@ -47,6 +49,7 @@ export const defaultState = {
   // state for individual settings
   settings: {
     [ENTER_SAVES_IMMEDIATELY]: newSetting(false),
+    [SYNTAX_HIGHLIGTING]: newSetting(false),
     [KEY_SUGGESTIONS_VISIBLE]: newSetting(true)
   // 'suggestions-heightpercent': { value: 0.3, saving: false, error:undefined }
   // 'setting-key': { value: defaultValue, saving: false, error: undefined }
@@ -58,6 +61,8 @@ export const getSuggestionsPanelVisible = settings =>
   settings.settings[KEY_SUGGESTIONS_VISIBLE].value
 export const getEnterSavesImmediately = settings =>
   settings.settings[ENTER_SAVES_IMMEDIATELY].value
+export const getSyntaxHighlighting = settings =>
+  settings.settings[SYNTAX_HIGHLIGTING].value
 export const getShortcuts = createSelector(getEnterSavesImmediately,
   enterSaves => enterSaves ? update(SHORTCUTS, {
     // Both shortcuts are at index 0, but replacing by value in case they move

--- a/server/zanata-frontend/src/frontend/app/editor/reducers/settings-reducer.test.js
+++ b/server/zanata-frontend/src/frontend/app/editor/reducers/settings-reducer.test.js
@@ -4,6 +4,7 @@ jest.disableAutomock()
 import reducer, {
   ENTER_SAVES_IMMEDIATELY,
   KEY_SUGGESTIONS_VISIBLE,
+  SYNTAX_HIGHLIGTING,
   getSuggestionsPanelVisible
 } from './settings-reducer'
 import { createAction } from 'redux-actions'
@@ -33,6 +34,11 @@ describe('settings-reducer test', () => {
           value: true,
           saving: false,
           error: undefined
+        },
+        [SYNTAX_HIGHLIGTING]: {
+          value: false,
+          saving: false,
+          error: undefined
         }
       }
     })
@@ -56,6 +62,11 @@ describe('settings-reducer test', () => {
           error: undefined
         },
         [KEY_SUGGESTIONS_VISIBLE]: {
+          value: false,
+          saving: false,
+          error: undefined
+        },
+        [SYNTAX_HIGHLIGTING]: {
           value: false,
           saving: false,
           error: undefined

--- a/server/zanata-frontend/src/frontend/package.json
+++ b/server/zanata-frontend/src/frontend/package.json
@@ -129,7 +129,7 @@
     "react-router-redux": "4.0.8",
     "react-select": "1.0.0-rc.5",
     "react-sortable-hoc": "0.6.3",
-    "react-syntax-highlighter": "^6.1.1",
+    "react-syntax-highlighter": "6.1.1",
     "react-textarea-autosize": "4.3.2",
     "react-toggle": "4.0.1",
     "redux": "3.5.2",

--- a/server/zanata-frontend/src/frontend/package.json
+++ b/server/zanata-frontend/src/frontend/package.json
@@ -129,6 +129,7 @@
     "react-router-redux": "4.0.8",
     "react-select": "1.0.0-rc.5",
     "react-sortable-hoc": "0.6.3",
+    "react-syntax-highlighter": "^6.1.1",
     "react-textarea-autosize": "4.3.2",
     "react-toggle": "4.0.1",
     "redux": "3.5.2",

--- a/server/zanata-frontend/src/frontend/yarn.lock
+++ b/server/zanata-frontend/src/frontend/yarn.lock
@@ -1932,6 +1932,14 @@ cli-width@^2.0.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/cli-width/-/cli-width-2.2.0.tgz#ff19ede8a9a5e579324147b0c11f0fbcbabed639"
 
+clipboard@^1.7.1:
+  version "1.7.1"
+  resolved "https://registry.yarnpkg.com/clipboard/-/clipboard-1.7.1.tgz#360d6d6946e99a7a1fef395e42ba92b5e9b5a16b"
+  dependencies:
+    good-listener "^1.2.2"
+    select "^1.1.2"
+    tiny-emitter "^2.0.0"
+
 cliui@^2.1.0:
   version "2.1.0"
   resolved "https://registry.yarnpkg.com/cliui/-/cliui-2.1.0.tgz#4b475760ff80264c762c3a1719032e91c7fea0d1"
@@ -2044,6 +2052,12 @@ combined-stream@^1.0.5, combined-stream@~1.0.5:
 combokeys@2.4.6:
   version "2.4.6"
   resolved "https://registry.yarnpkg.com/combokeys/-/combokeys-2.4.6.tgz#a5c47599632af7a36d1d9c2f98518c95b253d83b"
+
+comma-separated-tokens@^1.0.0:
+  version "1.0.4"
+  resolved "https://registry.yarnpkg.com/comma-separated-tokens/-/comma-separated-tokens-1.0.4.tgz#72083e58d4a462f01866f6617f4d98a3cd3b8a46"
+  dependencies:
+    trim "0.0.1"
 
 commander@^2.9.0:
   version "2.11.0"
@@ -2504,6 +2518,10 @@ del@^3.0.0:
 delayed-stream@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/delayed-stream/-/delayed-stream-1.0.0.tgz#df3ae199acadfb7d440aaae0b29e2272b24ec619"
+
+delegate@^3.1.2:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/delegate/-/delegate-3.2.0.tgz#b66b71c3158522e8ab5744f720d8ca0c2af59166"
 
 delegates@^1.0.0:
   version "1.0.0"
@@ -3553,6 +3571,12 @@ globjoin@^0.1.4:
   version "0.1.4"
   resolved "https://registry.yarnpkg.com/globjoin/-/globjoin-0.1.4.tgz#2f4494ac8919e3767c5cbb691e9f463324285d43"
 
+good-listener@^1.2.2:
+  version "1.2.2"
+  resolved "https://registry.yarnpkg.com/good-listener/-/good-listener-1.2.2.tgz#d53b30cdf9313dffb7dc9a0d477096aa6d145c50"
+  dependencies:
+    delegate "^3.1.2"
+
 graceful-fs@^4.1.11, graceful-fs@^4.1.2, graceful-fs@^4.1.6, graceful-fs@^4.1.9:
   version "4.1.11"
   resolved "https://registry.yarnpkg.com/graceful-fs/-/graceful-fs-4.1.11.tgz#0e8bdfe4d1ddb8854d64e04ea7c00e2a026e5658"
@@ -3648,6 +3672,20 @@ hasha@~2.2.0:
     is-stream "^1.0.1"
     pinkie-promise "^2.0.0"
 
+hast-util-parse-selector@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/hast-util-parse-selector/-/hast-util-parse-selector-2.1.0.tgz#b55c0f4bb7bb2040c889c325ef87ab29c38102b4"
+
+hastscript@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/hastscript/-/hastscript-3.1.0.tgz#66628ba6d7f1ad07d9277dd09028aba7f4934599"
+  dependencies:
+    camelcase "^3.0.0"
+    comma-separated-tokens "^1.0.0"
+    hast-util-parse-selector "^2.0.0"
+    property-information "^3.0.0"
+    space-separated-tokens "^1.0.0"
+
 hawk@3.1.3, hawk@~3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/hawk/-/hawk-3.1.3.tgz#078444bd7c1640b0fe540d2c9b73d59678e8e1c4"
@@ -3669,6 +3707,10 @@ hawk@~6.0.2:
 he@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/he/-/he-1.1.1.tgz#93410fd21b009735151f8868c2f271f3427e23fd"
+
+highlight.js@~9.12.0:
+  version "9.12.0"
+  resolved "https://registry.yarnpkg.com/highlight.js/-/highlight.js-9.12.0.tgz#e6d9dbe57cbefe60751f02af336195870c90c01e"
 
 history@3.3.0, history@^3.0.0:
   version "3.3.0"
@@ -5072,6 +5114,12 @@ loud-rejection@^1.0.0:
   dependencies:
     currently-unhandled "^0.4.1"
     signal-exit "^3.0.0"
+
+lowlight@~1.9.1:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/lowlight/-/lowlight-1.9.1.tgz#ed7c3dffc36f8c1f263735c0fe0c907847c11250"
+  dependencies:
+    highlight.js "~9.12.0"
 
 lru-cache@^3.2.0:
   version "3.2.0"
@@ -6583,6 +6631,12 @@ prettysize@^0.0.3:
   version "0.0.3"
   resolved "https://registry.yarnpkg.com/prettysize/-/prettysize-0.0.3.tgz#14afff6a645e591a4ddf1c72919c23b4146181a1"
 
+prismjs@^1.8.4, prismjs@~1.9.0:
+  version "1.9.0"
+  resolved "https://registry.yarnpkg.com/prismjs/-/prismjs-1.9.0.tgz#fa3e2d9edc3c3887c1f1f3095d41f1f9b4200f0f"
+  optionalDependencies:
+    clipboard "^1.7.1"
+
 private@^0.1.6, private@^0.1.7, private@~0.1.5:
   version "0.1.8"
   resolved "https://registry.yarnpkg.com/private/-/private-0.1.8.tgz#2381edb3689f7a53d653190060fcf822d2f368ff"
@@ -6637,6 +6691,10 @@ prop-types@15.5.10, prop-types@~15.5.7:
   dependencies:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
+
+property-information@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/property-information/-/property-information-3.2.0.tgz#fd1483c8fbac61808f5fe359e7693a1f48a58331"
 
 proto-list@~1.2.1:
   version "1.2.4"
@@ -7113,6 +7171,16 @@ react-style-proptype@^3.0.0:
   dependencies:
     prop-types "^15.5.4"
 
+react-syntax-highlighter@^6.1.1:
+  version "6.1.1"
+  resolved "https://registry.yarnpkg.com/react-syntax-highlighter/-/react-syntax-highlighter-6.1.1.tgz#4d134fa9217c4025e7fd6efeadd08ba92436ee4e"
+  dependencies:
+    babel-runtime "^6.18.0"
+    highlight.js "~9.12.0"
+    lowlight "~1.9.1"
+    prismjs "^1.8.4"
+    refractor "^2.0.0"
+
 react-test-renderer@15.6.1:
   version "15.6.1"
   resolved "https://registry.yarnpkg.com/react-test-renderer/-/react-test-renderer-15.6.1.tgz#026f4a5bb5552661fd2cc4bbcd0d4bc8a35ebf7e"
@@ -7366,6 +7434,13 @@ redux@^3.6.0, redux@^3.7.2:
     lodash-es "^4.2.1"
     loose-envify "^1.1.0"
     symbol-observable "^1.0.3"
+
+refractor@^2.0.0:
+  version "2.2.0"
+  resolved "https://registry.yarnpkg.com/refractor/-/refractor-2.2.0.tgz#9f0ff38ac76f6e5eaacfd689912ed6ab7ab07351"
+  dependencies:
+    hastscript "^3.1.0"
+    prismjs "~1.9.0"
 
 regenerate@^1.2.1:
   version "1.3.3"
@@ -7644,6 +7719,10 @@ select-hose@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/select-hose/-/select-hose-2.0.0.tgz#625d8658f865af43ec962bfc376a37359a4994ca"
 
+select@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/select/-/select-1.1.2.tgz#0e7350acdec80b1108528786ec1d4418d11b396d"
+
 selfsigned@^1.9.1:
   version "1.10.1"
   resolved "https://registry.yarnpkg.com/selfsigned/-/selfsigned-1.10.1.tgz#bf8cb7b83256c4551e31347c6311778db99eec52"
@@ -7873,6 +7952,12 @@ sourcemapped-stacktrace@^1.1.6:
   resolved "https://registry.yarnpkg.com/sourcemapped-stacktrace/-/sourcemapped-stacktrace-1.1.7.tgz#17e05374ff78b71a9d89ad3975a49f22725ba935"
   dependencies:
     source-map "0.5.6"
+
+space-separated-tokens@^1.0.0:
+  version "1.1.1"
+  resolved "https://registry.yarnpkg.com/space-separated-tokens/-/space-separated-tokens-1.1.1.tgz#9695b9df9e65aec1811d4c3f9ce52520bc2f7e4d"
+  dependencies:
+    trim "0.0.1"
 
 spdx-correct@~1.0.0:
   version "1.0.2"
@@ -8393,6 +8478,10 @@ timers-ext@0.1, timers-ext@^0.1.2:
     es5-ext "~0.10.14"
     next-tick "1"
 
+tiny-emitter@^2.0.0:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/tiny-emitter/-/tiny-emitter-2.0.2.tgz#82d27468aca5ade8e5fd1e6d22b57dd43ebdfb7c"
+
 tinycolor2@^1.4.1:
   version "1.4.1"
   resolved "https://registry.yarnpkg.com/tinycolor2/-/tinycolor2-1.4.1.tgz#f4fad333447bc0b07d4dc8e9209d8f39a8ac77e8"
@@ -8426,6 +8515,10 @@ trim-newlines@^1.0.0:
 trim-right@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/trim-right/-/trim-right-1.0.1.tgz#cb2e1203067e0c8de1f614094b9fe45704ea6003"
+
+trim@0.0.1:
+  version "0.0.1"
+  resolved "https://registry.yarnpkg.com/trim/-/trim-0.0.1.tgz#5858547f6b290757ee95cccc666fb50084c460dd"
 
 tryit@^1.0.1:
   version "1.0.3"

--- a/server/zanata-frontend/src/frontend/yarn.lock
+++ b/server/zanata-frontend/src/frontend/yarn.lock
@@ -7171,7 +7171,7 @@ react-style-proptype@^3.0.0:
   dependencies:
     prop-types "^15.5.4"
 
-react-syntax-highlighter@^6.1.1:
+react-syntax-highlighter@6.1.1:
   version "6.1.1"
   resolved "https://registry.yarnpkg.com/react-syntax-highlighter/-/react-syntax-highlighter-6.1.1.tgz#4d134fa9217c4025e7fd6efeadd08ba92436ee4e"
   dependencies:


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2325

Implemented Syntax Highlighting as an option in the React Editor
There a quite a few styles to choose from for the syntax highlighting which can been demoed here:
http://conor.rodeo/react-syntax-highlighter/demo/
altier-lakeside-light is the style being used in the editor to give some contrast, dark themes to not appear to work in the editor (possibly a css clash)

## QA: 
The checkbox is available in the editors settings panel and the selection should persist after refreshing.

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/653)
<!-- Reviewable:end -->
