### PR TITLE
Run watch tasks on separate ports

### DIFF
--- a/server/docker/conf/zanata-config.cli
+++ b/server/docker/conf/zanata-config.cli
@@ -23,7 +23,7 @@ batch
 
 ## Allows the editor development server to use the docker server as a backend.
 ## The editor development server is run with `make watch` in zanata-frontend/src/editor
-/system-property="zanata.origin.whitelist":add(value="http://localhost:8000")
+/system-property="zanata.origin.whitelist":add(value="http://localhost:8000 http://localhost:8001")
 /system-property="virusScanner":add(value="DISABLED")
 
 # ==== cached connection manager ====

--- a/server/zanata-frontend/src/.eslintrc
+++ b/server/zanata-frontend/src/.eslintrc
@@ -23,3 +23,5 @@ rules:
     - 2   // count tabs as 2 characters (required, but we don't allow tabs)
     // allow JSX to exceed 80 characters (https://twitter.com/timtyrrell/status/689912501165658112)
     - { ignorePattern: "\\s*<" }
+
+  quotes: [2, "single", {"avoidEscape": true, "allowTemplateLiterals": true}]

--- a/server/zanata-frontend/src/README.md
+++ b/server/zanata-frontend/src/README.md
@@ -6,7 +6,7 @@ This module contains: User profile page, Glossary page, and Zanata side menu bar
 
 Navigate to `frontend`, run `make install`
 
-### To run in dev mode http://localhost:8000 (a HTTP server to serve index.html with webpack produced bundle.js)
+### To run in dev mode http://localhost:8000 or http://localhost:8001 (a HTTP server to serve index.html with webpack produced bundle.js)
 
 - need http://localhost:8080/zanata to run separately
 `make start`
@@ -94,7 +94,7 @@ Build and run a server: `watch-editor`.
 - Editor is available at [localhost:8080](http://localhost:8080)
    - the editor will be blank at the base URL, include the project-version to
      show content. The format is
-     localhost:8000/#/{project-slug}/{version-slug}/translate
+     localhost:8001/#/{project-slug}/{version-slug}/translate
  - Assumes a server is already serving the Zanata REST API.
 
 

--- a/server/zanata-frontend/src/scripts/dev-server.config.js
+++ b/server/zanata-frontend/src/scripts/dev-server.config.js
@@ -1,6 +1,6 @@
-module.exports = {
+module.exports = (port) => ({
   contentBase: 'dist/',
-  port: 8000,
+  port,
   historyApiFallback: {
     // serve the index file instead of 404, needed to load the app using
     // paths other than /
@@ -29,4 +29,4 @@ module.exports = {
     chunks: false,
     modules: false
   }
-}
+})

--- a/server/zanata-frontend/src/scripts/dev-server.js
+++ b/server/zanata-frontend/src/scripts/dev-server.js
@@ -15,8 +15,11 @@ const createConfig = require('../webpack.config.js')
 const devServerConfig = require('./dev-server.config.js')
 
 const isEditor = process.argv.indexOf('--editor') !== -1
+const port = isEditor ? 8001 : 8000
+const devRoot = `http://localhost:${port}`
+const zanataRoot = 'http://localhost:8080'
 
-const webpackConfig = createConfig({ buildtype: 'dev' })
+const webpackConfig = createConfig({ buildtype: 'dev' }, isEditor, port)
 
 fs.ensureDir('dist')
   .then(() => {
@@ -34,7 +37,7 @@ function runDevServer () {
     webpackConfig.entry = {
       'editor': [
         // for inline mode
-        'webpack-dev-server/client?http://localhost:8000/',
+        `webpack-dev-server/client?${devRoot}/`,
         // for hot module replacement (not currently enabled)
         // 'webpack/hot/dev-server',
         // the entry-point
@@ -44,32 +47,37 @@ function runDevServer () {
   } else {
     webpackConfig.entry = {
       'frontend': [
-        'webpack-dev-server/client?http://localhost:8000/',
+        `webpack-dev-server/client?${devRoot}/`,
         webpackConfig.entry.frontend
       ]
     }
   }
 
   const compiler = webpack(webpackConfig)
-  const server = new WebpackDevServer(compiler, devServerConfig)
+  const server = new WebpackDevServer(compiler, devServerConfig(port))
 
-  server.listen(8000, 'localhost', () => {
-    console.log('       Server: ' + c.green('http://localhost:8000'))
+  server.listen(port, 'localhost', () => {
+    console.log('       Server: ' +
+      c.green(`${devRoot}/{sub-path}`))
     if (isEditor) {
       console.log('URL structure: ' + c.cyan(
-        'http://localhost:8000/project/translate/' + c.bold('{project}') +
-        '/v/' + c.bold('{version}') + '/' + c.bold('{path/and/docId}') +
+        `${devRoot}/project/translate/` +
+        c.bold('{project}') +
+        '/v/' + c.bold('{version}') +
+        '/' + c.bold('{path/and/docId}') +
         '?lang=' + c.bold('{locale}')))
     } else {
       console.log('  Valid paths: ' + c.cyan([
-        '/explore',
-        '/glossary',
-        '/glossary/project/' + c.bold('{projectSlug}'),
-        '/languages',
-        '/profile/view/' + c.bold('{username}')].join('\n               ')))
+        `${devRoot}/explore`,
+        `${devRoot}/glossary`,
+        `${devRoot}/glossary/project/` + c.bold('{projectSlug}'),
+        `${devRoot}/languages`,
+        `${devRoot}/profile/view/` + c.bold('{username}')]
+        .join('\n               ')))
     }
+    console.log(`See also:      ${devRoot}/webpack-dev-server`)
     console.log('REST requests: ' + c.blue(
-      'http://localhost:8080/rest (you need to run zanata server)'))
+      `${zanataRoot}/rest (you need to run zanata server)`))
     console.log(c.magenta('Watch browser console for actions and errors.'))
     console.log(c.red('If you see errors, please fix them before you commit.'))
     console.log(c.yellow(

--- a/server/zanata-frontend/src/webpack.config.js
+++ b/server/zanata-frontend/src/webpack.config.js
@@ -7,7 +7,6 @@ var webpack = require('webpack')
 var autoprefixer = require('autoprefixer')
 var join = require('path').join
 var _ = require('lodash')
-var stylelint = require('stylelint')
 var postcssDiscardDuplicates = require('postcss-discard-duplicates')
 var ExtractTextPlugin = require('extract-text-webpack-plugin')
 var postcssImport = require('postcss-import')
@@ -116,8 +115,8 @@ module.exports = function (env) {
   var fullBuild = draft || prod
 
   require.extensions['.css'] = () => {
-    return;
-  };
+    return
+  }
 
   return dropUndef({
     entry: storybook ? undefined : dropUndef({
@@ -161,7 +160,7 @@ module.exports = function (env) {
           loader: 'tslint-loader',
           options: {
             failOnHint: !dev,
-            formatter: 'verbose',
+            formatter: 'verbose'
           }
         },
 
@@ -171,7 +170,7 @@ module.exports = function (env) {
           test: /\.(j|t)sx?$/,
           exclude: /node_modules/,
           include: join(__dirname, 'app'),
-          loader: 'awesome-typescript-loader',
+          loader: 'awesome-typescript-loader'
         },
 
         /* TODO:
@@ -228,10 +227,11 @@ module.exports = function (env) {
       // This makes it easier to see if watch has picked up changes yet.
       // https://github.com/webpack/webpack/issues/1499#issuecomment-155064216
       // There's probably a config option for this (stats?) but I can't find it.
-      function() {
-        this.plugin('watch-run', function(watching, callback) {
-            console.log('Begin compile at ' + new Date());
-            callback();
+      function () {
+        this.plugin('watch-run', function (watching, callback) {
+          // eslint-disable-next-line no-console
+          console.log('Begin compile at ' + new Date())
+          callback()
         })
       },
 

--- a/server/zanata-frontend/src/webpack.config.js
+++ b/server/zanata-frontend/src/webpack.config.js
@@ -71,8 +71,9 @@ var postCssLoader = {
  * More info:
  *   https://blog.flennik.com/the-fine-art-of-the-webpack-2-config-dc4d19d7f172
  */
-module.exports = function (env) {
+module.exports = function (env, isEditor, devServerPort) {
   var buildtype = env && env.buildtype || 'prod'
+  const distDir = isEditor ? 'dist.editor' : 'dist'
 
   /**
    * Development build.
@@ -126,13 +127,16 @@ module.exports = function (env) {
     }),
 
     output: storybook ? undefined : dropUndef({
-      path: join(__dirname, 'dist'),
+      path: join(__dirname, distDir),
       filename: fullBuild ? '[name].[chunkhash:8].cache.js' : '[name].js',
       chunkFilename: fullBuild ? '[name].[chunkhash:8].cache.js' : '[name].js',
       // includes comments in the generated code about where the code came from
       pathinfo: dev,
       // required for hot module replacement
-      publicPath: dev ? 'http://localhost:8000/' : undefined
+      // or is it https://github.com/webpack-contrib/style-loader/issues/55 ?
+      publicPath: dev
+      ? `http://localhost:${devServerPort}/`
+      : undefined
     }),
     module: {
       rules: _.compact([


### PR DESCRIPTION
Right now they don't actually work together (the last server to be started seems to clobber the first one), but at least I've parameterised the port and URL. Also, the console messages now include full URLs.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/708)
<!-- Reviewable:end -->
