### PR TITLE
docs: replace api doc host with github

### DIFF
--- a/docs/index.md
+++ b/docs/index.md
@@ -12,6 +12,7 @@ Getting started
 - [Translator guide](user-guide/translator-guide.md)
 - [System admin guide](user-guide/system-admin/configuration/installation.md)
 - [Zanata client guide](client/index.md)
+- [API Documentation](http://zanata.org/zanata-platform/rest-api-docs/)
 
 Contribute
 ----------

--- a/docs/user-guide/api/api.md
+++ b/docs/user-guide/api/api.md
@@ -1,1 +1,1 @@
-All Zanata API documentation is located at [Zanata API](https://zanata.ci.cloudbees.com/job/zanata-api-site/site/zanata-common-api/rest-api-docs/index.html)
+All Zanata API documentation is located at [Zanata API](http://zanata.org/zanata-platform/rest-api-docs/)

--- a/parent/pom.xml
+++ b/parent/pom.xml
@@ -223,6 +223,7 @@
     <resteasy.version>3.0.13.Final</resteasy.version>
     <surefire.version>2.18.1</surefire.version>
     <maven.source.version>2.2.1</maven.source.version>
+    <site-maven-plugin.version>0.12</site-maven-plugin.version>
 
     <checkstyle.maven.version>2.17</checkstyle.maven.version>
     <checkstyle.version>7.2</checkstyle.version>
@@ -679,7 +680,6 @@
           <goals>deploy</goals>
         </configuration>
       </plugin>
-
     </plugins>
 
     <pluginManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -20,6 +20,37 @@
     <tag>HEAD</tag>
   </scm>
 
+  <build>
+    <plugins>
+      <!--
+        Uses maven-site-plugin to generate all modules' doc in root directory
+        before uploading to Github
+      -->
+      <plugin>
+        <groupId>com.github.github</groupId>
+        <artifactId>site-maven-plugin</artifactId>
+        <version>${site-maven-plugin.version}</version>
+        <configuration>
+          <message>Creating site for ${project.artifactId}, ${project.version}</message>
+          <merge>true</merge>
+          <!--
+            Authentication for github repository, settings.xml -> server with id=github
+            Alternately can be overrides with -Dgithub.global.oauth2Token={token}
+          -->
+          <server>github</server>
+        </configuration>
+        <executions>
+          <execution>
+            <goals>
+              <goal>site</goal>
+            </goals>
+            <phase>site</phase>
+          </execution>
+        </executions>
+      </plugin>
+    </plugins>
+  </build>
+
   <modules>
     <module>build-tools</module>
     <module>parent</module>


### PR DESCRIPTION
Replace API docs host in 
old: https://zanata.ci.cloudbees.com/job/zanata-api-site/site/ 
new: http://zanata.org/zanata-platform/

old: https://zanata.ci.cloudbees.com/job/zanata-api-site/site/zanata-common-api/rest-api-docs/index.html
new: http://zanata.org/zanata-platform/rest-api-docs/

- [x] ~~Jenkins job to perform deploy on release branch~~ [Jenkins job](https://zanata-jenkins.rhev-ci-vms.eng.rdu2.redhat.com/job/platform-site)
`mvn clean package site -DskipTests -Dfindbugs.skip -pl :build-tools,:api,:zanata-common-api,:zanata-platform -Dgithub.global.oauth2Token={github token}
`



## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
