### PR TITLE
style(ZNTA-2330): Fix classname for style highlighting in editor

### DIFF
--- a/server/zanata-frontend/src/frontend/app/editor/containers/Root/index.css
+++ b/server/zanata-frontend/src/frontend/app/editor/containers/Root/index.css
@@ -24,7 +24,7 @@ input, textarea, select, button  {
   font-size: 1rem;
 }
 
-.TransUnitItem .highlight {
+.TransUnit-item .highlight {
   background-color: #ff6;
 }
 


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2330

Small stylefix for the highlighting in the editor, classname was not applying

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/659)
<!-- Reviewable:end -->
