### PR TITLE
fix(ZNTA-2429): language page height scroll

### DIFF
--- a/server/zanata-frontend/src/app/containers/Languages/index.js
+++ b/server/zanata-frontend/src/app/containers/Languages/index.js
@@ -124,7 +124,6 @@ class Languages extends Component {
             {permission.canAddLocale &&
               <div>
                 <Button bsStyle='primary'
-                  id='btn-language-add-new'
                   onClick={handleOnDisplayNewLanguage}>
                   <Icon name='plus' className='n1' parentClassName='plusicon'
                     title='plus' />&nbsp;

--- a/server/zanata-frontend/src/app/containers/Languages/index.js
+++ b/server/zanata-frontend/src/app/containers/Languages/index.js
@@ -124,6 +124,7 @@ class Languages extends Component {
             {permission.canAddLocale &&
               <div>
                 <Button bsStyle='primary'
+                  id='btn-language-add-new'
                   onClick={handleOnDisplayNewLanguage}>
                   <Icon name='plus' className='n1' parentClassName='plusicon'
                     title='plus' />&nbsp;

--- a/server/zanata-frontend/src/app/containers/Languages/index.less
+++ b/server/zanata-frontend/src/app/containers/Languages/index.less
@@ -4,6 +4,10 @@
   --LanguagesLangCode-fontSize: 0.9rem;
 }
 
+.wideView.languages {
+  padding-bottom: 3rem;
+}
+
 .toolbar {
   padding-top: @spacing-hr;
   flex-direction: row;

--- a/server/zanata-frontend/src/app/containers/Languages/index.less
+++ b/server/zanata-frontend/src/app/containers/Languages/index.less
@@ -180,9 +180,6 @@ table#languages-table {
   width: 100%;
 }
 
-.wideView.bstrapReact.languages {
-  height: 100vh;
-}
 select#sort-options {
   width: inherit;
 }

--- a/server/zanata-frontend/src/app/containers/Languages/index.less
+++ b/server/zanata-frontend/src/app/containers/Languages/index.less
@@ -22,10 +22,6 @@ span.languageCode {
   color: #aaa;
 }
 
-#btn-language-add-new {
-  margin-left: @spacing-large-vertical;
-}
-
 .toolbar .sortItems {
   padding-right: 0;
   margin-bottom: 1rem;

--- a/server/zanata-frontend/src/app/containers/Languages/index.less
+++ b/server/zanata-frontend/src/app/containers/Languages/index.less
@@ -22,6 +22,10 @@ span.languageCode {
   color: #aaa;
 }
 
+#btn-language-add-new {
+  margin-left: @spacing-large-vertical;
+}
+
 .toolbar .sortItems {
   padding-right: 0;
   margin-bottom: 1rem;


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2429

height of languages page table now scrolls to fit content

<img width="1440" alt="scrolling-lang" src="https://user-images.githubusercontent.com/18179401/37391068-d5e14762-27b5-11e8-8e20-4971591b1b7e.png">

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*