### PR TITLE
fix(ZNTA-2339) fix FilterToggle backgrounds in editor

### DIFF
--- a/server/zanata-frontend/src/frontend/app/editor/components/FilterToggle/index.css
+++ b/server/zanata-frontend/src/frontend/app/editor/components/FilterToggle/index.css
@@ -56,6 +56,7 @@ not conflict with the other frontend code
   height: 100%;
   content: '';
   background-color: transparent;
+  border-radius: 4px;
 }
 
 .Toggle:hover > .Toggle-fakeCheckbox,
@@ -78,4 +79,8 @@ not conflict with the other frontend code
 .Toggle-checkbox:checked:focus ~ .Toggle-fakeCheckbox,
 .Toggle.is-active:hover > .Toggle-fakeCheckbox {
   opacity: 0.8;
+}
+
+.u-curved {
+  border-radius: 4px;
 }

--- a/server/zanata-frontend/src/frontend/app/editor/components/FilterToggle/index.js
+++ b/server/zanata-frontend/src/frontend/app/editor/components/FilterToggle/index.js
@@ -50,7 +50,7 @@ class FilterToggle extends React.Component {
   }
 
   render () {
-    const className = cx('Toggle u-round', this.props.className)
+    const className = cx('Toggle u-curved', this.props.className)
     const dot = this.props.withDot && <Icon name="dot" className="n1" />
 
     return (


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2339

Fix alignment of FilterToggle translation counts in editor - add a more appropriate border radius that does not shift the toggles when active.
![filter](https://user-images.githubusercontent.com/18179401/35075290-fcc20b76-fc3d-11e7-8c00-93ad9546c8dc.png)


## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/667)
<!-- Reviewable:end -->
