### PR TITLE
fix(ZNTA-193): Prevent user exceeding system filename length

### DIFF
--- a/server/services/src/main/java/org/zanata/service/impl/DocumentServiceImpl.java
+++ b/server/services/src/main/java/org/zanata/service/impl/DocumentServiceImpl.java
@@ -44,6 +44,7 @@ import org.zanata.dao.ProjectIterationDAO;
 import org.zanata.events.DocStatsEvent;
 import org.zanata.events.DocumentLocaleKey;
 import org.zanata.events.DocumentUploadedEvent;
+import org.zanata.exception.ZanataServiceException;
 import org.zanata.model.type.WebhookType;
 import org.zanata.i18n.Messages;
 import org.zanata.lock.Lock;
@@ -175,6 +176,10 @@ public class DocumentServiceImpl implements DocumentService {
             // TODO check that entity name matches id parameter
             document = new HDocument(sourceDoc.getName(),
                     sourceDoc.getContentType(), hLocale);
+            if(document.getPath().length() + document.getName().length() > 255) {
+                throw new ZanataServiceException(
+                        msgs.get("jsf.upload.FilenameIsTooLarge"));
+            }
             document.setProjectIteration(hProjectIteration);
             hProjectIteration.getDocuments().put(docId, document);
             document = documentDAO.makePersistent(document);

--- a/server/services/src/main/resources/messages.properties
+++ b/server/services/src/main/resources/messages.properties
@@ -709,6 +709,7 @@ jsf.upload.ChangeProjectTypeInstructions=A maintainer of this project can set or
 jsf.upload.DragDropOrBrowseFiles=Drag and drop or {0}browse files{1}
 jsf.upload.MaximumFileSize=Maximum file size is {0}MB
 jsf.upload.MaximumNumberOfFiles=Maximum number of files is {0}
+jsf.upload.MaximumFilenameLength=File names (including path) cannot be longer than 255 characters
 ! the variable is a comma-separated list of file extensions that can be uploaded
 jsf.upload.AcceptedFileTypes=Accepted: {0}
 jsf.upload.AdvancedSettings=Advanced settings
@@ -729,6 +730,7 @@ jsf.upload.ConfirmStopUploading=Do you really want to stop uploading files?
 jsf.upload.ConfirmInterruptByLeavingPage=Do you really want to interrupt your uploading files by leaving this page?
 jsf.upload.NotSupportedFileType="{filename}" is not a supported file type.
 jsf.upload.FileIsTooLarge="{filename}" is too large.
+jsf.upload.FilenameIsTooLarge=Maximum file path size exceeded
 jsf.upload.TooManyFiles=Too many files. You can upload more files after the current files are uploaded.
 jsf.upload.SessionTimedOut=Your session has timed out. Please log in again before uploading files.
 jsf.upload.ServerStoppedResponding=Some files could not be uploaded. The server stopped responding.

--- a/server/zanata-war/src/main/webapp/resources/jQuery-File-Upload/9_5_6/js/jquery.fileupload-ui.js
+++ b/server/zanata-war/src/main/webapp/resources/jQuery-File-Upload/9_5_6/js/jquery.fileupload-ui.js
@@ -144,7 +144,8 @@
                             substituteError('File is too large', options.i18n('jsf.upload.FileIsTooLarge', {filename: file.name})); // "{filename}" is too large.
                             substituteError('Maximum number of files exceeded',
                                 options.i18n('jsf.upload.TooManyFiles')); // Too many files. You can upload more files after the current files are uploaded.
-
+                            substituteError('Maximum file path size exceeded',
+                                options.i18n('jsf.upload.FilenameIsTooLarge')); // Maximum file path size exceeded
                             widget._showSingletonError(file.error);
                         } else {
                             successFiles.push(file);

--- a/server/zanata-war/src/main/webapp/resources/jQuery-File-Upload/9_5_6/js/jquery.fileupload-validate.js
+++ b/server/zanata-war/src/main/webapp/resources/jQuery-File-Upload/9_5_6/js/jquery.fileupload-validate.js
@@ -70,7 +70,8 @@
                 maxNumberOfFiles: 'Maximum number of files exceeded',
                 acceptFileTypes: 'File type not allowed',
                 maxFileSize: 'File is too large',
-                minFileSize: 'File is too small'
+                minFileSize: 'File is too small',
+                maxFilePathSize: 'Maximum file path size exceeded'
             }
         },
 
@@ -100,6 +101,8 @@
                 } else if ($.type(fileSize) === 'number' &&
                         fileSize < options.minFileSize) {
                     file.error = settings.i18n('minFileSize');
+                } else if (file.path.length + file.name.length > 255) {
+                    file.error = settings.i18n('maxNumberOfFiles');
                 } else {
                     delete file.error;
                 }

--- a/server/zanata-war/src/main/webapp/resources/zanata/multi-file-upload.xhtml
+++ b/server/zanata-war/src/main/webapp/resources/zanata/multi-file-upload.xhtml
@@ -114,6 +114,9 @@ site: http://www.fsf.org.
           <li data-key="jsf.upload.TooManyFiles">
             #{msgs['jsf.upload.TooManyFiles']}
           </li>
+          <li data-key="jsf.upload.FilenameIsTooLarge">
+            #{msgs['jsf.upload.FilenameIsTooLarge']}
+          </li>
           <li data-key="jsf.upload.SessionTimedOut">
             #{msgs['jsf.upload.SessionTimedOut']}
           </li>
@@ -216,7 +219,7 @@ site: http://www.fsf.org.
               <div id="#{cc.clientId}-fileupload-advanced"
                 class="l--pad-all-half bg--pop-higher is-hidden">
                 <label for="#filepath">#{msgs['jsf.upload.FilePath']}</label>
-                <input type="text" id="filepath" name="filepath"/>
+                <input type="text" id="filepath" maxlength="250" name="filepath"/>
                 <!-- Source language is currently ignored by the server.
                 <label for="filelang">Source Language</label>
                 <select name="filelang" id="filelang">


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-193

Prevent a user specifying a file path exceeding the standard 255 characters.

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
