### PR TITLE
fix(ZNTA-2473) background colour of editor sidebar panels

### DIFF
--- a/server/zanata-frontend/src/app/editor/containers/Sidebar/index.css
+++ b/server/zanata-frontend/src/app/editor/containers/Sidebar/index.css
@@ -32,6 +32,7 @@
   margin-top: 90px !important;
   position: static !important;
   width: 35%;
+  background-color: #fff;
 }
 
 .sidebar-editor :focus {
@@ -447,10 +448,6 @@ select.SettingsSelect {
   margin-bottom: 1em;
 }
 
-#SidebarEditorTabs-pane2 {
-  background-color: var(--Sidebar-tabpane);
-}
-
 .SidebarActivity {
   padding-bottom: 0.5rem;
   padding-top: 0.5rem;
@@ -542,7 +539,6 @@ img.ActivityAvatar {
 }
 
 .TransUnit-commentBox {
-  margin-top: 1rem;
   padding: 0.75rem;
 }
 

--- a/server/zanata-frontend/src/app/editor/containers/Sidebar/index.css
+++ b/server/zanata-frontend/src/app/editor/containers/Sidebar/index.css
@@ -559,6 +559,10 @@ img.ActivityAvatar {
   font-weight: 500;
 }
 
+.sidebar-editor .hide-md {
+  padding-left: 0.375rem;
+}
+
 h2.SettingsHeading {
   padding-bottom:1rem;
 }


### PR DESCRIPTION
JIRA issue URL:  https://zanata.atlassian.net/browse/ZNTA-2473

Improve spacing and layout of activity panel in react editor

### Before

![activity](https://user-images.githubusercontent.com/18179401/38287783-e9a40d6a-380f-11e8-9f55-b0485c425915.png)

### After
<img width="565" alt="activity2" src="https://user-images.githubusercontent.com/18179401/38287873-87b76da8-3810-11e8-8ecf-15b2929bba71.png">


## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
