### PR TITLE
fix(ZNTA-2499): update activity panel translation history on transunit revision

### DIFF
--- a/server/zanata-frontend/src/app/editor/actions/phrases-actions.js
+++ b/server/zanata-frontend/src/app/editor/actions/phrases-actions.js
@@ -58,10 +58,11 @@ export const undoEdit = createAction(UNDO_EDIT)
  */
 export function selectPhrase (phraseId, localeId, projectSlug, versionSlug) {
   return (dispatch) => {
-    dispatch(
-      fetchTransUnitHistory(localeId, phraseId, projectSlug, versionSlug))
     dispatch(savePreviousPhraseIfChanged(phraseId))
-    dispatch(createAction(SELECT_PHRASE)(phraseId))
+    dispatch(createAction(SELECT_PHRASE)(phraseId)).then(
+      dispatch(
+        fetchTransUnitHistory(localeId, phraseId, projectSlug, versionSlug))
+    )
   }
 }
 
@@ -185,7 +186,14 @@ export function savePhraseWithStatus (phrase, status, reviewComment) {
             // dispatch(phraseSaveFailed(currentPhrase, saveInfo))
           } else {
             response.json().then(({ revision, status }) => {
-              dispatch(saveFinished(phrase.id, status, revision))
+              dispatch(saveFinished(phrase.id, status, revision)).then(
+                dispatch(fetchTransUnitHistory(
+                  saveInfo.localeId,
+                  phrase.id,
+                  stateBefore.context.projectSlug,
+                  stateBefore.context.versionSlug
+                ))
+              )
             })
           }
           startPendingSaveIfPresent(currentPhrase)

--- a/server/zanata-frontend/src/app/editor/actions/phrases-actions.js
+++ b/server/zanata-frontend/src/app/editor/actions/phrases-actions.js
@@ -59,10 +59,9 @@ export const undoEdit = createAction(UNDO_EDIT)
 export function selectPhrase (phraseId, localeId, projectSlug, versionSlug) {
   return (dispatch) => {
     dispatch(savePreviousPhraseIfChanged(phraseId))
-    dispatch(createAction(SELECT_PHRASE)(phraseId)).then(
-      dispatch(
-        fetchTransUnitHistory(localeId, phraseId, projectSlug, versionSlug))
-    )
+    dispatch(createAction(SELECT_PHRASE)(phraseId))
+    dispatch(fetchTransUnitHistory(
+      localeId, phraseId, projectSlug, versionSlug))
   }
 }
 
@@ -78,10 +77,10 @@ const selectPhraseSpecificPlural = createAction(SELECT_PHRASE_SPECIFIC_PLURAL,
 export function selectPhrasePluralIndex (
   phraseId, index, localeId, projectSlug, versionSlug) {
   return (dispatch) => {
-    dispatch(
-      fetchTransUnitHistory(localeId, phraseId, projectSlug, versionSlug))
     dispatch(savePreviousPhraseIfChanged(phraseId))
     dispatch(selectPhraseSpecificPlural(phraseId, index))
+    dispatch(fetchTransUnitHistory(
+      localeId, phraseId, projectSlug, versionSlug))
   }
 }
 


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2449
Clones: https://zanata.atlassian.net/browse/ZNTA-2450

1. Go to the react editor
2. On a translated entry, change the text
3. Press the green Translated button

Altering the text of a 'translated' textflow and saving as translated should now update the activity list with the new revision.

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
