### PR TITLE
fix(ZNTA-2369) word wrapping in GWT history modal comments

### DIFF
--- a/server/zanata-frontend/src/app/styles/gwt.less
+++ b/server/zanata-frontend/src/app/styles/gwt.less
@@ -127,4 +127,11 @@
   .button--small {
     padding: 0.21429em 0.42857em !important;
   }
+  #gwt-debug-transHistoryTabPanel .gwt-TabLayoutPanelContent .gwt-InlineHTML .l--pad-v-half {
+    margin-top: 5px;
+    margin-bottom: 5px;
+    min-height: 1em;
+    word-wrap: break-word;
+    white-space: pre-wrap;
+  }
 }


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2369

Fix word wrapping for GWT translation history modal comments

**Result**
<img width="869" alt="history-wrap" src="https://user-images.githubusercontent.com/18179401/35490404-265f305c-04eb-11e8-93c8-a13baec46e12.png">

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/691)
<!-- Reviewable:end -->
