### PR TITLE
Use CurrentUser to get authenticated HAccount

### DIFF
--- a/server/functional-test/src/main/java/org/zanata/workflow/LoginWorkFlow.java
+++ b/server/functional-test/src/main/java/org/zanata/workflow/LoginWorkFlow.java
@@ -74,9 +74,13 @@ public class LoginWorkFlow extends AbstractWebWorkFlow {
         log.info("log in as username: {}", username);
         BasePage basePage = new BasePage(driver);
         basePage.deleteCookiesAndRefresh();
-        basePage.clickSignInLink().enterUsername(username)
-                .enterPassword(password).clickSignIn().waitForAMoment()
-                .withMessage("login").until(driver1 -> {
+        basePage.clickSignInLink()
+                .enterUsername(username)
+                .enterPassword(password)
+                .clickSignIn()
+                .waitForAMoment()
+                .withMessage("waiting for login (logout button visible)")
+                .until(driver1 -> {
                     // only enable this if you temporarily disable implicit
                     // waits:
                     // fail-fast logic

--- a/server/services/src/main/java/org/zanata/action/AbstractProfileAction.java
+++ b/server/services/src/main/java/org/zanata/action/AbstractProfileAction.java
@@ -9,8 +9,8 @@ import org.zanata.dao.AccountDAO;
 import org.zanata.dao.PersonDAO;
 import org.zanata.model.HAccount;
 import org.zanata.model.HPerson;
+import org.zanata.seam.security.CurrentUser;
 import org.zanata.security.ZanataIdentity;
-import org.zanata.security.annotations.Authenticated;
 import org.zanata.ui.faces.FacesMessages;
 
 /**
@@ -33,8 +33,7 @@ public abstract class AbstractProfileAction implements HasUserDetail {
     private FacesMessages facesMessages;
 
     @Inject
-    @Authenticated
-    HAccount authenticatedAccount;
+    CurrentUser currentUser;
 
     @Inject
     PersonDAO personDAO;
@@ -45,7 +44,7 @@ public abstract class AbstractProfileAction implements HasUserDetail {
     protected void validateEmail(String email) {
         HPerson person = personDAO.findByEmail(email);
 
-        if (person != null && !person.getAccount().equals(authenticatedAccount)) {
+        if (person != null && !person.getAccount().equals(currentUser.getAccount())) {
             valid = false;
             facesMessages.addToControl("email",
                     "This email address is already taken");
@@ -62,7 +61,7 @@ public abstract class AbstractProfileAction implements HasUserDetail {
 
     protected boolean isUsernameTaken(String username) {
         HAccount account = accountDAO.getByUsername(username);
-        return account != null && !account.equals(authenticatedAccount);
+        return account != null && !account.equals(currentUser.getAccount());
     }
 
     @NotEmpty

--- a/server/services/src/main/java/org/zanata/action/AccountMergeAction.java
+++ b/server/services/src/main/java/org/zanata/action/AccountMergeAction.java
@@ -34,9 +34,9 @@ import org.apache.commons.lang3.ObjectUtils;
 import org.apache.deltaspike.jpa.api.transaction.Transactional;
 import org.zanata.dao.AccountDAO;
 import org.zanata.model.HAccount;
+import org.zanata.seam.security.CurrentUser;
 import org.zanata.security.AuthenticationManager;
 import org.zanata.security.ZanataIdentity;
-import org.zanata.security.annotations.Authenticated;
 import org.zanata.security.openid.OpenIdAuthCallback;
 import org.zanata.security.openid.OpenIdAuthenticationResult;
 import org.zanata.security.openid.OpenIdProviderType;
@@ -65,8 +65,7 @@ public class AccountMergeAction implements Serializable {
 
     private static final long serialVersionUID = 1L;
     @Inject
-    @Authenticated
-    private HAccount authenticatedAccount;
+    private CurrentUser currentUser;
     @Inject
     private FacesMessages facesMessages;
     @Inject
@@ -136,7 +135,7 @@ public class AccountMergeAction implements Serializable {
                 facesMessages.addGlobal(SEVERITY_ERROR,
                         "Could not find an account for that user.");
                 valid = false;
-            } else if (authenticatedAccount.getId()
+            } else if (currentUser.getAccount().getId()
                     .equals(obsoleteAccount.getId())) {
                 facesMessages.addGlobal(SEVERITY_ERROR,
                         "You are attempting to merge the same account.");
@@ -147,7 +146,7 @@ public class AccountMergeAction implements Serializable {
     }
 
     public void mergeAccounts() {
-        registerServiceImpl.mergeAccounts(authenticatedAccount,
+        registerServiceImpl.mergeAccounts(currentUser.getAccount(),
                 getObsoleteAccount());
         setObsoleteAccount(null); // reset the obsolete account
         facesMessages.addGlobal("Your accounts have been merged.");

--- a/server/services/src/main/java/org/zanata/action/ProfileAction.java
+++ b/server/services/src/main/java/org/zanata/action/ProfileAction.java
@@ -52,10 +52,10 @@ public class ProfileAction extends AbstractProfileAction
     public void onCreate() {
         username = identity.getCredentials().getUsername();
         HPerson person = personDAO
-                .findById(authenticatedAccount.getPerson().getId(), false);
+                .findById(currentUser.getPerson().getId(), false);
         name = person.getName();
         email = person.getEmail();
-        authenticatedAccount.getPerson().setName(this.name);
-        authenticatedAccount.getPerson().setEmail(this.email);
+        currentUser.getPerson().setName(this.name);
+        currentUser.getPerson().setEmail(this.email);
     }
 }

--- a/server/services/src/main/java/org/zanata/action/ProjectHome.java
+++ b/server/services/src/main/java/org/zanata/action/ProjectHome.java
@@ -57,7 +57,6 @@ import org.zanata.dao.PersonDAO;
 import org.zanata.dao.WebHookDAO;
 import org.zanata.exception.ProjectNotFoundException;
 import org.zanata.i18n.Messages;
-import org.zanata.model.HAccount;
 import org.zanata.model.HAccountRole;
 import org.zanata.model.HLocale;
 import org.zanata.model.HPerson;
@@ -66,8 +65,8 @@ import org.zanata.model.HProjectIteration;
 import org.zanata.model.WebHook;
 import org.zanata.model.type.WebhookType;
 import org.zanata.model.validator.SlugValidator;
+import org.zanata.seam.security.CurrentUser;
 import org.zanata.security.ZanataIdentity;
-import org.zanata.security.annotations.Authenticated;
 import org.zanata.service.LocaleService;
 import org.zanata.service.ProjectService;
 import org.zanata.service.SlugEntityService;
@@ -119,8 +118,7 @@ public class ProjectHome extends SlugHome<HProject>
     @Inject
     private ZanataIdentity identity;
     @Inject
-    @Authenticated
-    private HAccount authenticatedAccount;
+    private CurrentUser currentUser;
     @Inject
     private LocaleService localeServiceImpl;
     @Inject
@@ -817,11 +815,11 @@ public class ProjectHome extends SlugHome<HProject>
             return null;
         }
         updateProjectType();
-        if (authenticatedAccount != null) {
+        if (currentUser.isLoggedIn()) {
             // authenticatedAccount person is a detached entity, so fetch a copy
             // that is attached to the current session.
             HPerson creator = personDAO
-                    .findById(authenticatedAccount.getPerson().getId());
+                    .findById(currentUser.getPerson().getId());
             getInstance().addMaintainer(creator);
             getInstance().getCustomizedValidations().clear();
             for (ValidationAction validationAction : validationServiceImpl
@@ -873,7 +871,7 @@ public class ProjectHome extends SlugHome<HProject>
                     person.getAccount().getUsername(), Maintainer,
                     getInstance().getWebHooks(),
                     ProjectMaintainerChangedEvent.ChangeType.REMOVE);
-            if (person.equals(authenticatedAccount.getPerson())) {
+            if (person.equals(currentUser.getPerson())) {
                 urlUtil.redirectToInternal(urlUtil.projectUrl(getSlug()));
             }
         }

--- a/server/services/src/main/java/org/zanata/action/ProjectHomeAction.java
+++ b/server/services/src/main/java/org/zanata/action/ProjectHomeAction.java
@@ -50,7 +50,6 @@ import org.zanata.dao.ProjectDAO;
 import org.zanata.dao.ProjectIterationDAO;
 import org.zanata.i18n.Messages;
 import org.zanata.model.Activity;
-import org.zanata.model.HAccount;
 import org.zanata.model.HLocale;
 import org.zanata.model.HPerson;
 import org.zanata.model.HProject;
@@ -60,8 +59,8 @@ import org.zanata.model.HProjectMember;
 import org.zanata.model.LocaleRole;
 import org.zanata.model.ProjectRole;
 import org.zanata.rest.service.GlossaryService;
+import org.zanata.seam.security.CurrentUser;
 import org.zanata.security.ZanataIdentity;
-import org.zanata.security.annotations.Authenticated;
 import org.zanata.service.ActivityService;
 import org.zanata.service.LocaleService;
 import org.zanata.service.VersionStateCache;
@@ -108,8 +107,7 @@ public class ProjectHomeAction extends AbstractSortAction
     @Inject
     private LocaleMemberDAO localeMemberDAO;
     @Inject
-    @Authenticated
-    private HAccount authenticatedAccount;
+    private CurrentUser currentUser;
     @Inject
     private ZanataIdentity identity;
     @Inject
@@ -231,7 +229,7 @@ public class ProjectHomeAction extends AbstractSortAction
                 getProjectVersions(),
                 input -> input != null ? input.getId(): null);
         return activityServiceImpl.findLatestVersionActivitiesByUser(
-                authenticatedAccount.getPerson().getId(),
+                currentUser.getPerson().getId(),
                 Lists.newArrayList(versionIds), 0, 1);
     }
 
@@ -366,11 +364,11 @@ public class ProjectHomeAction extends AbstractSortAction
     }
 
     public List<HLocale> getUserJoinedLocales(HProjectIteration version) {
-        if (authenticatedAccount == null) {
+        if (!currentUser.isLoggedIn()) {
             return Collections.emptyList();
         }
         List<HLocale> userJoinedLocales = Lists.newArrayList();
-        Long personId = authenticatedAccount.getPerson().getId();
+        Long personId = currentUser.getPerson().getId();
         for (HLocale supportedLocale : getSupportedLocale(version)) {
             if (localeMemberDAO.isLocaleMember(personId,
                     supportedLocale.getLocaleId())

--- a/server/services/src/main/java/org/zanata/dao/ProjectDAO.java
+++ b/server/services/src/main/java/org/zanata/dao/ProjectDAO.java
@@ -27,7 +27,6 @@ import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.annotation.Nullable;
 
-import com.google.common.annotations.VisibleForTesting;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.lucene.index.Term;
@@ -52,8 +51,8 @@ import org.zanata.model.HPerson;
 import org.zanata.model.HProject;
 import org.zanata.model.HProjectIteration;
 import org.zanata.model.ProjectRole;
+import org.zanata.seam.security.CurrentUser;
 import org.zanata.security.ZanataIdentity;
-import org.zanata.security.annotations.Authenticated;
 
 import static org.zanata.hibernate.search.IndexFieldLabels.FULL_SLUG_FIELD;
 
@@ -63,8 +62,8 @@ public class ProjectDAO extends AbstractDAOImpl<HProject, Long> {
     @SuppressFBWarnings(value = "SE_BAD_FIELD")
     @Inject @FullText
     private FullTextEntityManager entityManager;
-    @Inject @Authenticated
-    private HAccount authenticatedAccount;
+    @Inject
+    private CurrentUser currentUser;
     @Inject
     private ZanataIdentity identity;
 
@@ -72,8 +71,9 @@ public class ProjectDAO extends AbstractDAOImpl<HProject, Long> {
         super(HProject.class);
     }
 
-    public ProjectDAO(Session session) {
+    public ProjectDAO(Session session, CurrentUser currentUser) {
         super(HProject.class, session);
+        this.currentUser = currentUser;
     }
 
     public ProjectDAO(FullTextEntityManager entityManager, Session session,
@@ -96,8 +96,8 @@ public class ProjectDAO extends AbstractDAOImpl<HProject, Long> {
                     boolean filterOutActive, boolean filterOutReadOnly,
                     boolean filterOutObsolete) {
 
-        HPerson person = authenticatedAccount != null ?
-                authenticatedAccount.getPerson() : null;
+        HPerson person = currentUser.isLoggedIn() ?
+                currentUser.getPerson() : null;
 
         String condition =
                 constructFilterCondition(filterOutActive, filterOutReadOnly,
@@ -129,8 +129,8 @@ public class ProjectDAO extends AbstractDAOImpl<HProject, Long> {
 
     public int getFilterProjectSize(boolean filterOutActive,
             boolean filterOutReadOnly, boolean filterOutObsolete) {
-        HPerson person = authenticatedAccount != null ?
-                authenticatedAccount.getPerson() : null;
+        HPerson person = currentUser.isLoggedIn() ?
+                currentUser.getPerson() : null;
 
         String condition = constructFilterCondition(filterOutActive,
                 filterOutReadOnly, filterOutObsolete, person);
@@ -522,8 +522,4 @@ public class ProjectDAO extends AbstractDAOImpl<HProject, Long> {
         return ((Long) q.uniqueResult()).intValue();
     }
 
-    @VisibleForTesting
-    protected void setAuthenticatedAccount(HAccount authenticatedAccount) {
-        this.authenticatedAccount = authenticatedAccount;
-    }
 }

--- a/server/services/src/main/java/org/zanata/seam/security/CurrentUser.java
+++ b/server/services/src/main/java/org/zanata/seam/security/CurrentUser.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018, Red Hat, Inc. and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.zanata.seam.security;
+
+import java.io.Serializable;
+import javax.annotation.Nullable;
+
+import org.zanata.model.HAccount;
+import org.zanata.model.HPerson;
+
+/**
+ * @author Sean Flanigan <a href="mailto:sflaniga@redhat.com">sflaniga@redhat.com</a>
+ */
+public interface CurrentUser extends Serializable {
+    @Nullable
+    HAccount getAccount();
+
+    default boolean isLoggedIn() {
+        return getAccount() != null;
+    }
+
+    default @Nullable HPerson getPerson() {
+        HAccount acc = getAccount();
+        return acc != null ? acc.getPerson() : null;
+    }
+
+    default @Nullable String getUsername() {
+        HAccount acc = getAccount();
+        return acc != null ? acc.getUsername() : null;
+    }
+}

--- a/server/services/src/main/java/org/zanata/seam/security/CurrentUserImpl.java
+++ b/server/services/src/main/java/org/zanata/seam/security/CurrentUserImpl.java
@@ -22,7 +22,7 @@ package org.zanata.seam.security;
 
 import javax.annotation.Nullable;
 import javax.annotation.PostConstruct;
-import javax.enterprise.context.SessionScoped;
+import javax.enterprise.context.RequestScoped;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
@@ -33,7 +33,7 @@ import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 /**
  * @author Sean Flanigan <a href="mailto:sflaniga@redhat.com">sflaniga@redhat.com</a>
  */
-@SessionScoped
+@RequestScoped
 public class CurrentUserImpl implements CurrentUser {
     @SuppressFBWarnings("SE_BAD_FIELD")
     @Inject
@@ -44,14 +44,13 @@ public class CurrentUserImpl implements CurrentUser {
     @PostConstruct
     private void resolve() {
         // Note: the Dependent-scoped HAccount will be destroyed when this
-        // bean is destroyed (SessionScoped, thus when session is destroyed).
+        // (RequestScoped) bean is destroyed.
         // Ref: https://rmannibucau.wordpress.com/2015/03/02/cdi-and-instance-3-pitfalls-you-need-to-know/
         account = accountInstance.get();
     }
 
     /**
-     * Note that the HAccount will be null if the user is not authenticated,
-     * and will generally be disconnected from the Hibernate session.
+     * Note that the HAccount will be null if the user is not authenticated.
      */
     @Nullable
     @Override

--- a/server/services/src/main/java/org/zanata/seam/security/CurrentUserImpl.java
+++ b/server/services/src/main/java/org/zanata/seam/security/CurrentUserImpl.java
@@ -20,8 +20,8 @@
  */
 package org.zanata.seam.security;
 
-import java.io.Serializable;
 import javax.annotation.Nullable;
+import javax.annotation.PostConstruct;
 import javax.enterprise.context.SessionScoped;
 import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
@@ -38,12 +38,25 @@ public class CurrentUserImpl implements CurrentUser {
     @SuppressFBWarnings("SE_BAD_FIELD")
     @Inject
     @Authenticated
-    private Instance<HAccount> account;
+    private Instance<HAccount> accountInstance;
+    private HAccount account;
 
+    @PostConstruct
+    private void resolve() {
+        // Note: the Dependent-scoped HAccount will be destroyed when this
+        // bean is destroyed (SessionScoped, thus when session is destroyed).
+        // Ref: https://rmannibucau.wordpress.com/2015/03/02/cdi-and-instance-3-pitfalls-you-need-to-know/
+        account = accountInstance.get();
+    }
+
+    /**
+     * Note that the HAccount will be null if the user is not authenticated,
+     * and will generally be disconnected from the Hibernate session.
+     */
     @Nullable
     @Override
     public HAccount getAccount() {
-        return account.get();
+        return account;
     }
 
 }

--- a/server/services/src/main/java/org/zanata/seam/security/CurrentUserImpl.java
+++ b/server/services/src/main/java/org/zanata/seam/security/CurrentUserImpl.java
@@ -21,9 +21,7 @@
 package org.zanata.seam.security;
 
 import javax.annotation.Nullable;
-import javax.annotation.PostConstruct;
 import javax.enterprise.context.RequestScoped;
-import javax.enterprise.inject.Instance;
 import javax.inject.Inject;
 
 import org.zanata.model.HAccount;
@@ -38,16 +36,10 @@ public class CurrentUserImpl implements CurrentUser {
     @SuppressFBWarnings("SE_BAD_FIELD")
     @Inject
     @Authenticated
-    private Instance<HAccount> accountInstance;
+    // Note: the Dependent-scoped HAccount bean is bound to the lifecycle of
+    // this (RequestScoped) bean.
+    // Ref: https://rmannibucau.wordpress.com/2015/03/02/cdi-and-instance-3-pitfalls-you-need-to-know/
     private HAccount account;
-
-    @PostConstruct
-    private void resolve() {
-        // Note: the Dependent-scoped HAccount will be destroyed when this
-        // (RequestScoped) bean is destroyed.
-        // Ref: https://rmannibucau.wordpress.com/2015/03/02/cdi-and-instance-3-pitfalls-you-need-to-know/
-        account = accountInstance.get();
-    }
 
     /**
      * Note that the HAccount will be null if the user is not authenticated.

--- a/server/services/src/main/java/org/zanata/seam/security/CurrentUserImpl.java
+++ b/server/services/src/main/java/org/zanata/seam/security/CurrentUserImpl.java
@@ -1,0 +1,49 @@
+/*
+ * Copyright 2018, Red Hat, Inc. and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.zanata.seam.security;
+
+import java.io.Serializable;
+import javax.annotation.Nullable;
+import javax.enterprise.context.SessionScoped;
+import javax.enterprise.inject.Instance;
+import javax.inject.Inject;
+
+import org.zanata.model.HAccount;
+import org.zanata.security.annotations.Authenticated;
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+
+/**
+ * @author Sean Flanigan <a href="mailto:sflaniga@redhat.com">sflaniga@redhat.com</a>
+ */
+@SessionScoped
+public class CurrentUserImpl implements CurrentUser {
+    @SuppressFBWarnings("SE_BAD_FIELD")
+    @Inject
+    @Authenticated
+    private Instance<HAccount> account;
+
+    @Nullable
+    @Override
+    public HAccount getAccount() {
+        return account.get();
+    }
+
+}

--- a/server/services/src/test/java/org/zanata/action/AccountMergeActionTest.java
+++ b/server/services/src/test/java/org/zanata/action/AccountMergeActionTest.java
@@ -24,12 +24,14 @@ import java.io.Serializable;
 import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 
+import org.jglue.cdiunit.AdditionalClasses;
 import org.jglue.cdiunit.InRequestScope;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.mockito.Mock;
 import org.zanata.dao.AccountDAO;
 import org.zanata.model.HAccount;
+import org.zanata.seam.security.CurrentUserImpl;
 import org.zanata.security.AuthenticationManager;
 import org.zanata.security.ZanataIdentity;
 import org.zanata.security.annotations.Authenticated;
@@ -54,6 +56,7 @@ import static org.zanata.test.EntityTestData.setId;
 @InRequestScope
 @InSessionScope
 @RunWith(CdiUnitRunner.class)
+@AdditionalClasses(CurrentUserImpl.class)
 public class AccountMergeActionTest implements Serializable {
     private static final long serialVersionUID = 1L;
 

--- a/server/services/src/test/java/org/zanata/action/NewProfileActionTest.java
+++ b/server/services/src/test/java/org/zanata/action/NewProfileActionTest.java
@@ -38,6 +38,7 @@ import javax.enterprise.inject.Produces;
 import javax.inject.Inject;
 
 import org.jboss.weld.exceptions.WeldException;
+import org.jglue.cdiunit.AdditionalClasses;
 import org.jglue.cdiunit.InRequestScope;
 import org.jglue.cdiunit.InSessionScope;
 import org.junit.Before;
@@ -58,6 +59,7 @@ import org.zanata.i18n.Messages;
 import org.zanata.model.HAccount;
 import org.zanata.model.HAccountActivationKey;
 import org.zanata.model.HPerson;
+import org.zanata.seam.security.CurrentUserImpl;
 import org.zanata.security.AuthenticationType;
 import org.zanata.security.SimplePrincipal;
 import org.zanata.security.ZanataIdentity;
@@ -74,6 +76,7 @@ import org.zanata.util.UrlUtil;
 @InRequestScope
 @InSessionScope
 @RunWith(CdiUnitRunner.class)
+@AdditionalClasses(CurrentUserImpl.class)
 public class NewProfileActionTest {
 
     @Mock(answer = Answers.RETURNS_DEEP_STUBS)

--- a/server/services/src/test/java/org/zanata/dao/ProjectDAOTest.java
+++ b/server/services/src/test/java/org/zanata/dao/ProjectDAOTest.java
@@ -8,6 +8,7 @@ import org.junit.Test;
 import org.zanata.ZanataDbunitJpaTest;
 import org.zanata.model.HPerson;
 import org.zanata.model.HProject;
+import org.zanata.seam.security.AltCurrentUser;
 import org.zanata.security.ZanataIdentity;
 
 import java.util.List;
@@ -17,8 +18,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 public class ProjectDAOTest extends ZanataDbunitJpaTest {
 
     private ProjectDAO dao;
-
     private PersonDAO personDAO;
+    private AltCurrentUser currentUser = new AltCurrentUser();
 
     @Override
     protected void prepareDBUnitOperations() {
@@ -37,7 +38,8 @@ public class ProjectDAOTest extends ZanataDbunitJpaTest {
 
     @Before
     public void setup() {
-        dao = new ProjectDAO((Session) getEm().getDelegate());
+        dao = new ProjectDAO((Session) getEm().getDelegate(),
+                currentUser);
         personDAO = new PersonDAO((Session) getEm().getDelegate());
     }
 
@@ -115,7 +117,7 @@ public class ProjectDAOTest extends ZanataDbunitJpaTest {
     @Test
     public void getOffsetListPrivateProject() {
         HPerson person = personDAO.findById(4L);
-        dao.setAuthenticatedAccount(person.getAccount());
+        currentUser.account = person.getAccount();
         List<HProject> projects = dao.getOffsetList(-1, -1, false, false, false);
         assertThat(projects).hasSize(5);
     }

--- a/server/services/src/test/java/org/zanata/dao/TextFlowStreamingDAOTest.java
+++ b/server/services/src/test/java/org/zanata/dao/TextFlowStreamingDAOTest.java
@@ -9,6 +9,7 @@ import org.zanata.common.LocaleId;
 import org.zanata.model.HProject;
 import org.zanata.model.HProjectIteration;
 import org.zanata.model.HTextFlow;
+import org.zanata.seam.security.AltCurrentUser;
 import org.zanata.util.CloseableIterator;
 import com.google.common.collect.Iterators;
 
@@ -43,7 +44,7 @@ public class TextFlowStreamingDAOTest extends ZanataDbunitJpaTest {
     public void setup() {
         dao = new TextFlowStreamingDAO(getEmf().getSessionFactory());
         Session session = getSession();
-        projectDao = new ProjectDAO(session);
+        projectDao = new ProjectDAO(session, new AltCurrentUser());
         projectIterDao = new ProjectIterationDAO(session);
     }
 

--- a/server/services/src/test/java/org/zanata/rest/service/FileServiceTest.java
+++ b/server/services/src/test/java/org/zanata/rest/service/FileServiceTest.java
@@ -49,6 +49,7 @@ import org.zanata.model.HProjectIteration;
 import org.zanata.model.type.TranslationSourceType;
 import org.zanata.rest.DocumentFileUploadForm;
 import org.zanata.rest.dto.resource.Resource;
+import org.zanata.seam.security.CurrentUserImpl;
 import org.zanata.security.ZanataIdentity;
 import org.zanata.security.annotations.Authenticated;
 import org.zanata.service.CopyTransService;
@@ -76,7 +77,7 @@ import static org.mockito.Mockito.when;
  *         href="mailto:damason@redhat.com">damason@redhat.com</a>
  */
 @RunWith(CdiUnitRunner.class)
-@AdditionalClasses({FileService.class})
+@AdditionalClasses({FileService.class, CurrentUserImpl.class})
 public class FileServiceTest extends ZanataTest {
     private static final String PROJ_SLUG = "project-slug";
     private static final String VER_SLUG = "version-slug";

--- a/server/services/src/test/java/org/zanata/rest/service/LocalesServiceTest.java
+++ b/server/services/src/test/java/org/zanata/rest/service/LocalesServiceTest.java
@@ -22,6 +22,7 @@ import org.zanata.model.Request;
 import org.zanata.model.type.RequestType;
 import org.zanata.rest.dto.LocaleMember;
 import org.zanata.rest.dto.LocalesResults;
+import org.zanata.seam.security.CurrentUserImpl;
 import org.zanata.security.ZanataIdentity;
 import org.zanata.security.annotations.Authenticated;
 import org.zanata.service.RequestService;
@@ -48,7 +49,7 @@ import static org.mockito.Mockito.when;
  * @author Alex Eng <a href="mailto:aeng@redhat.com">aeng@redhat.com</a>
  */
 @RunWith(CdiUnitRunner.class)
-@AdditionalClasses({ LocaleServiceImpl.class })
+@AdditionalClasses({ LocaleServiceImpl.class, CurrentUserImpl.class })
 public class LocalesServiceTest extends ZanataDbunitJpaTest implements
         StaticProducer {
 

--- a/server/services/src/test/java/org/zanata/rest/service/ProjectVersionTest.java
+++ b/server/services/src/test/java/org/zanata/rest/service/ProjectVersionTest.java
@@ -17,6 +17,7 @@ import org.apache.deltaspike.core.spi.scope.window.WindowContext;
 import org.dbunit.operation.DatabaseOperation;
 import org.hibernate.Session;
 import org.hibernate.search.jpa.FullTextEntityManager;
+import org.jglue.cdiunit.AdditionalClasses;
 import org.jglue.cdiunit.InRequestScope;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -33,6 +34,7 @@ import org.zanata.rest.dto.User;
 import org.zanata.rest.dto.VersionTMMerge;
 import org.zanata.rest.editor.service.TransMemoryMergeManager;
 import org.zanata.rest.editor.service.resource.UserResource;
+import org.zanata.seam.security.CurrentUserImpl;
 import org.zanata.seam.security.IdentityManager;
 import org.zanata.security.ZanataIdentity;
 import org.zanata.security.annotations.Authenticated;
@@ -52,6 +54,7 @@ import org.zanata.webtrans.shared.rpc.MergeRule;
  * @author Alex Eng <a href="aeng@redhat.com">aeng@redhat.com</a>
  */
 @RunWith(CdiUnitRunner.class)
+@AdditionalClasses(CurrentUserImpl.class)
 public class ProjectVersionTest extends ZanataDbunitJpaTest {
 
     @Inject

--- a/server/services/src/test/java/org/zanata/rest/service/ProjectsServiceTest.java
+++ b/server/services/src/test/java/org/zanata/rest/service/ProjectsServiceTest.java
@@ -12,6 +12,7 @@ import org.zanata.ZanataDbunitJpaTest;
 import org.zanata.jpa.FullText;
 import org.zanata.model.HAccount;
 import org.zanata.rest.dto.Project;
+import org.zanata.seam.security.CurrentUserImpl;
 import org.zanata.security.ZanataIdentity;
 import org.zanata.security.annotations.Authenticated;
 import org.zanata.test.CdiUnitRunner;
@@ -30,7 +31,7 @@ import static org.assertj.core.api.Assertions.assertThat;
  * @author Alex Eng <a href="mailto:aeng@redhat.com">aeng@redhat.com</a>
  */
 @RunWith(CdiUnitRunner.class)
-@AdditionalClasses({ ProjectsService.class })
+@AdditionalClasses({ ProjectsService.class, CurrentUserImpl.class})
 public class ProjectsServiceTest extends ZanataDbunitJpaTest {
     @Inject
     private ProjectsService projectsService;

--- a/server/services/src/test/java/org/zanata/rest/service/StatisticsServiceImplTest.java
+++ b/server/services/src/test/java/org/zanata/rest/service/StatisticsServiceImplTest.java
@@ -67,6 +67,7 @@ import org.zanata.rest.dto.stats.TranslationStatistics;
 import org.zanata.rest.dto.stats.contribution.BaseContributionStatistic;
 import org.zanata.rest.dto.stats.contribution.ContributionStatistics;
 import org.zanata.rest.dto.stats.contribution.LocaleStatistics;
+import org.zanata.seam.security.CurrentUserImpl;
 import org.zanata.security.ZanataIdentity;
 import org.zanata.security.annotations.Authenticated;
 import org.zanata.service.ValidationService;
@@ -87,7 +88,8 @@ import com.google.common.collect.Lists;
 @RunWith(CdiUnitRunner.class)
 @AdditionalClasses({ TranslationStateCacheImpl.class,
         DocumentStatisticLoader.class, HTextFlowTargetIdLoader.class,
-        HTextFlowTargetValidationLoader.class, VersionStatisticLoader.class })
+        HTextFlowTargetValidationLoader.class, VersionStatisticLoader.class,
+        CurrentUserImpl.class})
 @SupportDeltaspikeCore
 public class StatisticsServiceImplTest extends ZanataDbunitJpaTest {
 

--- a/server/services/src/test/java/org/zanata/rest/service/raw/AccountRawRestITCase.java
+++ b/server/services/src/test/java/org/zanata/rest/service/raw/AccountRawRestITCase.java
@@ -45,6 +45,7 @@ import org.zanata.rest.MediaTypes;
 import org.zanata.rest.ResourceRequest;
 import org.zanata.rest.dto.Account;
 import org.zanata.rest.service.AccountService;
+import org.zanata.seam.security.CurrentUserImpl;
 
 import static java.util.Arrays.asList;
 import static org.assertj.core.api.Assertions.assertThat;
@@ -72,7 +73,8 @@ public class AccountRawRestITCase extends RestTest {
                 AccountService.class,
                 HLocaleMember.class,
                 AccessDeniedExceptionMapper.class,
-                AccessDeniedExceptionHandler.class
+                AccessDeniedExceptionHandler.class,
+                CurrentUserImpl.class
         ));
         classes.addAll(classesWithDependenciesForRest());
         return classes;

--- a/server/services/src/test/java/org/zanata/rest/service/raw/VersionRawRestITCase.kt
+++ b/server/services/src/test/java/org/zanata/rest/service/raw/VersionRawRestITCase.kt
@@ -49,6 +49,7 @@ import org.zanata.rest.service.raw.ArquillianRest.beansXmlForRest
 import org.zanata.rest.service.raw.ArquillianRest.classesWithDependenciesForRest
 import org.zanata.rest.service.raw.ArquillianRest.libsForRest
 import org.zanata.rest.service.raw.ArquillianRest.jbossDeploymentStructureForRest
+import org.zanata.seam.security.CurrentUserImpl
 
 // TODO we don't want to add LifecycleArquillian to the deployment
 @RunWith(Arquillian::class)
@@ -61,7 +62,8 @@ class VersionRawRestITCase : RestTest() {
             val classes = listOf(
                     VersionRawRestITCase::class.java,
                     VersionService::class.java,
-                    HApplicationConfiguration::class.java
+                    HApplicationConfiguration::class.java,
+                    CurrentUserImpl::class.java
             )
             val war = ShrinkWrap
                     .create(WebArchive::class.java, "VersionService.war")

--- a/server/services/src/test/java/org/zanata/seam/security/AltCurrentUser.java
+++ b/server/services/src/test/java/org/zanata/seam/security/AltCurrentUser.java
@@ -1,0 +1,39 @@
+/*
+ * Copyright 2018, Red Hat, Inc. and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.zanata.seam.security;
+
+import javax.annotation.Nullable;
+import javax.enterprise.inject.Alternative;
+
+import org.zanata.model.HAccount;
+
+/**
+ * @author Sean Flanigan <a href="mailto:sflaniga@redhat.com">sflaniga@redhat.com</a>
+ */
+@Alternative
+public class AltCurrentUser implements CurrentUser {
+    public HAccount account;
+    @Nullable
+    @Override
+    public HAccount getAccount() {
+        return account;
+    }
+}

--- a/server/services/src/test/java/org/zanata/security/ZanataIdentityTest.java
+++ b/server/services/src/test/java/org/zanata/security/ZanataIdentityTest.java
@@ -16,6 +16,7 @@ import org.zanata.exception.NotLoggedInException;
 import org.zanata.model.HAccount;
 import org.zanata.model.HAccountRole;
 import org.zanata.model.HProjectIteration;
+import org.zanata.seam.security.CurrentUserImpl;
 import org.zanata.seam.security.IdentityManager;
 import org.zanata.security.annotations.Authenticated;
 import org.zanata.servlet.annotations.ContextPath;
@@ -35,7 +36,7 @@ import static org.zanata.util.PasswordUtil.generateSaltedHash;
 
 @RunWith(CdiUnitRunner.class)
 @SupportDeltaspikeCore
-@AdditionalClasses({SecurityFunctions.class})
+@AdditionalClasses({SecurityFunctions.class, CurrentUserImpl.class})
 public class ZanataIdentityTest extends ZanataJpaTest {
     private static final String username = "translator";
     private static final String apiKey = "d83882201764f7d339e97c4b087f0806";

--- a/server/services/src/test/java/org/zanata/service/impl/CopyTransServiceImplParameterizedTest.java
+++ b/server/services/src/test/java/org/zanata/service/impl/CopyTransServiceImplParameterizedTest.java
@@ -56,6 +56,7 @@ import org.zanata.model.HProjectIteration;
 import org.zanata.model.HTextFlow;
 import org.zanata.model.HTextFlowTarget;
 import org.zanata.model.type.TranslationSourceType;
+import org.zanata.seam.security.CurrentUserImpl;
 import org.zanata.security.ZanataIdentity;
 import org.zanata.security.annotations.Authenticated;
 import org.zanata.service.VersionLocaleKey;
@@ -105,7 +106,7 @@ import static org.zanata.test.rule.FunctionalTestRule.reentrant;
 @AdditionalClasses({ ParamTestCdiExtension.class, LocaleServiceImpl.class,
         TranslationMemoryServiceImpl.class, VersionStateCacheImpl.class,
         TranslationStateCacheImpl.class, ValidationServiceImpl.class,
-        TransactionUtilImpl.class, UrlUtil.class })
+        TransactionUtilImpl.class, UrlUtil.class, CurrentUserImpl.class })
 public class CopyTransServiceImplParameterizedTest {
 
     @ClassRule

--- a/server/services/src/test/java/org/zanata/service/impl/CopyTransServiceImplTest.java
+++ b/server/services/src/test/java/org/zanata/service/impl/CopyTransServiceImplTest.java
@@ -46,6 +46,7 @@ import org.zanata.model.HAccount;
 import org.zanata.model.HDocument;
 import org.zanata.model.HProject;
 import org.zanata.model.HProjectIteration;
+import org.zanata.seam.security.CurrentUserImpl;
 import org.zanata.security.ZanataIdentity;
 import org.zanata.security.annotations.Authenticated;
 import org.zanata.service.VersionLocaleKey;
@@ -74,7 +75,8 @@ import static org.zanata.model.HCopyTransOptions.ConditionRuleAction.IGNORE;
 @RunWith(CdiUnitRunner.class)
 @AdditionalClasses({ LocaleServiceImpl.class,
         TranslationMemoryServiceImpl.class, VersionStateCacheImpl.class,
-        TranslationStateCacheImpl.class, ValidationServiceImpl.class })
+        TranslationStateCacheImpl.class, ValidationServiceImpl.class,
+        CurrentUserImpl.class})
 public class CopyTransServiceImplTest extends ZanataDbunitJpaTest {
 
     @Inject

--- a/server/services/src/test/java/org/zanata/service/impl/CopyVersionServiceImplPerformanceTest.java
+++ b/server/services/src/test/java/org/zanata/service/impl/CopyVersionServiceImplPerformanceTest.java
@@ -63,6 +63,7 @@ import org.zanata.model.HLocale;
 import org.zanata.model.HProject;
 import org.zanata.model.HProjectIteration;
 import org.zanata.model.HTextFlowBuilder;
+import org.zanata.seam.security.CurrentUserImpl;
 import org.zanata.security.annotations.Authenticated;
 import org.zanata.service.EntityManagerFactoryRule;
 import org.zanata.service.MockInitialContextRule;
@@ -93,7 +94,9 @@ import static com.github.huangp.entityunit.entity.EntityCleaner.deleteAll;
         FileSystemPersistService.class,
         TranslationStateCache.class,
         VersionStateCacheImpl.class,
-        ValidationServiceImpl.class })
+        ValidationServiceImpl.class,
+        CurrentUserImpl.class
+})
 public class CopyVersionServiceImplPerformanceTest extends ZanataTest {
     private static final Logger log = LoggerFactory
             .getLogger(CopyVersionServiceImplPerformanceTest.class);

--- a/server/services/src/test/java/org/zanata/service/impl/CopyVersionServiceImplTest.java
+++ b/server/services/src/test/java/org/zanata/service/impl/CopyVersionServiceImplTest.java
@@ -65,6 +65,7 @@ import org.zanata.model.HTextFlowTargetHistory;
 import org.zanata.model.HTextFlowTargetReviewComment;
 import org.zanata.model.po.HPoTargetHeader;
 import org.zanata.model.type.TranslationSourceType;
+import org.zanata.seam.security.CurrentUserImpl;
 import org.zanata.security.ZanataCredentials;
 import org.zanata.security.ZanataIdentity;
 import com.google.common.collect.Lists;
@@ -87,7 +88,8 @@ import javax.transaction.UserTransaction;
 @AdditionalClasses({
         VersionStateCacheImpl.class,
         // needed by service locator
-        TransactionUtilImpl.class
+        TransactionUtilImpl.class,
+        CurrentUserImpl.class
 })
 public class CopyVersionServiceImplTest extends ZanataDbunitJpaTest {
     @Inject

--- a/server/services/src/test/java/org/zanata/service/impl/CopyVersionServiceImplTest.java
+++ b/server/services/src/test/java/org/zanata/service/impl/CopyVersionServiceImplTest.java
@@ -88,8 +88,7 @@ import javax.transaction.UserTransaction;
 @AdditionalClasses({
         VersionStateCacheImpl.class,
         // needed by service locator
-        TransactionUtilImpl.class,
-        CurrentUserImpl.class
+        TransactionUtilImpl.class
 })
 public class CopyVersionServiceImplTest extends ZanataDbunitJpaTest {
     @Inject

--- a/server/services/src/test/java/org/zanata/service/impl/GlossaryFileServiceImplTest.java
+++ b/server/services/src/test/java/org/zanata/service/impl/GlossaryFileServiceImplTest.java
@@ -52,6 +52,7 @@ import com.google.common.collect.Lists;
 import org.zanata.rest.dto.QualifiedName;
 import org.zanata.rest.service.GlossaryResource;
 import org.zanata.rest.service.GlossaryService;
+import org.zanata.seam.security.CurrentUserImpl;
 import org.zanata.security.ZanataIdentity;
 import org.zanata.security.annotations.Authenticated;
 import org.zanata.test.CdiUnitRunner;
@@ -68,7 +69,8 @@ import static org.assertj.core.api.Assertions.assertThat;
  */
 @RunWith(CdiUnitRunner.class)
 @AdditionalClasses({
-        LocaleServiceImpl.class
+        LocaleServiceImpl.class,
+        CurrentUserImpl.class
 })
 public class GlossaryFileServiceImplTest extends ZanataDbunitJpaTest {
 

--- a/server/services/src/test/java/org/zanata/service/impl/MergeTranslationsServiceImplTest.java
+++ b/server/services/src/test/java/org/zanata/service/impl/MergeTranslationsServiceImplTest.java
@@ -50,6 +50,7 @@ import org.zanata.model.HProjectIteration;
 import org.zanata.model.HTextFlow;
 import org.zanata.model.HTextFlowTarget;
 import org.zanata.model.type.TranslationSourceType;
+import org.zanata.seam.security.CurrentUserImpl;
 import org.zanata.security.ZanataIdentity;
 import org.zanata.security.annotations.Authenticated;
 import org.zanata.service.TransMemoryMergeService;
@@ -88,7 +89,8 @@ import static org.zanata.action.MergeTranslationsManager.MergeVersionKey.getKey;
         VersionStateCacheImpl.class,
         TranslationStateCacheImpl.class,
         // classes invoked via ServiceLocator (they won't get autowired by cdiunit
-        TransactionUtilImpl.class
+        TransactionUtilImpl.class,
+        CurrentUserImpl.class
 })
 public class MergeTranslationsServiceImplTest extends ZanataDbunitJpaTest {
 

--- a/server/services/src/test/java/org/zanata/service/impl/TransMemoryMergeServiceImplJpaTest.java
+++ b/server/services/src/test/java/org/zanata/service/impl/TransMemoryMergeServiceImplJpaTest.java
@@ -48,6 +48,7 @@ import org.zanata.model.tm.TransMemory;
 import org.zanata.model.tm.TransMemoryUnit;
 import org.zanata.model.tm.TransMemoryUnitVariant;
 import org.zanata.rest.dto.VersionTMMerge;
+import org.zanata.seam.security.CurrentUserImpl;
 import org.zanata.security.ZanataIdentity;
 import org.zanata.security.annotations.Authenticated;
 import org.zanata.service.TransMemoryMergeService;
@@ -66,7 +67,7 @@ import com.google.common.collect.Lists;
 @RunWith(CdiUnitRunner.class)
 @AdditionalClasses({ ProjectIterationDAO.class, TextFlowDAO.class,
         TransMemoryUnitDAO.class, LocaleServiceImpl.class,
-        TranslationMemoryServiceImpl.class })
+        TranslationMemoryServiceImpl.class, CurrentUserImpl.class })
 public class TransMemoryMergeServiceImplJpaTest extends ZanataJpaTest {
 
     @Inject

--- a/server/services/src/test/java/org/zanata/service/impl/TranslationServiceImplTest.java
+++ b/server/services/src/test/java/org/zanata/service/impl/TranslationServiceImplTest.java
@@ -41,6 +41,7 @@ import org.zanata.dao.AccountDAO;
 import org.zanata.model.HLocale;
 import org.zanata.model.HProject;
 import org.zanata.model.type.TranslationSourceType;
+import org.zanata.seam.security.CurrentUserImpl;
 import org.zanata.security.ZanataIdentity;
 import org.zanata.security.annotations.Authenticated;
 import org.zanata.service.LockManagerService;
@@ -67,7 +68,8 @@ import static org.zanata.service.TranslationService.TranslationResult;
 @RunWith(CdiUnitRunner.class)
 @AdditionalClasses({
         LocaleServiceImpl.class,
-        ValidationServiceImpl.class
+        ValidationServiceImpl.class,
+        CurrentUserImpl.class
 })
 public class TranslationServiceImplTest extends ZanataDbunitJpaTest {
 

--- a/server/services/src/test/java/org/zanata/service/impl/VersionGroupServiceImplTest.java
+++ b/server/services/src/test/java/org/zanata/service/impl/VersionGroupServiceImplTest.java
@@ -44,6 +44,7 @@ import org.zanata.model.HAccount;
 import org.zanata.model.HLocale;
 import org.zanata.model.HPerson;
 import org.zanata.model.HProjectIteration;
+import org.zanata.seam.security.CurrentUserImpl;
 import org.zanata.security.ZanataIdentity;
 import org.zanata.security.annotations.Authenticated;
 import org.zanata.service.VersionLocaleKey;
@@ -67,7 +68,8 @@ import static org.assertj.core.api.Assertions.assertThat;
 @AdditionalClasses({
         VersionStateCacheImpl.class,
         LocaleServiceImpl.class,
-        VersionStatisticLoader.class
+        VersionStatisticLoader.class,
+        CurrentUserImpl.class
 })
 public class VersionGroupServiceImplTest extends ZanataDbunitJpaTest {
 

--- a/server/services/src/test/java/org/zanata/webtrans/server/rpc/GetTransUnitListHandlerTest.java
+++ b/server/services/src/test/java/org/zanata/webtrans/server/rpc/GetTransUnitListHandlerTest.java
@@ -30,6 +30,7 @@ import org.zanata.jpa.FullText;
 import org.zanata.model.HAccount;
 import org.zanata.model.HLocale;
 import org.zanata.rest.service.ResourceUtils;
+import org.zanata.seam.security.CurrentUserImpl;
 import org.zanata.security.ZanataIdentity;
 import org.zanata.security.annotations.Authenticated;
 import org.zanata.service.LocaleService;
@@ -64,7 +65,8 @@ import javax.persistence.EntityManager;
  */
 @RunWith(CdiUnitRunner.class)
 @AdditionalClasses({ TranslationStateCacheImpl.class,
-        TextFlowSearchServiceImpl.class, ValidationServiceImpl.class })
+        TextFlowSearchServiceImpl.class, ValidationServiceImpl.class,
+        CurrentUserImpl.class })
 public class GetTransUnitListHandlerTest extends ZanataDbunitJpaTest {
     private static final org.slf4j.Logger log = org.slf4j.LoggerFactory
             .getLogger(GetTransUnitListHandlerTest.class);


### PR DESCRIPTION
I'm hoping this will help to get around the non-serialisable ValidatorImpl problem, which I suspect is caused by injecting Dependent-scoped `@Authenticated HAccount` into SessionScoped beans.

If this approach helps, we may need to use CurrentUser everywhere, but for now I've just converted some of the code to use CurrentUser instead of `@Authenticated HAccount`.