### PR TITLE
fix(ZNTA-2396): TM suggestion highlighting shows mismatched diff 

### DIFF
--- a/server/gwt-editor/src/main/java/org/zanata/webtrans/client/ui/DiffColorLegendPanel.ui.xml
+++ b/server/gwt-editor/src/main/java/org/zanata/webtrans/client/ui/DiffColorLegendPanel.ui.xml
@@ -50,7 +50,7 @@
         </tr>
 
         <tr>
-          <td>
+          <td class="CodeMirror-searching">
             <g:InlineLabel ui:field="matchLabel">
               <ui:text from="{messages.matching}" />
             </g:InlineLabel>
@@ -63,7 +63,7 @@
         </tr>
 
         <tr>
-          <td class="CodeMirror-searching">
+          <td>
             <g:InlineLabel ui:field="absentLabel">
               <ui:text from="{messages.noMatch}" />
             </g:InlineLabel>

--- a/server/gwt-editor/src/main/java/org/zanata/webtrans/client/ui/Highlighting.java
+++ b/server/gwt-editor/src/main/java/org/zanata/webtrans/client/ui/Highlighting.java
@@ -136,11 +136,11 @@ public class Highlighting {
               '<span class="newline"></span><br>');
 
       if (part.added) {
-        html[x] = '<span class="CodeMirror-searching">' + text + '</span>';
+        html[x] = text;
       } else if (part.removed) {
         html[x] = '';
       } else {
-        html[x] = text;
+        html[x] = '<span class="CodeMirror-searching">' + text + '</span>';
       }
     }
     return html.join('');

--- a/server/gwt-editor/src/main/java/org/zanata/webtrans/client/ui/Highlighting.java
+++ b/server/gwt-editor/src/main/java/org/zanata/webtrans/client/ui/Highlighting.java
@@ -83,19 +83,8 @@ public class Highlighting {
 
     @CoverageIgnore("JSNI")
     private static native JavaScriptObject diff(String oldText, String newText,
-            boolean cleanupSemantic)
-        /*-{
-    if (!$wnd.diffMatchPatch) {
-      $wnd.diffMatchPatch = new $wnd.diff_match_patch();
-      $wnd.diffMatchPatch.Diff_Timeout = 0.2;
-    }
-
-    var dmp = $wnd.diffMatchPatch;
-    var diffs = dmp.diff_main(oldText, newText);
-    if (cleanupSemantic) {
-      dmp.diff_cleanupSemantic(diffs);
-    }
-    return diffs;
+            boolean cleanupSemantic) /*-{
+      return $wnd.JsDiff.diffWords(oldText, newText, {ignoreCase: true});
     }-*/;
 
     // modified diff_prettyHtml() from diff_match_patch.js
@@ -108,20 +97,17 @@ public class Highlighting {
     var pattern_gt = />/g;
     var pattern_para = /\n/g;
     for ( var x = 0; x < diffs.length; x++) {
-      var op = diffs[x][0]; // Operation (insert, delete, equal)
-      var data = diffs[x][1]; // Text of change.
+      var part = diffs[x];
+      var data = diffs[x].value; // Text of change.
       var text = data.replace(pattern_amp, '&amp;').replace(pattern_lt, '&lt;')
           .replace(pattern_gt, '&gt;').replace(pattern_para, '&para;<br>');
-      switch (op) {
-      case $wnd['DIFF_INSERT']:
+
+      if (part.added) {
         html[x] = '<ins class="diff-insert">' + text + '</ins>';
-        break;
-      case $wnd['DIFF_DELETE']:
+      } else if (part.removed) {
         html[x] = '<del class="diff-delete">' + text + '</del>';
-        break;
-      case $wnd['DIFF_EQUAL']:
+      } else {
         html[x] = '<span class="diff-equal">' + text + '</span>';
-        break;
       }
     }
     return html.join('');
@@ -143,20 +129,18 @@ public class Highlighting {
     var pattern_gt = />/g;
     var pattern_para = /\n/g;
     for ( var x = 0; x < diffs.length; x++) {
-      var op = diffs[x][0]; // Operation (insert, delete, equal)
-      var data = diffs[x][1]; // Text of change.
+      var part = diffs[x];
+      var data = diffs[x].value; // Text of change.
       var text = data.replace(pattern_amp, '&amp;').replace(pattern_lt, '&lt;')
           .replace(pattern_gt, '&gt;').replace(pattern_para,
               '<span class="newline"></span><br>');
-      switch (op) {
-      case $wnd['DIFF_INSERT']:
+
+      if (part.added) {
         html[x] = '<span class="CodeMirror-searching">' + text + '</span>';
-        break;
-      case $wnd['DIFF_DELETE']:
-        break;
-      case $wnd['DIFF_EQUAL']:
+      } else if (part.removed) {
+        html[x] = '';
+      } else {
         html[x] = text;
-        break;
       }
     }
     return html.join('');

--- a/server/gwt-editor/src/main/java/org/zanata/webtrans/client/ui/Highlighting.java
+++ b/server/gwt-editor/src/main/java/org/zanata/webtrans/client/ui/Highlighting.java
@@ -83,7 +83,8 @@ public class Highlighting {
 
     @CoverageIgnore("JSNI")
     private static native JavaScriptObject diff(String oldText, String newText,
-            boolean cleanupSemantic) /*-{
+            boolean cleanupSemantic)
+    /*-{
       return $wnd.JsDiff.diffWords(oldText, newText, {ignoreCase: true});
     }-*/;
 

--- a/server/gwt-editor/src/main/java/org/zanata/webtrans/client/view/TransMemoryView.java
+++ b/server/gwt-editor/src/main/java/org/zanata/webtrans/client/view/TransMemoryView.java
@@ -91,7 +91,7 @@ public class TransMemoryView extends Composite implements
     UiMessages messages;
 
     @UiField
-    InlineLabel searchOnly, tmOnly, diffLegendLabel, notMatching;
+    InlineLabel searchOnly, tmOnly, diffLegendLabel, matching;
 
     @UiField
     FocusPanel diffLegend;
@@ -235,14 +235,12 @@ public class TransMemoryView extends Composite implements
         if (determineDiffMode() == DiffMode.NORMAL) {
             tmOnly.removeStyleName("is-hidden");
             searchOnly.removeStyleName("is-hidden");
-            notMatching.removeStyleName("CodeMirror-searching");
-            notMatching.setText(messages.matching());
+            matching.removeStyleName("CodeMirror-searching");
             diffLegendLabel.setText(messages.tmDiffHighlighting());
         } else {
             tmOnly.addStyleName("is-hidden");
             searchOnly.addStyleName("is-hidden");
-            notMatching.addStyleName("CodeMirror-searching");
-            notMatching.setText(messages.matching());
+            matching.addStyleName("CodeMirror-searching");
             diffLegendLabel.setText(messages.tmHighlighting());
         }
     }

--- a/server/gwt-editor/src/main/java/org/zanata/webtrans/client/view/TransMemoryView.java
+++ b/server/gwt-editor/src/main/java/org/zanata/webtrans/client/view/TransMemoryView.java
@@ -242,7 +242,7 @@ public class TransMemoryView extends Composite implements
             tmOnly.addStyleName("is-hidden");
             searchOnly.addStyleName("is-hidden");
             notMatching.addStyleName("CodeMirror-searching");
-            notMatching.setText(messages.notMatching());
+            notMatching.setText(messages.matching());
             diffLegendLabel.setText(messages.tmHighlighting());
         }
     }
@@ -268,12 +268,12 @@ public class TransMemoryView extends Composite implements
         }
         if (determineDiffMode() == DiffMode.NORMAL) {
             SafeHtml safeHtml =
-                    TextContentsDisplay.asDiff(sourceContents, queriesPadded)
+                    TextContentsDisplay.asDiff(queriesPadded, sourceContents)
                             .toSafeHtml();
             panel.setWidget(new InlineHTML(safeHtml));
         } else {
             SafeHtml safeHtmlHighlight =
-                    TextContentsDisplay.asDiffHighlight(sourceContents, queriesPadded).toSafeHtml();
+                    TextContentsDisplay.asDiffHighlight(queriesPadded, sourceContents).toSafeHtml();
             panel.setWidget(new InlineHTML(safeHtmlHighlight));
         }
         return panel;

--- a/server/gwt-editor/src/main/java/org/zanata/webtrans/client/view/TransMemoryView.ui.xml
+++ b/server/gwt-editor/src/main/java/org/zanata/webtrans/client/view/TransMemoryView.ui.xml
@@ -69,9 +69,9 @@
       <li class="bx--inline">
         <g:FocusPanel ui:field="diffLegend" styleName="{style.legend} bx--inline">
           <g:HTMLPanel styleName="bx--inline button--link">
-            <g:InlineLabel styleName="CodeMirror-searching l--pad-h-quarter" ui:field="notMatching">Not matching</g:InlineLabel>
-            <g:InlineLabel styleName="diff-delete l--pad-h-quarter" ui:field="tmOnly">TM only</g:InlineLabel>
-            <g:InlineLabel styleName="diff-insert l--pad-h-quarter" ui:field="searchOnly">Search only</g:InlineLabel>
+            <g:InlineLabel styleName="CodeMirror-searching l--pad-h-quarter" ui:field="notMatching">Matching</g:InlineLabel>
+            <g:InlineLabel styleName="diff-insert l--pad-h-quarter" ui:field="tmOnly">TM only</g:InlineLabel>
+            <g:InlineLabel styleName="diff-delete l--pad-h-quarter" ui:field="searchOnly">Search only</g:InlineLabel>
           </g:HTMLPanel>
         </g:FocusPanel>
       </li>

--- a/server/gwt-editor/src/main/java/org/zanata/webtrans/client/view/TransMemoryView.ui.xml
+++ b/server/gwt-editor/src/main/java/org/zanata/webtrans/client/view/TransMemoryView.ui.xml
@@ -69,7 +69,7 @@
       <li class="bx--inline">
         <g:FocusPanel ui:field="diffLegend" styleName="{style.legend} bx--inline">
           <g:HTMLPanel styleName="bx--inline button--link">
-            <g:InlineLabel styleName="CodeMirror-searching l--pad-h-quarter" ui:field="notMatching">Matching</g:InlineLabel>
+            <g:InlineLabel styleName="CodeMirror-searching l--pad-h-quarter" ui:field="matching">Matching</g:InlineLabel>
             <g:InlineLabel styleName="diff-insert l--pad-h-quarter" ui:field="tmOnly">TM only</g:InlineLabel>
             <g:InlineLabel styleName="diff-delete l--pad-h-quarter" ui:field="searchOnly">Search only</g:InlineLabel>
           </g:HTMLPanel>

--- a/server/gwt-editor/src/main/webapp/webtrans/Application.xhtml
+++ b/server/gwt-editor/src/main/webapp/webtrans/Application.xhtml
@@ -49,8 +49,7 @@
     <link rel="stylesheet" type="text/css"
       href="codemirror/codemirror-3.21.cache.css"/>
 
-    <script src="diff_match_patch/javascript/diff_match_patch.js"
-      type="text/javascript"></script>
+    <h:outputScript target="body" library="webjars" name="${webjars.diff}"/>
 
     <script src="search-field-suggestions.js" type="text/javascript"></script>
 

--- a/server/services/pom.xml
+++ b/server/services/pom.xml
@@ -1367,6 +1367,12 @@
     </dependency>
 
     <dependency>
+      <groupId>org.webjars.npm</groupId>
+      <artifactId>diff</artifactId>
+      <version>3.5.0</version>
+    </dependency>
+
+    <dependency>
       <groupId>javax.validation</groupId>
       <artifactId>validation-api</artifactId>
       <scope>provided</scope>

--- a/server/services/src/main/java/org/zanata/util/Webjars.kt
+++ b/server/services/src/main/java/org/zanata/util/Webjars.kt
@@ -1,0 +1,57 @@
+/*
+ * Copyright 2018, Red Hat, Inc. and individual contributors
+ * as indicated by the @author tags. See the copyright.txt file in the
+ * distribution for a full listing of individual contributors.
+ *
+ * This is free software; you can redistribute it and/or modify it
+ * under the terms of the GNU Lesser General Public License as
+ * published by the Free Software Foundation; either version 2.1 of
+ * the License, or (at your option) any later version.
+ *
+ * This software is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU
+ * Lesser General Public License for more details.
+ *
+ * You should have received a copy of the GNU Lesser General Public
+ * License along with this software; if not, write to the Free
+ * Software Foundation, Inc., 51 Franklin St, Fifth Floor, Boston, MA
+ * 02110-1301 USA, or see the FSF site: http://www.fsf.org.
+ */
+package org.zanata.util
+
+import javax.enterprise.context.ApplicationScoped
+import javax.inject.Named
+import java.io.Serializable
+
+/**
+ * @author Sean Flanigan
+ * [sflaniga@redhat.com](mailto:sflaniga@redhat.com)
+ */
+@Named("webjars")
+@ApplicationScoped
+class Webjars : Serializable {
+
+    companion object {
+        private const val serialVersionUID = 1L
+
+        private val DIFF_VER: String = Dependencies.getVersion("org.webjars.npm:diff:jar")
+        private val DIFF_SCRIPT =
+                "diff/$DIFF_VER/dist/diff.min.js"
+    }
+
+    /**
+     * Return the name of the 'diff' script for JSF h:outputScript.
+     *
+     * You can use it like this:
+     *
+     * <pre>
+     * `<h:outputScript target="body" library="webjars"
+     * name="${webjars.diff}"/>`
+     * </pre>
+     *
+     * @return
+     */
+    val diff: String = DIFF_SCRIPT
+
+}

--- a/server/zanata-frontend/src/.storybook-editor/__snapshots__/storyshots-editor.test.js.snap
+++ b/server/zanata-frontend/src/.storybook-editor/__snapshots__/storyshots-editor.test.js.snap
@@ -7651,16 +7651,25 @@ exports[`Editor Storyshots TextDiff default 1`] = `
     changed
   </ins>
   <span>
-     text, what
+     text, 
   </span>
   <del>
-    ever it wa
+    whatever
   </del>
   <ins>
-     it now i
+    what
   </ins>
   <span>
-    s.
+     it 
+  </span>
+  <del>
+    was
+  </del>
+  <ins>
+    now is
+  </ins>
+  <span>
+    .
   </span>
 </div>
 `;

--- a/server/zanata-frontend/src/app/editor/components/TextDiff/TextDiff.test.js
+++ b/server/zanata-frontend/src/app/editor/components/TextDiff/TextDiff.test.js
@@ -7,15 +7,15 @@ describe('TextDiffTest', () => {
     const actual = ReactDOMServer.renderToStaticMarkup(
       <TextDiff
         text1="It was the best of times"
-        text2="It was the worst of times"/>
+        text2="It was the worst of times" />
     )
 
     const expected = ReactDOMServer.renderToStaticMarkup(
       <div className="Difference">
         <span>It was the </span>
-        <del>be</del>
-        <ins>wor</ins>
-        <span>st of times</span>
+        <del>best</del>
+        <ins>worst</ins>
+        <span> of times</span>
       </div>
     )
     expect(actual).toEqual(expected)

--- a/server/zanata-frontend/src/app/editor/components/TextDiff/index.js
+++ b/server/zanata-frontend/src/app/editor/components/TextDiff/index.js
@@ -35,37 +35,16 @@ export default class extends React.Component {
 
   render () {
     var differences = compare(this.props.text1, this.props.text2)
-    // modifies in-place
-    // diff.cleanupSemantic(differences)
     const simpleMatch = this.props.simpleMatch
-    // const result = differences.map(([type, text], index) => {
-    //   switch (type) {
-    //     case -1:
-    //       return (simpleMatch
-    //         ? <span className="line-through" key={index}>{text}</span>
-    //         : <del key={index}>{text}</del>)
-    //     case 0:
-    //       return (simpleMatch
-    //         ? <span className="highlight" key={index}>{text}</span>
-    //         : <span key={index}>{text}</span>)
-    //     case 1:
-    //       return (simpleMatch
-    //         ? ''
-    //         : <ins key={index}>{text}</ins>)
-    //     default:
-    //       console.error('invalid diff match type "' + type +
-    //                     '". Expecting one of: -1, 0, 1')
-    //   }
-    // })
     const result = differences.map((part, index) => {
       if (part.added) {
         return (simpleMatch
-                ? ''
+                ? <span key={index}>{part.value}</span>
                 : <ins key={index}>{part.value}</ins>)
       }
       if (part.removed) {
         return (simpleMatch
-                ? <span className="line-through" key={index}>{part.value}</span>
+                ? ''
                 : <del key={index}>{part.value}</del>)
       }
       return (simpleMatch

--- a/server/zanata-frontend/src/app/editor/components/TextDiff/index.js
+++ b/server/zanata-frontend/src/app/editor/components/TextDiff/index.js
@@ -1,11 +1,9 @@
 import React from 'react'
 import * as PropTypes from 'prop-types'
-import Diff from 'text-diff'
-
-const diff = new Diff()
+import { diffWords } from 'diff'
 
 function compare (text1, text2) {
-  return diff.main(text1, text2)
+  return diffWords(text1, text2, { ignoreCase: true })
 }
 
 export default class extends React.Component {
@@ -38,26 +36,41 @@ export default class extends React.Component {
   render () {
     var differences = compare(this.props.text1, this.props.text2)
     // modifies in-place
-    diff.cleanupSemantic(differences)
+    // diff.cleanupSemantic(differences)
     const simpleMatch = this.props.simpleMatch
-    const result = differences.map(([type, text], index) => {
-      switch (type) {
-        case -1:
-          return (simpleMatch
-            ? <span className="line-through" key={index}>{text}</span>
-            : <del key={index}>{text}</del>)
-        case 0:
-          return (simpleMatch
-            ? <span className="highlight" key={index}>{text}</span>
-            : <span key={index}>{text}</span>)
-        case 1:
-          return (simpleMatch
-            ? ''
-            : <ins key={index}>{text}</ins>)
-        default:
-          console.error('invalid diff match type "' + type +
-                        '". Expecting one of: -1, 0, 1')
+    // const result = differences.map(([type, text], index) => {
+    //   switch (type) {
+    //     case -1:
+    //       return (simpleMatch
+    //         ? <span className="line-through" key={index}>{text}</span>
+    //         : <del key={index}>{text}</del>)
+    //     case 0:
+    //       return (simpleMatch
+    //         ? <span className="highlight" key={index}>{text}</span>
+    //         : <span key={index}>{text}</span>)
+    //     case 1:
+    //       return (simpleMatch
+    //         ? ''
+    //         : <ins key={index}>{text}</ins>)
+    //     default:
+    //       console.error('invalid diff match type "' + type +
+    //                     '". Expecting one of: -1, 0, 1')
+    //   }
+    // })
+    const result = differences.map((part, index) => {
+      if (part.added) {
+        return (simpleMatch
+                ? ''
+                : <ins key={index}>{part.value}</ins>)
       }
+      if (part.removed) {
+        return (simpleMatch
+                ? <span className="line-through" key={index}>{part.value}</span>
+                : <del key={index}>{part.value}</del>)
+      }
+      return (simpleMatch
+              ? <span className="highlight" key={index}>{part.value}</span>
+              : <span key={index}>{part.value}</span>)
     })
 
     return (

--- a/server/zanata-frontend/src/package.json
+++ b/server/zanata-frontend/src/package.json
@@ -154,6 +154,7 @@
     "cli-color": "1.2.0",
     "combokeys": "2.4.6",
     "defined": "1.0.0",
+    "diff": "^3.5.0",
     "enzyme": "2.9.1",
     "faster-stable-stringify": "1.0.0",
     "file-saver": "1.3.3",

--- a/server/zanata-frontend/src/package.json
+++ b/server/zanata-frontend/src/package.json
@@ -208,7 +208,6 @@
     "suitcss-utils-size": "0.7.1",
     "suitcss-utils-text": "0.4.1",
     "svg-sprite": "1.3.7",
-    "text-diff": "1.0.1",
     "ts-jest": "^22.0.1",
     "tslib": "^1.9.0",
     "typesafe-actions": "^1.1.2",

--- a/server/zanata-frontend/src/yarn.lock
+++ b/server/zanata-frontend/src/yarn.lock
@@ -3327,6 +3327,10 @@ diff@^3.2.0:
   version "3.4.0"
   resolved "https://registry.yarnpkg.com/diff/-/diff-3.4.0.tgz#b1d85507daf3964828de54b37d0d73ba67dda56c"
 
+diff@^3.5.0:
+  version "3.5.0"
+  resolved "https://registry.yarnpkg.com/diff/-/diff-3.5.0.tgz#800c0dd1e0a8bfbc95835c202ad220fe317e5a12"
+
 diffie-hellman@^5.0.0:
   version "5.0.2"
   resolved "https://registry.yarnpkg.com/diffie-hellman/-/diffie-hellman-5.0.2.tgz#b5835739270cfe26acf632099fded2a07f209e5e"

--- a/server/zanata-frontend/src/yarn.lock
+++ b/server/zanata-frontend/src/yarn.lock
@@ -10196,10 +10196,6 @@ test-exclude@^4.1.1:
     read-pkg-up "^1.0.1"
     require-main-filename "^1.0.1"
 
-text-diff@1.0.1:
-  version "1.0.1"
-  resolved "https://registry.yarnpkg.com/text-diff/-/text-diff-1.0.1.tgz#6c105905435e337857375c9d2f6ca63e453ff565"
-
 text-table@~0.2.0:
   version "0.2.0"
   resolved "https://registry.yarnpkg.com/text-table/-/text-table-0.2.0.tgz#7f5ee823ae805207c00af2df4a84ec3fcfa570b4"


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2396
Duplicates: https://zanata.atlassian.net/browse/ZNTA-2397 

Zanata TM highlighting is confusing for low-similarity matches due to a mismatch between the backend TM matching and the frontend (GWT and React Editor) diffing algorithms.

## QA
The TM Suggestions should now correctly display matches on full words for both the GWT editor and Alpha editor (using the same diff library). 
Punctuation not effect the diff now (punctuation causing the initial issue with matching words not being displayed).
The matching words of a source/target diff should be more evident now:
![worddiff](https://user-images.githubusercontent.com/7971187/37440130-250c918e-2847-11e8-9ff5-2f110d88c25c.png)
The simple diff mode has also been modified to highlight the Matching parts, rather than non-matching:
![highlightdiff](https://user-images.githubusercontent.com/7971187/37440173-500642d6-2847-11e8-905c-6ae289855a09.png)
The diff views in the Alpha editor should be identical.

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
