### PR TITLE
style(ZNTA-2091): Widen GWT Editor scrollbar using webkit-scrollbar

### DIFF
--- a/server/zanata-war/src/main/webapp/resources/assets/css/application.css
+++ b/server/zanata-war/src/main/webapp/resources/assets/css/application.css
@@ -913,23 +913,21 @@ a.downloadLink {
 .translatorEditorContainer *::-webkit-scrollbar-track
 {
   -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.3);
-	border-radius: 10px;
-	background-color: #F5F5F5;
+  border-radius: 10px;
+  background-color: #F5F5F5;
 }
 
 .translatorEditorContainer *::-webkit-scrollbar
 {
   width: 14px;
-	background-color: #F5F5F5;
+  background-color: #F5F5F5;
 }
 
 .translatorEditorContainer *::-webkit-scrollbar-thumb
 {
   background-color: #03A6D7;
   border-radius: 10px;
-	background-image: -webkit-gradient(linear, 0 0, 0 100%,
-	                   color-stop(.5, rgba(255, 255, 255, .2)),
-					   color-stop(.5, transparent), to(transparent));
+  background-image: -webkit-gradient(linear, 0 0, 0 100%,color-stop(.5,rgba(255, 255, 255, .2)),color-stop(.5, transparent), to(transparent));
 }
 
 .translationContainer > div:nth-of-type(2) > div > div:nth-of-type(2) {

--- a/server/zanata-war/src/main/webapp/resources/assets/css/application.css
+++ b/server/zanata-war/src/main/webapp/resources/assets/css/application.css
@@ -910,6 +910,28 @@ a.downloadLink {
   position: relative;
 }
 
+.translatorEditorContainer *::-webkit-scrollbar-track
+{
+  -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.3);
+	border-radius: 10px;
+	background-color: #F5F5F5;
+}
+
+.translatorEditorContainer *::-webkit-scrollbar
+{
+  width: 14px;
+	background-color: #F5F5F5;
+}
+
+.translatorEditorContainer *::-webkit-scrollbar-thumb
+{
+  background-color: #03A6D7;
+  border-radius: 10px;
+	background-image: -webkit-gradient(linear, 0 0, 0 100%,
+	                   color-stop(.5, rgba(255, 255, 255, .2)),
+					   color-stop(.5, transparent), to(transparent));
+}
+
 .translationContainer > div:nth-of-type(2) > div > div:nth-of-type(2) {
   background-color: rgba(255, 255, 255, 0.4);
 }

--- a/server/zanata-war/src/main/webapp/resources/assets/css/application.css
+++ b/server/zanata-war/src/main/webapp/resources/assets/css/application.css
@@ -910,20 +910,20 @@ a.downloadLink {
   position: relative;
 }
 
-.translatorEditorContainer *::-webkit-scrollbar-track
+.gwt-SplitLayoutPanel *::-webkit-scrollbar-track
 {
   -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.3);
   border-radius: 10px;
   background-color: #F5F5F5;
 }
 
-.translatorEditorContainer *::-webkit-scrollbar
+.gwt-SplitLayoutPanel *::-webkit-scrollbar
 {
   width: 14px;
   background-color: #F5F5F5;
 }
 
-.translatorEditorContainer *::-webkit-scrollbar-thumb
+.gwt-SplitLayoutPanel *::-webkit-scrollbar-thumb
 {
   background-color: #03A6D7;
   border-radius: 10px;


### PR DESCRIPTION
JIRA issue URL:https://zanata.atlassian.net/browse/ZNTA-2091

Widened the GWT editors vertical scrollbar using webkit-scrollbar.

QA: Style will only be viewable in webkit broswers (Chrome)
Firefox still has no support for scrollbar styling without Javascript: https://stackoverflow.com/questions/6165472/custom-css-scrollbar-for-firefox

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/687)
<!-- Reviewable:end -->
