### PR TITLE
fix(ZNTA-2363) width of project version languages list items set to 100%

### DIFF
--- a/server/zanata-frontend/src/frontend/app/styles/style.less
+++ b/server/zanata-frontend/src/frontend/app/styles/style.less
@@ -2897,6 +2897,10 @@ li.progress-bar__expander.panels__panel__item a .list__item, li.progress-bar__ex
   padding: 0.75em 0.75em 0.75em !important;
 }
 
+li.progress-bar__expander.panels__panel__item a .list__item {
+  width: 100%;
+}
+
 input[type=button].btn-block, input[type=reset].btn-block, input[type=submit].btn-block {
   width: 100%;
 }


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2363

Width of project version languages list items set to 100%

**Before**
<img width="657" alt="lanpanel" src="https://user-images.githubusercontent.com/18179401/35201781-e71c6936-ff69-11e7-8c81-55675fe356b9.png">

**After**
<img width="608" alt="langfix" src="https://user-images.githubusercontent.com/18179401/35201788-ee9a4e8a-ff69-11e7-840f-d64bdde9a9fe.png">

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/681)
<!-- Reviewable:end -->
