### PR TITLE
fix: remove sidebar from gwt editor

### DIFF
--- a/server/gwt-editor/src/main/java/org/zanata/webtrans/client/ui/Breadcrumb.ui.xml
+++ b/server/gwt-editor/src/main/java/org/zanata/webtrans/client/ui/Breadcrumb.ui.xml
@@ -10,9 +10,13 @@
       text-decoration: none;
       cursor: default;
     }
+
+    .breadcrumb {
+      font-size: 1.1em;
+    }
   </ui:style>
 
-  <g:HTMLPanel styleName="bx--inline-block">
+  <g:HTMLPanel styleName="bx--inline-block {style.breadcrumb}">
     <g:HTMLPanel tag="i" ui:field="rightChevron"
       styleName="i i--arrow-right" />
     <g:Anchor ui:field="link"/>

--- a/server/gwt-editor/src/main/java/org/zanata/webtrans/client/view/AppView.ui.xml
+++ b/server/gwt-editor/src/main/java/org/zanata/webtrans/client/view/AppView.ui.xml
@@ -24,6 +24,7 @@
     .right-nav {
       position: absolute;
       right: 0;
+      min-width: unset;
     }
 
     .translationStats {
@@ -69,11 +70,16 @@
   </ui:style>
   <g:LayoutPanel stylePrimaryName="{style.rootContainer}"
     ui:field="rootContainer">
-    <g:layer top="0.40625em" height="1.8em" left="0.5em" right="0.5em">
+    <g:layer top="0.40625em" height="2.3em" left="0.5em" right="0.5em">
       <g:HTMLPanel styleName="new-zanata">
         <ul class="list--horizontal">
           <li class="{style.topPanel-Workspace}">
             <nobr>
+              <g:HTMLPanel styleName="bx--inline-block">
+                <a href="/">
+                  <img src="http://zanata.org/images/logo/logo-32.png" height="30" width="30"/>
+                </a>
+              </g:HTMLPanel>
               <g:InlineLabel ui:field="readOnlyLabel"
                 styleName="i i--lock txt--danger txt--hero l--push-right-quarter" />
               <g:InlineLabel ui:field="obsoleteLabel"
@@ -102,7 +108,7 @@
       </g:HTMLPanel>
     </g:layer>
 
-    <g:layer top="2em" bottom="0" left='0.5em' right='0.5em'>
+    <g:layer top="2.8em" bottom="0" left='0.5em' right='0.5em'>
       <g:HTMLPanel ui:field="contentContainer">
         <div class="new-zanata">
           <fui:UnorderedListWidget ui:field="notifications"
@@ -116,7 +122,7 @@
       </g:HTMLPanel>
     </g:layer>
 
-    <g:layer right="0" width="2em" top="2em" bottom="0">
+    <g:layer right="0" width="2em" top="2.8em" bottom="0">
       <g:LayoutPanel ui:field="sideMenuContainer" styleName="new-zanata" />
     </g:layer>
 

--- a/server/gwt-editor/src/main/webapp/webtrans/Application.xhtml
+++ b/server/gwt-editor/src/main/webapp/webtrans/Application.xhtml
@@ -38,11 +38,10 @@
     <link rel="preload" as="font" crossorigin="anonymous" type="font/woff"
       href="#{request.contextPath}/resources/fontello/font/fontello.woff" />
 
-    <link rel="stylesheet" href="#{frontendAssets.frontendCss}" type="text/css"/>
     <link type="text/css" rel="stylesheet"
       href="#{request.contextPath}/resources/fontello/css/fontello.css"/>
     <link type="text/css" rel="stylesheet" href="#{request.contextPath}/resources/assets/css/style.css"/>
-    <link type="text/css" rel="stylesheet" href="#{request.contextPath}/resources/assets/css/application.css"/>
+    <link type="text/css" rel="stylesheet" href="#{request.contextPath}/resources/assets/css/gwt-editor.css"/>
 
     <script src="codemirror/codemirror-compressed-3.21.cache.js"
         type="text/javascript"></script>
@@ -69,31 +68,11 @@
   <!--                                           -->
   <h:body styleClass="new-zanata-body">
     <ds:windowId/>
-    <div id="config"
-      data-app-url="#{request.contextPath}"
-      data-server-url="#{request.contextPath}"
-      data-api-server-url="#{request.contextPath}/rest"
-      data-user="#{authenticatedAccountHome.getUser()}"
-      data-permission="#{authenticatedAccountHome.getUserPermission().getJSON()}"
-      data-links='{"loginUrl": "#{applicationConfigurationAction.getLoginUrl(request)}",
-                   "registerUrl": "#{applicationConfigurationAction.registerUrl}"}'>
-    </div>
     <script type="application/javascript">
       var zanataSessionId = '#{request.session.id}';
-      window.config = JSON.parse(JSON.stringify(document.getElementById('config').dataset))
     </script>
 
-
-    <div class='templateWrapper'>
-      <div class='templateContainer'>
-        <div id="root" />
-        <div id="container" class="containerEditor"/>
-      </div>
-    </div>
-    <script type="text/javascript"
-      src="#{frontendAssets.runtime}"></script>
-    <script type="text/javascript"
-      src="#{frontendAssets.legacyJs}"></script>
+    <div id="container"/>
     <!-- OPTIONAL: include this if you want history support -->
     <iframe src="javascript:''" id="__gwt_historyFrame" tabIndex='-1'
       style="position:absolute;width:0;height:0;border:0"></iframe>

--- a/server/zanata-frontend/src/app/styles/legacy.less
+++ b/server/zanata-frontend/src/app/styles/legacy.less
@@ -1,19 +1,22 @@
-/* JSF and GWT overrides
+/* JSF overrides
 - fixes UI issues caused by assets and bootstrap css conflicts
 */
 
 @import "./variables.less";
+
 // These two rules do not apply to specifically new-zanata wrapped pages
 body.bodyStyle {
   margin: 0;
   padding: 0;
 }
+
 .htmlStyle {
   font-family: "Source Sans Pro", "Helvetica Neue", Helvetica, Arial, sans-serif;
   line-height: 1.5;
   background-color: #fff;
   font-size: @font-size-base;
 }
+
 .new-zanata {
   //body class
   .bg--pop-highest {
@@ -315,16 +318,6 @@ body.bodyStyle {
   .panel__results .txt--meta {
     color: #BDD4DC;
   }
-  /* Fix for Search and Replace in GWT */
-  table .projectWideSearchResultsDocumentBody {
-    display: table !important;
-  } // Bugfix for a container, do not remove
-  .GNM0BIKDBN {
-    min-width: unset;
-  } // GWT cancel buttons at bottom of pages
-  form .button.button--link {
-    padding: 0.1875em 0.75em
-  }
   #cacheStatisticsTable {
     overflow: auto;
     overflow-x: scroll;
@@ -337,50 +330,16 @@ body.bodyStyle {
   select {
     width: inherit !important;
   }
-  .gwt-DialogBox-CloseButton {
-    position: relative;
-    bottom: -4px;
-    right: 5px;
-    float: right;
-    clear: both;
-    width: 6%;
-    margin-left: 94%;
-  }
   .revision__box {
     display: flex !important;
     padding: 10px !important;
   }
-  #gwt-debug-transHistoryTabPanel .gwt-TabLayoutPanelContent {
-    overflow-x: hidden !important;
-  }
-  #gwt-debug-transHistoryTabPanel .gwt-TabLayoutPanelContent .g--tight {
-    margin: 0 !important;
-  }
-  .gwt-DialogBox {
-    padding-right: 15px;
-  }
-  .resultTable, .transUnitTable {
-    margin: 0;
-  }
-  .resultTable button {
-    padding: 0.1875em 0.375em !important;
-  }
-  .gwt-TabLayoutPanelContent table {
-    margin: auto;
-  }
-  .button--small {
-    padding: 0.21429em 0.42857em !important;
-  }
-  #gwt-debug-transHistoryTabPanel .gwt-TabLayoutPanelContent .gwt-InlineHTML .l--pad-v-half {
-    margin-top: 5px;
-    margin-bottom: 5px;
-    min-height: 1em;
-    word-wrap: break-word;
-    white-space: pre-wrap;
-  } //fixes to Versions/Projects page
-  #projectsWrapper~.g.u-fullWidth, li#projects.is-active {
+
+  //fixes to Versions/Projects page
+  #projectsWrapper ~ .g.u-fullWidth, li#projects.is-active {
     padding-bottom: 12rem;
-  } // fix to settings dropdowns on languages tab
+  }
+  // fix to settings dropdowns on languages tab
   li#settings ul.tabsContent {
     padding-bottom: 10rem;
   }
@@ -418,22 +377,10 @@ body.bodyStyle {
     -webkit-flex-grow: 1;
     padding: @spacing-rh;
   }
-  .containerEditor {
-    margin-left: 0;
-    margin-right: 0;
-    width: 100%;
-    overflow-x: scroll;
-    margin-bottom: 4.5rem;
-  }
 }
 @media (min-width: 29.376rem) {
   main {
     margin-left: 4.5rem;
-  }
-  .containerEditor {
-    margin-left: 4.5rem;
-    width: 100%;
-    margin-bottom: 0;
   }
   #nav {
     height: 100vh;
@@ -459,9 +406,3 @@ body.bodyStyle {
     padding-bottom: @spacing-rq;
   }
 }
-@media (min-width: @screen-lg) {
-  .containerEditor {
-    overflow-x: hidden;
-  }
-}
-

--- a/server/zanata-war/src/main/webapp/resources/assets/css/gwt-editor.css
+++ b/server/zanata-war/src/main/webapp/resources/assets/css/gwt-editor.css
@@ -351,6 +351,7 @@ tr.TableEditorRow.content-filter-nomatch {
 }
 
 .projectWideSearchResultsDocumentBody {
+  display: table !important;
   padding-top: 15px;
   background-color: #ffffff;
   border: 2px solid lightgrey;
@@ -910,26 +911,6 @@ a.downloadLink {
   position: relative;
 }
 
-.gwt-SplitLayoutPanel *::-webkit-scrollbar-track
-{
-  -webkit-box-shadow: inset 0 0 6px rgba(0,0,0,0.3);
-  border-radius: 10px;
-  background-color: #F5F5F5;
-}
-
-.gwt-SplitLayoutPanel *::-webkit-scrollbar
-{
-  width: 14px;
-  background-color: #F5F5F5;
-}
-
-.gwt-SplitLayoutPanel *::-webkit-scrollbar-thumb
-{
-  background-color: #03A6D7;
-  border-radius: 10px;
-  background-image: -webkit-gradient(linear, 0 0, 0 100%,color-stop(.5,rgba(255, 255, 255, .2)),color-stop(.5, transparent), to(transparent));
-}
-
 .translationContainer > div:nth-of-type(2) > div > div:nth-of-type(2) {
   background-color: rgba(255, 255, 255, 0.4);
 }
@@ -994,17 +975,19 @@ a.downloadLink {
 }
 
 .gwt-DialogBox-CloseButton {
-  position: absolute;
-  bottom: 8px;
+  position: relative;
+  bottom: -4px;
   right: 5px;
   float: right;
   margin: 0;
-  width: 5em;
+  width: 6%;
   border: none !important;
   border-radius: 4px;
   background-color: #fff;
   box-shadow: 0 1px 2px rgba(0, 0, 0, 0.1);
   text-align: center;
+  clear: both;
+  margin-left: 94%;
 }
 .gwt-DialogBox-CloseButton:hover {
   background-color: #fcfcfc;
@@ -1022,10 +1005,6 @@ a.downloadLink {
 
 #container > div {
   background: #fff !important;
-}
-#container > div > div:nth-of-type(3),
-#container > div > div:nth-of-type(4) {
-  top: 32px !important;
 }
 
 .subHeader > div:nth-of-type(2) td:first-of-type > div {
@@ -1963,4 +1942,61 @@ html .gwt-DialogBox .dialogBottomRightInner {
   opacity: .5;
   zoom: 1;
   filter: alpha(opacity=40);
+}
+
+.label {
+  font-size: 0.8rem;
+  font-weight: 500;
+  line-height: 1;
+  display: inline;
+  padding: 0.1rem 0.2rem 0.1rem;
+  text-align: center;
+  vertical-align: baseline;
+  white-space: nowrap;
+  color: #fff;
+  border-radius: 0.25rem;
+  margin-left: 0.38rem;
+  margin-right: 0.38rem;
+}
+
+.txt--meta {
+  color: #20718A;
+}
+
+table {
+  font-size: 0.875rem;
+}
+
+/* GWT cancel buttons at bottom of pages */
+form .button.button--link {
+ padding: 0.1875em 0.75em
+}
+
+#gwt-debug-transHistoryTabPanel .gwt-TabLayoutPanelContent {
+  overflow-x: hidden !important;
+}
+#gwt-debug-transHistoryTabPanel .gwt-TabLayoutPanelContent .g--tight {
+  margin: 0 !important;
+}
+.gwt-DialogBox {
+  padding-right: 15px;
+}
+.resultTable, .transUnitTable {
+  margin: 0;
+}
+.resultTable button {
+  padding: 0.1875em 0.375em !important;
+}
+.gwt-TabLayoutPanelContent table {
+  margin: auto;
+}
+.button--small {
+  padding: 0.21429em 0.42857em !important;
+}
+#gwt-debug-transHistoryTabPanel .gwt-TabLayoutPanelContent .gwt-InlineHTML .l--pad-v-half {
+  margin-top: 5px;
+  margin-bottom: 5px;
+  min-height: 1em;
+  word-wrap: break-word;
+  white-space: pre-wrap;
 }


### PR DESCRIPTION
Remove all frontend dependency (js and css) from gwt.

- Remove sidebar from gwt-editor
- Clean up unused css classes due to the removal
- Remove frontend.legacy.js import from gwt-editor
- remove frontend.css import from gwt
- rename application.css to gwt-editor.css


https://zanata.atlassian.net/browse/ZNTA-2454

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
