### PR TITLE
style(ZNTA-2488) add Tachyons css utility classes to frontend

### DIFF
--- a/server/zanata-frontend/src/app/entrypoint/index.js
+++ b/server/zanata-frontend/src/app/entrypoint/index.js
@@ -15,6 +15,7 @@ import Root from '../containers/Root'
 
 import '../styles/style.less'
 import '../editor/index.css'
+import '../../node_modules/tachyons/css/tachyons.min.css'
 
 WebFont.load({
   google: {

--- a/server/zanata-frontend/src/package.json
+++ b/server/zanata-frontend/src/package.json
@@ -207,6 +207,7 @@
     "suitcss-utils-size": "0.7.1",
     "suitcss-utils-text": "0.4.1",
     "svg-sprite": "1.3.7",
+    "tachyons": "^4.9.1",
     "ts-jest": "^22.0.1",
     "tslib": "^1.9.0",
     "typesafe-actions": "^1.1.2",

--- a/server/zanata-frontend/src/yarn.lock
+++ b/server/zanata-frontend/src/yarn.lock
@@ -10202,6 +10202,10 @@ table@^4.0.1:
     slice-ansi "1.0.0"
     string-width "^2.1.1"
 
+tachyons@^4.9.1:
+  version "4.9.1"
+  resolved "https://registry.yarnpkg.com/tachyons/-/tachyons-4.9.1.tgz#f88d7059d6e53c833bf9351a26f18314c8fdc76a"
+
 tap-parser@~0.4.0:
   version "0.4.3"
   resolved "https://registry.yarnpkg.com/tap-parser/-/tap-parser-0.4.3.tgz#a4eae190c10d76c7a111921ff38bbe4d58f09eea"


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2488

### Reviewer/s
So that developers can quickly make padding/spacing modifications to css components where antd is not suitable, the Tachyons css utility package has been added via yarn and loaded in frontend entrypoint.

- For an overview of the utility styles: http://tachyons.io/
- Utility styles in detail: http://tachyons.io/docs
- All css classes: https://github.com/tachyons-css/tachyons/blob/master/css/tachyons.css

### QA
To test, add one of the utility classes to a pre existing css class in the browser inspector and inspect change

_eg. add `ttu` to some text class to convert it all to uppercase_

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
