### PR TITLE
feat(ZNTA-2401): editor user mode display (Translating/Viewing/Reviewing)

### DIFF
--- a/server/zanata-frontend/src/app/editor/components/TranslatingIndicator/TranslatingIndicator.test.js
+++ b/server/zanata-frontend/src/app/editor/components/TranslatingIndicator/TranslatingIndicator.test.js
@@ -7,7 +7,7 @@ import { IntlProvider } from 'react-intl'
 
 /* global describe expect it */
 describe('TranslatingIndicator', () => {
-  it('renders default markup', () => {
+  it('renders default viewing markup', () => {
     const permissions = {
       reviewer: false,
       translator: false
@@ -21,9 +21,57 @@ describe('TranslatingIndicator', () => {
       /* eslint-disable max-len */
       <button className='Link--neutral u-sPV-1-6 u-floatLeft u-sizeHeight-1_1-2 u-sMR-1-4'>
         <Row>
-          <Icon name='translate' className='s2' /> <span
+          <Icon name='locked' className='s2 u-textDanger' /> <span
             className='u-ltemd-hidden TransIndicator u-sMR-1-4'>
             <span>Viewing</span>
+          </span>
+        </Row>
+      </button>
+      /* eslint-enable max-len */
+    )
+    expect(actual).toEqual(expected)
+  })
+  it('renders reviewer markup', () => {
+    const permissions = {
+      reviewer: true,
+      translator: false
+    }
+    const actual = ReactDOMServer.renderToStaticMarkup(
+      <IntlProvider locale='en'>
+        <TranslatingIndicator permissions={permissions} />
+      </IntlProvider>)
+
+    const expected = ReactDOMServer.renderToStaticMarkup(
+      /* eslint-disable max-len */
+      <button className='Link--neutral u-sPV-1-6 u-floatLeft u-sizeHeight-1_1-2 u-sMR-1-4'>
+        <Row>
+          <Icon name='review' className='s2' /> <span
+            className='u-ltemd-hidden TransIndicator u-sMR-1-4'>
+            <span>Reviewing</span>
+          </span>
+        </Row>
+      </button>
+      /* eslint-enable max-len */
+    )
+    expect(actual).toEqual(expected)
+  })
+  it('renders translator markup', () => {
+    const permissions = {
+      reviewer: false,
+      translator: true
+    }
+    const actual = ReactDOMServer.renderToStaticMarkup(
+      <IntlProvider locale='en'>
+        <TranslatingIndicator permissions={permissions} />
+      </IntlProvider>)
+
+    const expected = ReactDOMServer.renderToStaticMarkup(
+      /* eslint-disable max-len */
+      <button className='Link--neutral u-sPV-1-6 u-floatLeft u-sizeHeight-1_1-2 u-sMR-1-4'>
+        <Row>
+          <Icon name='translate' className='s2' /> <span
+            className='u-ltemd-hidden TransIndicator u-sMR-1-4'>
+            <span>Translating</span>
           </span>
         </Row>
       </button>

--- a/server/zanata-frontend/src/app/editor/components/TranslatingIndicator/TranslatingIndicator.test.js
+++ b/server/zanata-frontend/src/app/editor/components/TranslatingIndicator/TranslatingIndicator.test.js
@@ -8,14 +8,13 @@ import { IntlProvider } from 'react-intl'
 /* global describe expect it */
 describe('TranslatingIndicator', () => {
   it('renders default markup', () => {
-    const gettextCatalog = {
-      getString: (key) => {
-        return key
-      }
+    const permissions = {
+      reviewer: false,
+      translator: false
     }
     const actual = ReactDOMServer.renderToStaticMarkup(
       <IntlProvider locale='en'>
-        <TranslatingIndicator gettextCatalog={gettextCatalog} />
+        <TranslatingIndicator permissions={permissions} />
       </IntlProvider>)
 
     const expected = ReactDOMServer.renderToStaticMarkup(
@@ -24,7 +23,7 @@ describe('TranslatingIndicator', () => {
         <Row>
           <Icon name='translate' className='s2' /> <span
             className='u-ltemd-hidden TransIndicator u-sMR-1-4'>
-            <span>Translating</span>
+            <span>Viewing</span>
           </span>
         </Row>
       </button>

--- a/server/zanata-frontend/src/app/editor/components/TranslatingIndicator/index.js
+++ b/server/zanata-frontend/src/app/editor/components/TranslatingIndicator/index.js
@@ -32,23 +32,45 @@ import { FormattedMessage } from 'react-intl'
  */
 class TranslatingIndicator extends React.Component {
   static propTypes = {
-    // DO NOT RENAME, the translation string extractor looks specifically
-    // for gettextCatalog.getString when generating the translation template.
-    gettextCatalog: PropTypes.shape({
-      getString: PropTypes.func.isRequired
+    permissions: PropTypes.shape({
+      reviewer: PropTypes.bool.isRequired,
+      translator: PropTypes.bool.isRequired
     }).isRequired
   }
 
   render () {
+    // These need to be translated individually for context
+    const reviewingMessage = (
+      <FormattedMessage id='TranslatingIndicator.reviewing'
+        description={'Indicator of editor reviewing mode'}
+        defaultMessage='Reviewing' />
+    )
+    const translatingMessage = (
+      <FormattedMessage id='TranslatingIndicator.translating'
+        description={'Indicator of editor translating mode'}
+        defaultMessage='Translating' />
+    )
+    const viewingMessage = (
+      <FormattedMessage id='TranslatingIndicator.viewing'
+        description={'Indicator of editor viewing mode'}
+        defaultMessage='Viewing' />
+    )
+    const modeMessage = () => {
+      if (this.props.permissions.reviewer === true) {
+        return reviewingMessage
+      } else if (this.props.permissions.translator === true) {
+        return translatingMessage
+      } else {
+        return viewingMessage
+      }
+    }
     return (
       /* eslint-disable max-len */
       <button className='Link--neutral u-sPV-1-6 u-floatLeft u-sizeHeight-1_1-2 u-sMR-1-4'>
         <Row>
           <Icon name='translate' className='s2' /> <span
             className='u-ltemd-hidden TransIndicator u-sMR-1-4'>
-            <FormattedMessage id='TranslatingIndicator.translating'
-              description={'Indicator of editor translating mode'}
-              defaultMessage='Translating' />
+            {modeMessage()}
           </span>
         </Row>
       </button>

--- a/server/zanata-frontend/src/app/editor/components/TranslatingIndicator/index.js
+++ b/server/zanata-frontend/src/app/editor/components/TranslatingIndicator/index.js
@@ -39,6 +39,7 @@ class TranslatingIndicator extends React.Component {
   }
 
   render () {
+    const { permissions } = this.props
     // These need to be translated individually for context
     const reviewingMessage = (
       <FormattedMessage id='TranslatingIndicator.reviewing'
@@ -55,22 +56,30 @@ class TranslatingIndicator extends React.Component {
         description={'Indicator of editor viewing mode'}
         defaultMessage='Viewing' />
     )
-    const modeMessage = () => {
-      if (this.props.permissions.reviewer === true) {
-        return reviewingMessage
-      } else if (this.props.permissions.translator === true) {
-        return translatingMessage
-      } else {
-        return viewingMessage
-      }
-    }
+    const modeMessage = (
+        permissions.reviewer
+        ? reviewingMessage : permissions.translator
+        ? translatingMessage
+        : viewingMessage
+    )
+    const iconName = (
+        permissions.reviewer
+          ? 'review' : permissions.translator
+          ? 'translate'
+          : 'locked'
+    )
+    const iconStyle = (
+      permissions.reviewer || permissions.translator
+          ? 's2'
+          : 's2 u-textDanger'
+    )
     return (
       /* eslint-disable max-len */
       <button className='Link--neutral u-sPV-1-6 u-floatLeft u-sizeHeight-1_1-2 u-sMR-1-4'>
         <Row>
-          <Icon name='translate' className='s2' /> <span
+          <Icon name={iconName} className={iconStyle} /> <span
             className='u-ltemd-hidden TransIndicator u-sMR-1-4'>
-            {modeMessage()}
+            {modeMessage}
           </span>
         </Row>
       </button>

--- a/server/zanata-frontend/src/app/editor/containers/ControlsHeader.js
+++ b/server/zanata-frontend/src/app/editor/containers/ControlsHeader.js
@@ -48,12 +48,6 @@ type props = {
 }
 */
 
-// TODO: Retrieve permissions object from redux store
-const permissions = {
-  reviewer: true,
-  translator: true
-}
-
 /**
  * Header row with editor controls (filtering, paging, etc.)
  */
@@ -71,7 +65,8 @@ export const ControlsHeader = ({
   toggleHeader,
   toggleShowSettings,
   toggleSuggestions,
-  gettextCatalog
+  gettextCatalog,
+  permissions
   /* eslint-enable react/prop-types */
  }/*: props*/) => {
   return (
@@ -167,7 +162,6 @@ export const ControlsHeader = ({
 
 function mapStateToProps (state) {
   const { ui: { gettextCatalog } } = state
-
   return {
     glossaryVisible: getGlossaryVisible(state),
     infoPanelVisible: getInfoPanelVisible(state),
@@ -175,7 +169,8 @@ function mapStateToProps (state) {
     navHeaderVisible: getNavHeaderVisible(state),
     suggestionsVisible: getSuggestionsPanelVisible(state),
     showSettings: getShowSettings(state),
-    gettextCatalog
+    gettextCatalog,
+    permissions: state.headerData.permissions
   }
 }
 

--- a/server/zanata-frontend/src/app/editor/containers/ControlsHeader.js
+++ b/server/zanata-frontend/src/app/editor/containers/ControlsHeader.js
@@ -48,6 +48,12 @@ type props = {
 }
 */
 
+// TODO: Retrieve permissions object from redux store
+const permissions = {
+  reviewer: true,
+  translator: true
+}
+
 /**
  * Header row with editor controls (filtering, paging, etc.)
  */
@@ -71,7 +77,7 @@ export const ControlsHeader = ({
   return (
     /* eslint-disable max-len */
     <nav className="flex flex-wrapper u-bgHighest u-sPH-1-2 l--cf-of u-sizeHeight-1_1-2">
-      <TranslatingIndicator gettextCatalog={gettextCatalog} />
+      <TranslatingIndicator permissions={permissions} />
       <div className="u-floatLeft"><PhraseStatusFilter /></div>
       {/* FIXME move InputEditorSearch into component. Layout component should
                 not have to know the internals of how the component is


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2401

With information about the user permissions for Translating and Reviewing available in the React Editor, use the Icon and Text in top left of the page to relate this information to the users.
The text for each mode can be localized as it has been for "Translating"
## QA
Three different modes should appear as below depending on the users permissions for a project:
![translating](https://user-images.githubusercontent.com/7971187/37260524-e909b310-25df-11e8-9096-4ca380affe99.png)
![reviewing](https://user-images.githubusercontent.com/7971187/37260530-f47b074e-25df-11e8-960b-e43964862c00.png)
![viewingdanger](https://user-images.githubusercontent.com/7971187/37260533-fa0cf6f4-25df-11e8-9c08-7cc806ce81c2.png)

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
