### PR TITLE
Revert "Update Kotlin to 1.2.21"

### DIFF
--- a/server/pom.xml
+++ b/server/pom.xml
@@ -22,7 +22,7 @@
     <byteman.version>2.1.2</byteman.version>
     <failsafe.skipAfterFailureCount>10</failsafe.skipAfterFailureCount>
     <failsafe.rerunFailingTestsCount>0</failsafe.rerunFailingTestsCount>
-    <kotlin.version>1.2.21</kotlin.version>
+    <kotlin.version>1.2.0</kotlin.version>
     <kotlin.compiler.incremental>true</kotlin.compiler.incremental>
     <kotlin.compiler.jvmTarget>1.8</kotlin.compiler.jvmTarget>
 <!-- We can use these if we don't want the lang/API version set by the compiler version:


### PR DESCRIPTION
Reverts zanata/zanata-platform#726

For some reason the Kotlin upgrade breaks rundev:

`org.hibernate.boot.MappingException: Unable to resolve explicitly named mapping-file : META-INF/orm.xml : origin(META-INF/orm.xml)`

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/zanata/zanata-platform/728)
<!-- Reviewable:end -->
