### PR TITLE
fix(ZNTA-2446): increase clickable area for Update Translation modal

### DIFF
--- a/server/zanata-frontend/src/app/styles/legacy.less
+++ b/server/zanata-frontend/src/app/styles/legacy.less
@@ -32,6 +32,11 @@ body.bodyStyle {
   #uploadForm .rf-fu-btns-lft .rf-fu-btn-add .rf-fu-btn-cnt-add .rf-fu-inp-cntr {
     position: relative;
   }
+  /* remove + icon that cannot be clicked */
+  #uploadForm .rf-fu-btns-lft .rf-fu-btn-add .rf-fu-btn-cnt-add {
+    padding: 0 0 0 10px !important;
+    background-image: none;
+  }
   .view {
     width: 100%;
     height: 100%;

--- a/server/zanata-frontend/src/app/styles/legacy.less
+++ b/server/zanata-frontend/src/app/styles/legacy.less
@@ -24,7 +24,7 @@ body.bodyStyle {
   /* Fixes for Add translation modal buttons */
   #uploadForm .rf-fu,
   #uploadForm .rf-fu-btns-lft,
-  #uploadForm .rf-fu-btns-lft .rf-fu-btn-add
+  #uploadForm .rf-fu-btns-lft .rf-fu-btn-add,
   #uploadForm .rf-fu-btns-lft .rf-fu-btn-add .rf-fu-btn-cnt-add {
     width: 100%;
   }

--- a/server/zanata-frontend/src/app/styles/legacy.less
+++ b/server/zanata-frontend/src/app/styles/legacy.less
@@ -21,6 +21,13 @@ body.bodyStyle {
   .bg--pop-highest {
     border: none;
   }
+  /* Fixes for Add translation modal buttons */
+  #uploadForm .rf-fu,
+  #uploadForm .rf-fu-btns-lft,
+  #uploadForm .rf-fu-btns-lft .rf-fu-btn-add
+  #uploadForm .rf-fu-btns-lft .rf-fu-btn-add .rf-fu-btn-cnt-add {
+    width: 100%;
+  }
   .view {
     width: 100%;
     height: 100%;

--- a/server/zanata-frontend/src/app/styles/legacy.less
+++ b/server/zanata-frontend/src/app/styles/legacy.less
@@ -25,8 +25,12 @@ body.bodyStyle {
   #uploadForm .rf-fu,
   #uploadForm .rf-fu-btns-lft,
   #uploadForm .rf-fu-btns-lft .rf-fu-btn-add,
-  #uploadForm .rf-fu-btns-lft .rf-fu-btn-add .rf-fu-btn-cnt-add {
+  #uploadForm .rf-fu-btns-lft .rf-fu-btn-add .rf-fu-btn-cnt-add,
+  #uploadForm .rf-fu-btns-lft .rf-fu-btn-add .rf-fu-btn-cnt-add input.rf-fu-inp {
     width: 100%;
+  }
+  #uploadForm .rf-fu-btns-lft .rf-fu-btn-add .rf-fu-btn-cnt-add .rf-fu-inp-cntr {
+    position: relative;
   }
   .view {
     width: 100%;


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2446

* increase clickable area for Update Translation modal by increasing the width of parent classes to 100%. all of these changes had to be made to ensure the entire button was clickable.
* remove icon that cannot be clicked - poor UX design

![update-trans-noicon](https://user-images.githubusercontent.com/18179401/38009748-33770e6e-3299-11e8-8f89-96bf7d6b43c0.png)

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
