### PR TITLE
fix: controlled text input components enforce maxLength prop

### DIFF
--- a/server/zanata-frontend/src/app/components/EditableText/index.js
+++ b/server/zanata-frontend/src/app/components/EditableText/index.js
@@ -26,6 +26,10 @@ class EditableText extends Component {
      */
     editing: PropTypes.bool,
     /**
+     * Maximum length of text field. <input> 'maxlength' attribute
+     */
+    maxLength: PropTypes.number,
+    /**
      * Placeholder
      */
     placeholder: PropTypes.string,
@@ -67,6 +71,7 @@ class EditableText extends Component {
       emptyReadOnlyText = '',
       placeholder = '',
       title,
+      maxLength,
       ...props
     } = this.props
 
@@ -78,6 +83,7 @@ class EditableText extends Component {
           {...props}
           autoFocus={this.state.focus}
           onBlur={this.handleBlur}
+          maxLength={maxLength}
           placeholder={placeholder}
           value={children}
         />

--- a/server/zanata-frontend/src/app/components/TextInput/index.js
+++ b/server/zanata-frontend/src/app/components/TextInput/index.js
@@ -157,6 +157,7 @@ class TextInput extends Component {
       autoFocus,
       editable = true,
       keyboardType = 'default',
+      maxLength,
       maxNumberOfLines,
       multiline = false,
       numberOfLines = 2,
@@ -207,6 +208,7 @@ class TextInput extends Component {
       onFocus: this._onFocus,
       onSelect: onSelectionChange && this._onSelectionChange,
       onKeyDown: (onKeyDown) && this._onKeyDown,
+      maxLength,
       placeholder,
       readOnly: !editable,
       value


### PR DESCRIPTION
JIRA issue URL: n/a

Two controlled input components in the frontend were not passing the maxLength prop to their <input> tag

##QA
Affected inputs that should now enforce a max length include:
- Glossary entry and new entry modal inputs
- Explore page search entry
- Review Criteria input page #672 

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
