### PR TITLE
feat(ZNTA-2325): display syntax highlighting for focused translation item only

### DIFF
--- a/server/zanata-frontend/src/app/editor/components/TransUnitTranslationPanel.js
+++ b/server/zanata-frontend/src/app/editor/components/TransUnitTranslationPanel.js
@@ -263,7 +263,7 @@ export class TranslationItem extends React.Component {
       whiteSpace: 'pre-wrap',
       wordWrap: 'break-word'
     }
-    const syntaxHighlighter = this.props.syntaxOn
+    const syntaxHighlighter = (this.props.syntaxOn && selected)
       ? <SyntaxHighlighter
         language='html'
         style={atelierLakesideLight}


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2325

Small change to limit the syntax highlighting to the focused translation item.

##QA:
The syntax highlighting should now only display for the selected translation item.

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
