### PR TITLE
fix(ZNTA-2410) width of close buttons in GWT now handles text correctly

### DIFF
--- a/server/gwt-editor/src/main/java/org/zanata/webtrans/client/resources/UiMessages.java
+++ b/server/gwt-editor/src/main/java/org/zanata/webtrans/client/resources/UiMessages.java
@@ -192,7 +192,7 @@ public interface UiMessages extends Messages {
     @DefaultMessage("Glossary Details")
     String glossaryDetails();
 
-    @DefaultMessage("Dismiss")
+    @DefaultMessage("Close")
     String dismiss();
 
     @DefaultMessage("Last modified on {0}")

--- a/server/gwt-editor/src/main/java/org/zanata/webtrans/client/resources/UiMessages.java
+++ b/server/gwt-editor/src/main/java/org/zanata/webtrans/client/resources/UiMessages.java
@@ -192,9 +192,6 @@ public interface UiMessages extends Messages {
     @DefaultMessage("Glossary Details")
     String glossaryDetails();
 
-    @DefaultMessage("Close")
-    String dismiss();
-
     @DefaultMessage("Last modified on {0}")
     String lastModifiedOn(String date);
 

--- a/server/gwt-editor/src/main/java/org/zanata/webtrans/client/view/GlossaryDetailsView.java
+++ b/server/gwt-editor/src/main/java/org/zanata/webtrans/client/view/GlossaryDetailsView.java
@@ -50,7 +50,7 @@ public class GlossaryDetailsView extends DialogBox
     ListBox entryListBox;
 
     @UiField(provided = true)
-    DialogBoxCloseButton dismissButton;
+    DialogBoxCloseButton closeButton;
 
     @UiField
     Anchor link;
@@ -65,12 +65,11 @@ public class GlossaryDetailsView extends DialogBox
         setGlassEnabled(true);
         this.messages = messages;
 
-        dismissButton = new DialogBoxCloseButton(this);
+        closeButton = new DialogBoxCloseButton(this);
 
         HTMLPanel container = uiBinder.createAndBindUi(this);
         getCaption().setText(messages.glossaryDetails());
         setWidget(container);
-        dismissButton.setText(messages.dismiss());
     }
 
     public void hide() {

--- a/server/gwt-editor/src/main/java/org/zanata/webtrans/client/view/GlossaryDetailsView.ui.xml
+++ b/server/gwt-editor/src/main/java/org/zanata/webtrans/client/view/GlossaryDetailsView.ui.xml
@@ -18,7 +18,7 @@
   </ui:style>
 
   <g:HTMLPanel styleName="new-zanata">
-    <fui:DialogBoxCloseButton ui:field="dismissButton" />
+    <fui:DialogBoxCloseButton ui:field="closeButton" />
     <div class="l__wrapper l--limit-medium {style.container} l--scroll-auto">
       <span class="epsilon">Entries</span>
       <g:ListBox ui:field='entryListBox' />

--- a/server/zanata-frontend/src/app/styles/legacy.less
+++ b/server/zanata-frontend/src/app/styles/legacy.less
@@ -98,8 +98,8 @@
     right: 5px;
     float: right;
     clear: both;
-    width: 5%;
-    margin-left: 95%;
+    width: 6%;
+    margin-left: 94%;
   }
   .revision__box {
     display: flex !important;


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2410

Increased width of close/cancel buttons in GWT to handle text correctly. The cancel text was overriding the button width.

### Fixes
<img width="1348" alt="close" src="https://user-images.githubusercontent.com/18179401/36655445-7614bd7c-1b0e-11e8-978c-5401becd1353.png">

<img width="840" alt="cancel" src="https://user-images.githubusercontent.com/18179401/36655439-72d1ac4c-1b0e-11e8-9a72-6aa44f912dc1.png">


## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
