### PR TITLE
Update versions-maven-plugin; ignore prereleases

### DIFF
--- a/build-tools/src/main/resources/zanata-build-tools/versions-rules.xml
+++ b/build-tools/src/main/resources/zanata-build-tools/versions-rules.xml
@@ -3,6 +3,6 @@
          xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 http://mojo.codehaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
   <!-- Thanks to Michael Piefel and Philip Helger: https://stackoverflow.com/a/22174801/14379 -->
   <ignoreVersions>
-    <ignoreVersion type="regex">.*[-_\.](alpha|Alpha|ALPHA|b|beta|Beta|BETA|rc|RC|M|EA)[-_\.]?[0-9]*</ignoreVersion>
+    <ignoreVersion type="regex">.*[-_\.](alpha|Alpha|ALPHA|b|beta|Beta|BETA|cr|CR|rc|RC|M|EA)[-_\.]?[0-9]*</ignoreVersion>
   </ignoreVersions>
 </ruleset>

--- a/build-tools/src/main/resources/zanata-build-tools/versions-rules.xml
+++ b/build-tools/src/main/resources/zanata-build-tools/versions-rules.xml
@@ -1,0 +1,8 @@
+<ruleset comparisonMethod="maven"
+         xmlns="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0" xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xsi:schemaLocation="http://mojo.codehaus.org/versions-maven-plugin/rule/2.0.0 http://mojo.codehaus.org/versions-maven-plugin/xsd/rule-2.0.0.xsd">
+  <!-- Thanks to Michael Piefel and Philip Helger: https://stackoverflow.com/a/22174801/14379 -->
+  <ignoreVersions>
+    <ignoreVersion type="regex">.*[-_\.](alpha|Alpha|ALPHA|b|beta|Beta|BETA|rc|RC|M|EA)[-_\.]?[0-9]*</ignoreVersion>
+  </ignoreVersions>
+</ruleset>

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -596,7 +596,17 @@
       <plugin>
         <groupId>org.codehaus.mojo</groupId>
         <artifactId>versions-maven-plugin</artifactId>
-        <version>2.2</version>
+        <version>2.5</version>
+        <configuration>
+          <rulesUri>classpath:///zanata-build-tools/versions-rules.xml</rulesUri>
+        </configuration>
+        <dependencies>
+          <dependency>
+            <groupId>org.zanata</groupId>
+            <artifactId>build-tools</artifactId>
+            <version>${project.version}</version>
+          </dependency>
+        </dependencies>
       </plugin>
 
       <plugin>


### PR DESCRIPTION
This will allow us to generate a report for outdated dependencies, eg
```
./mvnw --batch-mode --threads 1 \
    -DallowMajorUpdates=false \
    versions:display-plugin-updates \
    versions:display-dependency-updates \
    versions:display-property-updates
```
or perhaps attempt automatic upgrades with something a bit like this (see also https://www.dependencies.io/ - Java support "coming soon"):
```
./mvnw --batch-mode --threads 1 \
    -DallowMajorUpdates=false \
    versions:update-properties \
    versions:use-latest-versions
```

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/727)
<!-- Reviewable:end -->
