### PR TITLE
refactor(ZNTA-2400): Consistency of sizes in css (use rem)

### DIFF
--- a/server/zanata-frontend/src/app/components/Sidebar/index.less
+++ b/server/zanata-frontend/src/app/components/Sidebar/index.less
@@ -42,8 +42,8 @@
     flex-grow: 1;
     padding-bottom: @spacing-rh;
     position: relative;
-    padding-left: 1em;
-    padding-right: 1em;
+    padding-left: 1rem;
+    padding-right: 1rem;
   }
 
   .accordion-section-title .iconProject svg {
@@ -158,7 +158,7 @@
   }
 
   .sidebar #sidebarVersion {
-    margin-top: 1.5em;
+    margin-top: 1.5rem;
     padding-top: 10px;
     border-top: solid 1px #bdd4dc;
   }
@@ -288,7 +288,7 @@
 
     .sidebar ul li {
       padding-right: 10px;
-      line-height: 2em;
+      line-height: 2rem;
     }
   }
 

--- a/server/zanata-frontend/src/app/containers/Admin/index.less
+++ b/server/zanata-frontend/src/app/containers/Admin/index.less
@@ -6,12 +6,12 @@
   border: 1px solid rgba(32, 113, 138, 0.15);
   border-bottom-width: 2px;
   background-color: @gray-lightest;
-  font-size: 1em;
+  font-size: 1rem;
   font-weight: 600;
-  line-height: 1.5em;
+  line-height: 1.5rem;
   color: @color-new-zanata-blue;
   svg.s2 {
-    padding-right: 1.5em !important
+    padding-right: 1.5rem !important
   }
 }
 #admin-review .centerWrapper {

--- a/server/zanata-frontend/src/app/containers/Explore/index.less
+++ b/server/zanata-frontend/src/app/containers/Explore/index.less
@@ -153,7 +153,7 @@
     vertical-align: sub;
   }
   #explore h1 {
-    font-size: 1.2em !important;
+    font-size: 1.2rem !important;
     margin-bottom: 0;
   } // @screen-xs variable depreciated
   @media (max-width: 29.375rem) {

--- a/server/zanata-frontend/src/app/containers/Glossary/index.less
+++ b/server/zanata-frontend/src/app/containers/Glossary/index.less
@@ -196,10 +196,10 @@
     position: relative;
   }
   td.languageSelect .Select-input input {
-    margin-top: 0.25em;
+    margin-top: 0.25rem;
   }
   .glossaryHeader .row .Select-control {
-    width: 4em;
+    width: 4rem;
   }
   td.languageSelect .row {
     position: absolute;
@@ -223,7 +223,7 @@
     vertical-align: middle;
     top: @spacing-search-box;
     color: @color-neutral;
-    font-size: 1.2em;
+    font-size: 1.2rem;
   }
   .glossaryTable .tr-flex1 {
     border: none;
@@ -367,7 +367,7 @@
   }
   @media (min-width: @screen-lg-min) {
     .glossaryHeader-title {
-      margin-right: 9em;
+      margin-right: 9rem;
     }
   }
 }

--- a/server/zanata-frontend/src/app/containers/ProjectVersion/index.less
+++ b/server/zanata-frontend/src/app/containers/ProjectVersion/index.less
@@ -61,7 +61,7 @@
     margin-bottom: 0;
   }
   .versionMergeRow {
-    margin-bottom: 1.75em;
+    margin-bottom: 1.75rem;
   }
   .versionMergeDropdown {
     font-weight: 500;
@@ -116,7 +116,7 @@
     margin-left: 0;
   }
   .versionMergeTitle-sub {
-    font-size: 0.85em;
+    font-size: 0.85rem;
   }
   .modal-body .dropdown .dropdown-menu>li>a {
     font-size: 1rem;

--- a/server/zanata-frontend/src/app/editor/components/Dropdown/index.css
+++ b/server/zanata-frontend/src/app/editor/components/Dropdown/index.css
@@ -100,7 +100,7 @@ not conflict with the other frontend code
 }
 
 .TransUnit-panelFooter .EditorDropdown-content .EditorButton {
-  padding-right: .5rem;
+  padding-right: 0.5rem;
 }
 
 /**

--- a/server/zanata-frontend/src/app/editor/components/EditorSearchInput/index.css
+++ b/server/zanata-frontend/src/app/editor/components/EditorSearchInput/index.css
@@ -4,8 +4,8 @@
 }
 
 .InputEditorSearch {
-  margin-left: 0.75em;
-  margin-right: 1em;
+  margin-left: 0.75rem;
+  margin-right: 1rem;
   display: inline-flex;
   padding-top: 0.35rem;
   flex: 2 0 16rem;
@@ -16,7 +16,7 @@
 }
 
 .InputEditorSearch input {
-  font-size: 0.875em;
+  font-size: 0.875rem;
 }
 
 .InputEditorSearch > div {
@@ -34,7 +34,7 @@
 /* bootstrap classes used throughout */
 
 .InputEditorSearch .panel {
-  margin-bottom: 0.5em !important;
+  margin-bottom: 0.5rem !important;
   position: absolute;
   width: 100%;
 }
@@ -50,7 +50,7 @@
 
 .InputEditorSearch .icon-help button {
   vertical-align: sub;
-  margin-left: 0.375em;
+  margin-left: 0.375rem;
 }
 
 .InputEditorSearch .EditorInputGroup {
@@ -73,7 +73,7 @@
 li.InlineSearch-list {
   display: inline-flex;
   width: 100%;
-  margin-right: 1em;
+  margin-right: 1rem;
 }
 
 li.InlineSearch-list span {
@@ -100,6 +100,6 @@ li.InlineSearch-list span {
 button.AdvSearch-clear {
   color: #03A6D7;
   padding: 0;
-  padding-top: 0.75em;
+  padding-top: 0.75rem;
 }
 

--- a/server/zanata-frontend/src/app/editor/components/GlossaryTermModal/index.css
+++ b/server/zanata-frontend/src/app/editor/components/GlossaryTermModal/index.css
@@ -1,11 +1,11 @@
 .Editor-suggestionsBody .TransUnit--suggestion .TransUnit-text--tight {
     padding-top: 0 !important;
-    font-size:1em;
+    font-size:1rem;
 }
 
 .TransUnit--suggestion .TransUnit-text--tight {
     padding-top:40px !important;
-    font-size:1.2em;
+    font-size:1.2rem;
 }
 /* Based on bootstrap styles. */
 

--- a/server/zanata-frontend/src/app/editor/components/TransUnit/index.css
+++ b/server/zanata-frontend/src/app/editor/components/TransUnit/index.css
@@ -172,7 +172,7 @@
 }
 
 h3.TransUnit-heading {
-  padding-left:1.5em;
+  padding-left:1.5rem;
 }
 
 .TransUnit-text {

--- a/server/zanata-frontend/src/app/editor/containers/Root/index.css
+++ b/server/zanata-frontend/src/app/editor/containers/Root/index.css
@@ -215,7 +215,7 @@ input, textarea, select, button  {
 }
 
 .Editor-docsDropdown button.Link--invert div span {
-  max-width: 25em;
+  max-width: 25rem;
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
@@ -227,7 +227,7 @@ input, textarea, select, button  {
 }
 
 .TransUnit-panel .u-textMeta .loaderText span span {
-  padding-left: 1em;
+  padding-left: 1rem;
 }
 
 .Editor-suggestionsBody .loaderText span span {
@@ -331,12 +331,12 @@ li.DocName span.ellipsis {
 }
 
 .TransUnitLink.form-group {
-  padding-top: 0.75em;
+  padding-top: 0.75rem;
 }
 
 .TransUnitLink.form-group .form-control {
   color: var(--Editor-color-dark);
-  height: 2.25em;
+  height: 2.25rem;
   width: 90%;
 }
 
@@ -348,7 +348,7 @@ li.DocName span.ellipsis {
 }
 
 .panel-group {
-  margin-bottom: 1.429em;
+  margin-bottom: 1.429rem;
 }
 
 .panel-group .panel {
@@ -357,7 +357,7 @@ li.DocName span.ellipsis {
 }
 
 .panel-group .panel + .panel {
-  margin-top: 0.357em;
+  margin-top: 0.357rem;
 }
 
 .panel-group .panel-heading {
@@ -383,12 +383,12 @@ li.DocName span.ellipsis {
   border-radius: var(--border-radius-base);
   box-shadow: 0 1px 1px rgba(0, 0, 0, .05);
   -webkit-box-shadow: 0 1px 1px rgba(0, 0, 0, .05);
-  margin-bottom: 1.429em;
+  margin-bottom: 1.429rem;
 }
 
 .panel-body {
   color: var(--brand-primary);
-  font-size: 1em;
+  font-size: 1rem;
   padding: var(--padding-large-vertical);
 }
 
@@ -398,7 +398,7 @@ li.DocName span.ellipsis {
 
 .panel-title {
   color: inherit;
-  font-size: 1.143em;
+  font-size: 1.143rem;
   margin-bottom: 0;
   margin-top: 0;
   padding-bottom: 0
@@ -416,7 +416,7 @@ li.DocName span.ellipsis {
   border-top-left-radius: var(--Editor-border-radius-small);
   border-top-right-radius: var(--Editor-border-radius-small);
   color: var(--brand-secondary);
-  font-size: 1.1em !important;
+  font-size: 1.1rem !important;
   font-weight: 600;
   padding: var(--padding-small-horizontal);
 }
@@ -471,7 +471,7 @@ li.DocName span.ellipsis {
   left: 0;
   outline: 0;
   overflow: hidden;
-  padding: 1em;
+  padding: 1rem;
   position: fixed;
   right: 0;
   top: 0;
@@ -502,7 +502,7 @@ li.DocName span.ellipsis {
 }
 
 .modal-dialog {
-  margin: 1em;
+  margin: 1rem;
   position: relative;
   width: auto;
 }
@@ -557,14 +557,14 @@ li.DocName span.ellipsis {
 .modal-title {
   font-size: 1.725rem;
   font-weight: 400;
-  line-height: 1.333em;
+  line-height: 1.333rem;
   margin: 0;
   text-align: center;
 }
 
 .modal-body {
   color: #333;
-  padding: 2em;
+  padding: 2rem;
   position: relative;
 }
 
@@ -584,14 +584,14 @@ li.DocName span.ellipsis {
 .modal-footer {
   background: rgba(0, 0, 0, .05);
   border-top: 0;
-  padding: 1em;
+  padding: 1rem;
   right: 0;
   text-align: right;
 }
 
 .modal-footer .btn + .btn {
   margin-bottom: 0;
-  margin-left: 0.75em;
+  margin-left: 0.75rem;
 }
 
 .modal-footer .btn-group .btn + .btn {
@@ -614,18 +614,18 @@ h4.modal-title {
   color: var(--Editor-color-bright);
   font-size: 1.728rem;
   font-weight: 300;
-  line-height: 1em;
+  line-height: 1rem;
   text-align: center;
 }
 
 .label {
   color: #fff;
   border-radius: var(--Editor-border-radius-small);
-  padding: 0.21429em 0.42857em;
+  padding: 0.21429rem 0.42857rem;
 }
 
 .panel-body h3 {
-  font-size: 1.2em;
+  font-size: 1.2rem;
   font-weight: 500;
 }
 
@@ -639,13 +639,13 @@ h4.modal-title {
 
 .modal-body .list-group-item-heading {
   color: var(--Editor-color-dark);
-  margin-top: 0.5em;
+  margin-top: 0.5rem;
 }
 
 .panel-body .modal-term {
   color: var(--Editor-color-dark);
-  font-size: 1.1em;
-  line-height: 2em;
+  font-size: 1.1rem;
+  line-height: 2rem;
 }
 
 .row span.s1, .row span.s0, .row span.n1 {
@@ -679,7 +679,7 @@ h4.modal-title {
 }
 
 .CommentBox {
-  margin-top: 1em;
+  margin-top: 1rem;
 }
 
 .CommentBox li {
@@ -691,7 +691,7 @@ h4.modal-title {
 }
 
 ul.listInline li.s1 {
-  margin-right: 0.375em;
+  margin-right: 0.375rem;
 }
 
 ul.Source-infoList {
@@ -871,7 +871,7 @@ ul.u-listInline li .u-textHighlight {
 }
 
 .tab-pane #tab1, .tab-pane #tab2 {
-  margin-top: 2.7em;
+  margin-top: 2.7rem;
 }
 
 .nav-tabs .dropdown-menu {
@@ -1029,17 +1029,17 @@ label span.n1 {
 
 @media (max-width: 740px) {
   .TransUnit-heading {
-    padding-left: 1.5em;
+    padding-left: 1.5rem;
   }
 
   td.StringLong {
     display: table-row !important;
-    max-width: 10em !important;
+    max-width: 10rem !important;
     padding-bottom: 0 !important;
   }
 
   .StringLong span {
-    max-width: 9.5em !important;
+    max-width: 9.5rem !important;
   }
 }
 
@@ -1065,17 +1065,17 @@ label span.n1 {
   }
 
   .hide-mdplus {
-    margin-right: 0.75em;
+    margin-right: 0.75rem;
   }
 
   td.StringLong {
     display: table-row !important;
-    max-width: 12em !important;
+    max-width: 12rem !important;
     padding-bottom: 0 !important;
   }
 
   .StringLong span {
-    max-width: 10em !important;
+    max-width: 10rem !important;
   }
 
   .hide-md {
@@ -1085,18 +1085,18 @@ label span.n1 {
 
   #SidebarEditor-tabsPane1 table tbody tr {
     display: inline-table;
-    margin-bottom: 1em;
+    margin-bottom: 1rem;
   }
 
   #SidebarEditor-tabsPane1.tab-pane.active table tbody tr {
     border-bottom: 1px solid rgb(99, 156, 173);
-    padding-bottom: 0.375em;
+    padding-bottom: 0.375rem;
     width: 100%;
   }
 
   #SidebarEditor-tabsPane1 td .Button--primary {
     float: none;
-    margin-bottom: 1em;
+    margin-bottom: 1rem;
   }
 
 }
@@ -1113,12 +1113,12 @@ label span.n1 {
   }
 
   td.StringLong {
-    min-width: 6em;
-    padding-bottom: 0.75em;
+    min-width: 6rem;
+    padding-bottom: 0.75rem;
   }
 
   .StringLong span {
-    max-width: 5.5em;
+    max-width: 5.5rem;
   }
 
   #SidebarEditor-tabsPane1 table tbody tr {
@@ -1130,17 +1130,17 @@ label span.n1 {
   }
 
   #SidebarEditor-tabsPane1 table tbody tr td {
-    padding-right: 0.5em;
+    padding-right: 0.5rem;
   }
 }
 
 @media (min-width: 1100px) {
   td.StringLong {
-    max-width: 10em;
+    max-width: 10rem;
   }
 
   .StringLong span {
-    max-width: 9.5em;
+    max-width: 9.5rem;
   }
 
   li.DocName .row {

--- a/server/zanata-frontend/src/app/editor/containers/Sidebar/index.css
+++ b/server/zanata-frontend/src/app/editor/containers/Sidebar/index.css
@@ -188,7 +188,7 @@ table th {
 }
 
 table tbody tr {
-  height: 2em;
+  height: 2rem;
 }
 
 table.GlossaryDetails-table {
@@ -196,7 +196,7 @@ table.GlossaryDetails-table {
 }
 
 table.GlossaryDetails-table tbody td {
-  font-size: 1em;
+  font-size: 1rem;
   white-space: inherit;
 }
 
@@ -216,7 +216,7 @@ table.GlossaryDetails-table thead th {
 
 .GlossaryDetails-panel.panel .panel-body {
   height: inherit;
-  max-height: 10em;
+  max-height: 10rem;
   overflow: auto;
 }
 
@@ -239,7 +239,7 @@ table.GlossaryDetails-table thead th {
 }
 
 .icon-comment svg {
-  margin-right: 0.1375em;
+  margin-right: 0.1375rem;
 }
 
 .Glossary-noResults svg, .Search-enterText svg {
@@ -281,7 +281,7 @@ table td button.gButton--link {
   font-style: normal;
   font-weight: 400;
   letter-spacing: normal;
-  line-height: 1.333em;
+  line-height: 1.333rem;
   position: absolute;
   text-align: left;
   text-decoration: none;
@@ -304,7 +304,7 @@ table td button.gButton--link {
 }
 
 .tooltip.top {
-  margin-top: -.75em;
+  margin-top: -0.75rem;
   padding: var(--Sidebar-spacing-small) 0;
 }
 
@@ -314,7 +314,7 @@ table td button.gButton--link {
   border-radius: 3px;
   color: #fff;
   max-width: 15rem;
-  padding: 0.5em;
+  padding: 0.5rem;
   text-align: center;
 }
 
@@ -336,7 +336,7 @@ span.loader span div {
   border-radius: 5px;
   box-shadow: 0 1px 1px rgba(0, 0, 0, .05);
   -webkit-box-shadow: 0 1px 1px rgba(0, 0, 0, .05);
-  margin-bottom: 1.3em;
+  margin-bottom: 1.3rem;
 }
 
 .panel-default, .well blockquote {
@@ -345,7 +345,7 @@ span.loader span div {
 
 .panel-body {
   color: var(--Sidebar-panel-dark);
-  padding: 0.85em;
+  padding: 0.85rem;
 }
 
 .panel-title {
@@ -358,7 +358,7 @@ span.loader span div {
 .panel.panel-side {
   background-color: #fff !important;
   border: solid 1px var(--Sidebar-border) !important;
-  padding: 0.5em;
+  padding: 0.5rem;
 }
 
 .panel-heading {
@@ -367,14 +367,14 @@ span.loader span div {
   border-top-left-radius: 3px;
   border-top-right-radius: 3px;
   color: var(--Sidebar-color-highlight);
-  font-size: 1.1em !important;
+  font-size: 1.1rem !important;
   font-weight: 600;
 }
 
 .panel-body h3 {
   color: var(--Sidebar-color-highlight);
   margin-bottom: 0.714rem;
-  margin-top: 0.5em;
+  margin-top: 0.5rem;
 }
 
 .InlineSearch {
@@ -444,7 +444,7 @@ li .checkbox input {
 
 select.SettingsSelect {
   color: var(--Sidebar-color-text);
-  margin-bottom: 1em;
+  margin-bottom: 1rem;
 }
 
 #SidebarEditorTabs-pane2 {
@@ -587,7 +587,7 @@ h3.SettingsHeading {
 
 @media (max-width: 740px) {
   table td button.Button--link {
-    margin-right: 1em;
+    margin-right: 1rem;
     vertical-align: middle;
   }
 }

--- a/server/zanata-frontend/src/app/editor/containers/SuggestionDetailsModal/index.css
+++ b/server/zanata-frontend/src/app/editor/containers/SuggestionDetailsModal/index.css
@@ -8,12 +8,12 @@
 
 .Editor-suggestionsBody .TransUnit--suggestion .TransUnit-text--tight {
     padding-top: 0 !important;
-    font-size: 1em;
+    font-size: 1rem;
 }
 
 .TransUnit--suggestion .TransUnit-text--tight {
     padding-top: 40px !important;
-    font-size: 1.2em;
+    font-size: 1.2rem;
 }
 /* Based on bootstrap styles. */
 
@@ -35,7 +35,7 @@
 }
 
 .panel-group {
-    margin-bottom: 1.429em;
+    margin-bottom: 1.429rem;
 }
 
 .panel-group .panel {
@@ -44,7 +44,7 @@
 }
 
 .panel-group .panel + .panel {
-    margin-top: 0.357em;
+    margin-top: 0.357rem;
 }
 
 .panel-group .panel-heading {
@@ -65,19 +65,19 @@
 }
 
 .panel {
-    margin-bottom: 1.429em;
+    margin-bottom: 1.429rem;
     border: 1px solid transparent;
     border-radius: var(--border-radius-base);
     -webkit-box-shadow: 0 1px 1px rgba(0, 0, 0, .05);
     box-shadow: 0 1px 1px rgba(0, 0, 0, .05);
     background-color: #fcfcfc;
-    line-height: 1.2em;
+    line-height: 1.2rem;
 }
 
 .panel-body {
     padding: var(--padding-large-vertical);
     color: var(--brand-primary);
-    font-size: 1em;
+    font-size: 1rem;
 }
 
 .panel-body h3 {
@@ -88,7 +88,7 @@
     margin-top: 0;
     margin-bottom: 0;
     color: inherit;
-    font-size: 1.143em;
+    font-size: 1.143rem;
     padding-bottom: 0;
 }
 
@@ -103,14 +103,14 @@
     border-bottom: 1px solid transparent;
     border-top-left-radius: var(--border-radius-small);
     border-top-right-radius: var(--border-radius-small);
-    font-size: 1.1em !important;
+    font-size: 1.1rem !important;
     font-weight: 600;
     color: var(--brand-secondary);
     background-color: #fff;
 }
 
 .panel-heading .TransUnit-details {
-  line-height: 1.2em;
+  line-height: 1.2rem;
 }
 
 .panel-info > .panel-heading {
@@ -168,17 +168,17 @@
 }
 
 .TransUnit-sourceHeading {
-    padding-left: 1.1em;
+    padding-left: 1.1rem;
     top: inherit;
-    line-height: 3em;
+    line-height: 3rem;
     font-weight: 600;
     color: var(--brand-primary);
 }
 
 .TransUnit-targetHeading {
-    padding-left: 1.9em;
+    padding-left: 1.9rem;
     top: inherit;
-    line-height: 3em;
+    line-height: 3rem;
     font-weight: 600;
     color: var(--brand-primary);
 }
@@ -187,18 +187,18 @@
     font-size: 70%;
     font-weight: 600;
     display: inline;
-    padding: 0.2em 0.6em 0.3em;
+    padding: 0.2rem 0.6rem 0.3rem;
     text-align: center;
     vertical-align: super;
     white-space: nowrap;
     color: #fff;
-    border-radius: 0.25em;
+    border-radius: 0.25rem;
 }
 
 .TransUnit-details {
     white-space: normal;
     word-break: break-all;
-    line-height: 1em;
+    line-height: 1rem;
 }
 
 .TransUnit-details .u-listInline {
@@ -211,7 +211,7 @@ li.TransUnit-label-suggestions {
 }
 
 span.TransUnit-details-inner {
-    padding-left: 0.375em;
+    padding-left: 0.375rem;
     font-weight: 500;
     color: #444c54;
 }
@@ -219,12 +219,12 @@ span.TransUnit-details-inner {
 
 @media (max-width: 740px) {
   .TransUnit-sourceHeading {
-    padding-left: 2.1em;
+    padding-left: 2.1rem;
   }
 
   .TransUnit--suggestion .TransUnit-text--tight {
     padding-top: 0 !important;
-    font-size: 1.2em;
+    font-size: 1.2rem;
   }
 
 }

--- a/server/zanata-frontend/src/app/styles/legacy.less
+++ b/server/zanata-frontend/src/app/styles/legacy.less
@@ -270,9 +270,6 @@ body.bodyStyle {
     height: auto;
     min-height: max-content;
   }
-  h1 {
-    height: 1.1rem;
-  }
   .h1, h1 {
     font-weight: 500 !important;
   }

--- a/server/zanata-frontend/src/app/styles/legacy.less
+++ b/server/zanata-frontend/src/app/styles/legacy.less
@@ -71,7 +71,7 @@ body.bodyStyle {
   }
   .u-textNeutral-top {
     color: @color-neutral;
-    margin-top: 0.3em;
+    margin-top: 0.3rem;
   }
   .u-textNeutral, .txt--neutral {
     color: @color-neutral;
@@ -271,7 +271,7 @@ body.bodyStyle {
     min-height: max-content;
   }
   h1 {
-    height: 1.1em;
+    height: 1.1rem;
   }
   .h1, h1 {
     font-weight: 500 !important;

--- a/server/zanata-frontend/src/app/styles/style.less
+++ b/server/zanata-frontend/src/app/styles/style.less
@@ -63,7 +63,7 @@
     padding-left: @spacing-base;
     padding-right: @spacing-base;
   }
-  .wideView#languages, .wideView#glossary {
+  .wideView.languages, .wideView#glossary {
     padding-bottom: 3rem;
   }
   .wideView#profile, .wideView#glossary {
@@ -222,7 +222,7 @@
   }
   .flexTab {
     overflow: hidden;
-    padding: 1em;
+    padding: 1rem;
   }
   .flexChart-container {
     display: flex;
@@ -339,7 +339,7 @@
   }
   .react-autosuggest__suggestion {
     cursor: pointer;
-    padding: 0.4em 0.5rem;
+    padding: 0.4rem 0.5rem;
   }
   .react-autosuggest__suggestion--highlighted {
     background-color: @color-neutral;
@@ -858,7 +858,7 @@
   }
   fieldset {
     margin: 0 2px;
-    padding: 0.35em 0.625em @spacing-rq;
+    padding: 0.35rem 0.625rem @spacing-rq;
     border: 1px solid silver;
   }
   legend {
@@ -989,8 +989,8 @@
     font-size: 2.25rem !important;
     color: @color-new-zanata-blue;
     font-weight: 500;
-    line-height: 1em;
-    letter-spacing: -0.05em;
+    line-height: 1rem;
+    letter-spacing: -0.05rem;
   }
   .h2, h2 {
     font-size: 1.875rem;
@@ -1782,7 +1782,7 @@
   }
   button.btnSort i.fa.fa-sort {
     color: @color-neutral;
-    margin-right: 1em;
+    margin-right: 1rem;
   }
   .btn.active.focus, .btn.active:focus, .btn.focus, .btn:active.focus, .btn:active:focus, .btn:focus {
     outline: 0;
@@ -1967,7 +1967,7 @@
     width: 100%;
   }
   .btn-sm .loaderText {
-    font-size: 1em;
+    font-size: 1rem;
   }
   .btn-block+.btn-block {
     margin-top: @spacing-btn-block;
@@ -2179,7 +2179,7 @@
   } // The dropdown menu (ul)
   .dropdown-menu {
     position: absolute;
-    font-size: 1em;
+    font-size: 1rem;
     top: 100%;
     left: 0;
     z-index: @zindex-dropdown;
@@ -2717,8 +2717,8 @@
     border-color: #9cbeca #bdd4dc #cedfe5;
   }
   .Select-menu-outer {
-    border-bottom-right-radius: 0.375em;
-    border-bottom-left-radius: 0.375em;
+    border-bottom-right-radius: 0.375rem;
+    border-bottom-left-radius: 0.375rem;
     background-color: #fff;
     border: 1px solid #bdd4dc;
     border-top-color: #deeaee;
@@ -2796,8 +2796,8 @@
     border-color: #9cbeca #bdd4dc #cedfe5;
   }
   .Select-menu-outer {
-    border-bottom-right-radius: 0.375em;
-    border-bottom-left-radius: 0.375em;
+    border-bottom-right-radius: 0.375rem;
+    border-bottom-left-radius: 0.375rem;
     background-color: #fff;
     box-shadow: 0 1px 0 rgba(0, 0, 0, 0.06);
     margin-top: -1px;
@@ -2823,20 +2823,20 @@
     color: #8799ad;
     cursor: pointer;
     display: block;
-    padding: 0.375em 0.75em;
-    line-height: 1em;
+    padding: 0.375rem 0.75rem;
+    line-height: 1rem;
   }
   .Select-control {
     background-color: #fff;
     border-color: #cedfe5 #bdd4dc #9cbeca;
-    border-radius: 0.375em;
-    border: 0.125em solid #bdd4dc;
+    border-radius: 0.375rem;
+    border: 0.125rem solid #bdd4dc;
     color: #54667a;
     cursor: default;
     display: table;
     border-spacing: 0;
     border-collapse: separate;
-    height: 2.25em;
+    height: 2.25rem;
     outline: none;
     overflow: hidden;
     position: relative;
@@ -2846,8 +2846,8 @@
     bottom: 0;
     color: #bdd4dc;
     left: 0;
-    padding-left: 0.75em;
-    padding-right: 0.75em;
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
     position: absolute;
     right: 0;
     top: 0;
@@ -2857,9 +2857,9 @@
     white-space: nowrap;
   }
   .Select-input {
-    height: 2em;
-    padding-left: 0.75em;
-    padding-right: 0.75em;
+    height: 2rem;
+    padding-left: 0.75rem;
+    padding-right: 0.75rem;
     vertical-align: middle;
   }
   .Select-input input {
@@ -2877,20 +2877,20 @@
     position: relative;
     text-align: center;
     vertical-align: middle;
-    width: 1.5625em;
-    padding-right: 0.3125em;
+    width: 1.5625rem;
+    padding-right: 0.3125rem;
   }
   .Select-arrow-zone:focus {
     outline: 0;
   }
   .Select-option:last-child {
-    border-bottom-right-radius: 0.375em;
-    border-bottom-left-radius: 0.375em;
+    border-bottom-right-radius: 0.375rem;
+    border-bottom-left-radius: 0.375rem;
   }
   .Select-arrow {
     border-color: #bdd4dc transparent transparent;
     border-style: solid;
-    border-width: 0.3125em 0.3125em 0.15625em;
+    border-width: 0.3125rem 0.3125rem 0.15625rem;
     display: inline-block;
     height: 0;
     width: 0;
@@ -2904,7 +2904,7 @@
     position: relative;
     text-align: center;
     vertical-align: middle;
-    width: 1.6em;
+    width: 1.6rem;
   }
   .pageCurrent {
     color: @color-muted;
@@ -3234,8 +3234,8 @@
     font-size: 0.9rem;
     line-height: 1rem;
     background-color: #546677;
-    padding-left: 0.375em;
-    padding-right: 0.375em;
+    padding-left: 0.375rem;
+    padding-right: 0.375rem;
     color: #fff;
   }
   .badge:empty {
@@ -3383,7 +3383,7 @@
     border-bottom: 1px solid transparent;
     border-top-left-radius: @border-radius-small;
     border-top-right-radius: @border-radius-small;
-    font-size: 1.1em !important;
+    font-size: 1.1rem !important;
     font-weight: 600;
     color: @color-light;
     background-color: #fff;
@@ -3393,10 +3393,10 @@
     hyphens: initial;
   }
   .tmPanel .panel-body {
-    padding: 0.375em;
-    margin-left: 1em;
+    padding: 0.375rem;
+    margin-left: 1rem;
     color: @color-neutral;
-    font-size: 0.75em;
+    font-size: 0.75rem;
     font-weight: 600;
   }
   .tmPanel .panel-body .and {
@@ -3408,10 +3408,10 @@
     vertical-align: sub;
   }
   #settingsMaintainersForm #maintainerAutocomplete {
-    margin-bottom: 11em;
+    margin-bottom: 11rem;
   }
   #groupInfo h1 {
-    height: 1.1em;
+    height: 1.1rem;
   }
   .ellipsis {
     text-overflow: ellipsis;
@@ -3986,13 +3986,13 @@
     padding-top: @spacing-base-and-a-half;
   }
   table.tableSearch {
-    max-width: 36.05em;
+    max-width: 36.05rem;
   }
   .tabsContent {
     padding-bottom: @spacing-base-and-a-half;
   }
   .g--padded {
-    padding-bottom: 4.2em !important;
+    padding-bottom: 4.2rem !important;
   }
   li.moreContent-info {
     padding-top: @spacing-base-and-a-half;
@@ -4003,7 +4003,7 @@
     padding-top: @spacing-base-and-a-half;
   }
   table.tableSearch {
-    max-width: 36.05em;
+    max-width: 36.05rem;
   }
   .textMeta.content {
     padding-top: 0;

--- a/server/zanata-frontend/src/app/styles/style.less
+++ b/server/zanata-frontend/src/app/styles/style.less
@@ -989,7 +989,7 @@
     font-size: 2.25rem !important;
     color: @color-new-zanata-blue;
     font-weight: 500;
-    line-height: 1rem;
+    line-height: 2.25rem;
     letter-spacing: -0.05rem;
   }
   .h2, h2 {


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2400

Use 'rem', not 'em' in frontend css 
https://getflywheel.com/layout/rems-ems-and-pixels-whats-the-difference/

Px or pixels is still used where absolute sizing must be set

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
