### PR TITLE
fix(ZNTA-2341) add top spacing to editor search

### DIFF
--- a/server/zanata-frontend/src/frontend/app/editor/components/PhraseStatusFilter/PhraseStatusFilter.test.js
+++ b/server/zanata-frontend/src/frontend/app/editor/components/PhraseStatusFilter/PhraseStatusFilter.test.js
@@ -25,7 +25,7 @@ describe('PhraseStatusFilterTest', () => {
         withDot />
     )
     const expected = ReactDOMServer.renderToStaticMarkup(
-      <div className="Toggle u-round soClassy">
+      <div className="Toggle u-curved soClassy">
         <input className="Toggle-checkbox"
           type="checkbox"
           id="government-issued"
@@ -58,7 +58,7 @@ describe('PhraseStatusFilterTest', () => {
         withDot={false} />
     )
     const expected = ReactDOMServer.renderToStaticMarkup(
-      <div className="Toggle u-round soClassy">
+      <div className="Toggle u-curved soClassy">
         <input className="Toggle-checkbox"
           type="checkbox"
           id="government-issued"

--- a/server/zanata-frontend/src/frontend/app/editor/components/SuggestionSearchInput/index.js
+++ b/server/zanata-frontend/src/frontend/app/editor/components/SuggestionSearchInput/index.js
@@ -21,7 +21,6 @@
 
 import cx from 'classnames'
 import { Icon } from '../../../components'
-import IconButton from '../IconButton'
 import React from 'react'
 import PropTypes from 'prop-types'
 
@@ -120,20 +119,6 @@ class SuggestionSearchInput extends React.Component {
     )
   }
 
-  clearButtonElement = () => {
-    if (!this.props.hasSearch) {
-      return undefined
-    }
-    return (
-      <span className="EditorInputGroup-addon">
-        <IconButton icon="cross"
-          title="Clear search"
-          className="n1"
-          onClick={this.clearSearch} />
-      </span>
-    )
-  }
-
   render () {
     return (
       <div className={cx('EditorInputGroup EditorInputGroup--outlined' +
@@ -153,7 +138,6 @@ class SuggestionSearchInput extends React.Component {
           onChange={this.props.onTextChange}
           className="EditorInputGroup-input u-sizeLineHeight-1_1-4" />
         {this.resultsElement()}
-        {this.clearButtonElement()}
       </div>
     )
   }

--- a/server/zanata-frontend/src/frontend/app/editor/containers/Root/index.css
+++ b/server/zanata-frontend/src/frontend/app/editor/containers/Root/index.css
@@ -319,7 +319,7 @@ li.DocName span.ellipsis {
 }
 
 .Editor-suggestions.is-search-active .Editor-suggestionsBody {
-  top: calc(var(--Editor-rhythm) * 3);
+  top: calc(var(--Editor-rhythm) * 3.5);
 }
 
 .Editor-suggestionsSearch {


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2341

* Added spacing above alpha editor suggestions search
* Removed the duplicate 'x' that closes the suggestions search
* Updated tests

I had to start again on a clean branch from release after all those release changes were made yesterday so it will need a second review. 

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/666)
<!-- Reviewable:end -->
