### PR TITLE
fix(ZNTA-2342): editor filter by translated state breaking keyboard navigation

### DIFF
--- a/server/zanata-frontend/src/app/editor/reducers/phrase-reducer/index.js
+++ b/server/zanata-frontend/src/app/editor/reducers/phrase-reducer/index.js
@@ -235,13 +235,17 @@ function changeSelectedIndex (state, globalState, indexUpdateCallback) {
   const { inDoc, inDocFiltered, filter, selectedPhraseId } = state
   const phrases = hasAdvancedFilter(filter.advanced)
     ? inDocFiltered[docId] : inDoc[docId]
-
-  const currentIndex = phrases.findIndex(x => x.id === selectedPhraseId)
+  const phrasesFiltered = filter.status.all
+    ? phrases
+    : phrases.filter((phrase) => {
+      return filter.status[phrase.status]
+    })
+  const currentIndex = phrasesFiltered.findIndex(x => x.id === selectedPhraseId)
 
   const newIndex = indexUpdateCallback(currentIndex)
-  const indexOutOfBounds = newIndex < 0 || newIndex >= phrases.length
+  const indexOutOfBounds = newIndex < 0 || newIndex >= phrasesFiltered.length
   if (!indexOutOfBounds && newIndex !== currentIndex) {
-    const moveToId = phrases[newIndex].id
+    const moveToId = phrasesFiltered[newIndex].id
     return selectPhrase(state, globalState, moveToId)
   }
 


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2342?streamsSourceProduct=jira

Now filtering the list of phrases to only include those matching the status of translation filter selection.
Keyboard navigation using ALT+UP or ALT+DOWN should no longer select targets that are not displayed.

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/664)
<!-- Reviewable:end -->
