### PR TITLE
refactor: reduce imports for react-sytax-highlighter

### DIFF
--- a/server/zanata-frontend/src/app/editor/components/TransUnitTranslationPanel.js
+++ b/server/zanata-frontend/src/app/editor/components/TransUnitTranslationPanel.js
@@ -8,8 +8,13 @@ import { LoaderText } from '../../components'
 import { pick } from 'lodash'
 import { phraseTextSelectionRange } from '../actions/phrases-actions'
 import { getSyntaxHighlighting } from '../reducers'
-import SyntaxHighlighter from 'react-syntax-highlighter'
+import SyntaxHighlighter, { registerLanguage }
+  from 'react-syntax-highlighter/light'
+import xml from 'react-syntax-highlighter/languages/hljs/xml'
 import { atelierLakesideLight } from 'react-syntax-highlighter/styles/hljs'
+
+registerLanguage('xml', xml)
+
 /**
  * Panel to display and edit translations of a phrase.
  */


### PR DESCRIPTION
JIRA issue URL: N/A

Reduces the import footprint of the react-syntax-highlighter significantly by only importing the xml language. (which is all we are using at the moment)

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
