### PR TITLE
fix(ZNTA-2382) minor editor button UX issues

### DIFF
--- a/server/zanata-frontend/src/frontend/app/editor/components/Button/index.css
+++ b/server/zanata-frontend/src/frontend/app/editor/components/Button/index.css
@@ -230,7 +230,7 @@ not conflict with the other frontend code
   font-size: calc(14/16)rem;
 }
 
-EditorButton:hover, html input[type=button], input[type=reset], input[type=submit] {
+.EditorButton:hover, html input[type=button], input[type=reset], input[type=submit] {
   cursor: pointer;
   -webkit-appearance: button;
 }

--- a/server/zanata-frontend/src/frontend/app/editor/components/Button/index.css
+++ b/server/zanata-frontend/src/frontend/app/editor/components/Button/index.css
@@ -229,3 +229,8 @@ not conflict with the other frontend code
   padding: var(--Button-padding-small);
   font-size: calc(14/16)rem;
 }
+
+EditorButton:hover, html input[type=button], input[type=reset], input[type=submit] {
+  cursor: pointer;
+  -webkit-appearance: button;
+}

--- a/server/zanata-frontend/src/frontend/app/editor/components/EditorSearchInput/index.css
+++ b/server/zanata-frontend/src/frontend/app/editor/components/EditorSearchInput/index.css
@@ -7,7 +7,6 @@
   margin-left: 0.75em;
   margin-right: 1em;
   display: inline-flex;
-  padding-bottom: 1rem;
   padding-top: 0.15rem;
   flex: 2 0 16rem;
 }

--- a/server/zanata-frontend/src/frontend/app/editor/containers/ControlsHeader.js
+++ b/server/zanata-frontend/src/frontend/app/editor/containers/ControlsHeader.js
@@ -66,7 +66,7 @@ export const ControlsHeader = ({
 }: props) => {
   return (
     <nav className="flex flex-wrapper u-bgHighest u-sPH-1-2 l--cf-of
-        u-sizeHeight-1_1-2">
+        controlHeader">
       <TranslatingIndicator gettextCatalog={gettextCatalog} />
       <div className="u-floatLeft"><PhraseStatusFilter /></div>
       {/* FIXME move InputEditorSearch into component. Layout component should

--- a/server/zanata-frontend/src/frontend/app/editor/containers/Root/index.css
+++ b/server/zanata-frontend/src/frontend/app/editor/containers/Root/index.css
@@ -992,6 +992,14 @@ label span.n1 {
   background-color: var(--Editor-color-dark);
 }
 
+.controlHeader {
+  min-height: 2.25rem !important;
+  padding-top: 0.2rem;
+}
+
+.TransUnit-panelFooterLeftNav .Button--snug .u-textMini {
+  vertical-align: text-top;
+}
 
 /**
  * Media Queries


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2382

- cursor: pointer added to editor buttons 
Please note: does not show on left-hand part of Translated/Needs Work buttons with dropdowns because they are disabled
- controlHeader height and padding fix - buttons now work on smaller screen sizes.
- text-alignment in TransUnit footer IconButtons - fixed so that it was tidier

<img width="585" alt="editobrns" src="https://user-images.githubusercontent.com/18179401/35801943-f1553a9e-0ab9-11e8-8d7a-5e41c9c82610.png">



## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/713)
<!-- Reviewable:end -->
