### PR TITLE
style: dynamically size editor sidebar 

### DIFF
--- a/server/zanata-frontend/src/app/editor/containers/Sidebar/index.css
+++ b/server/zanata-frontend/src/app/editor/containers/Sidebar/index.css
@@ -23,16 +23,27 @@
   --Editor-color-rejected: #FFA800;
 }
 
+/* const height = this.props.headerOpen ? '91%' : '93%'
+const margin = this.props.headerOpen ? '6rem' : '3rem' */
+
 .sidebar-editor {
   border-left: solid 1px var(--Sidebar-border);
   float: right !important;
-  height: 99.5% !important;
   overflow-x: hidden !important;
   overflow-y: auto !important;
-  margin-top: 90px !important;
   position: static !important;
   width: 35%;
   background-color: #fff;
+}
+
+.sidebar-editor-contract {
+  height: 91% !important;
+  margin-top: 6rem !important;
+}
+
+.sidebar-editor-expand {
+  height: 95.3% !important;
+  margin-top: 3rem !important;
 }
 
 .sidebar-editor :focus {

--- a/server/zanata-frontend/src/app/editor/containers/Sidebar/index.js
+++ b/server/zanata-frontend/src/app/editor/containers/Sidebar/index.js
@@ -3,7 +3,7 @@ import React from 'react'
 import { Component } from 'react'
 import * as PropTypes from 'prop-types'
 import { connect } from 'react-redux'
-import { getSidebarVisible } from '../../reducers'
+import { getSidebarVisible, getNavHeaderVisible } from '../../reducers'
 import { setSidebarVisibility } from '../../actions'
 import ReactSidebar from 'react-sidebar'
 import SidebarContent from '../SidebarContent'
@@ -19,6 +19,8 @@ const defaultState = {
 class Sidebar extends Component {
   static propTypes = {
     open: PropTypes.bool.isRequired,
+
+    headerOpen: PropTypes.bool.isRequired,
 
     setSidebarVisibility: PropTypes.func.isRequired,
     // The main content display should be passed as children to this component
@@ -53,7 +55,9 @@ class Sidebar extends Component {
 
   render () {
     const content = <SidebarContent />
-
+    const height = this.props.headerOpen
+        ? 'sidebar-editor sidebar-editor-contract'
+        : 'sidebar-editor sidebar-editor-expand'
     return (
       <ReactSidebar
         sidebar={content}
@@ -68,7 +72,7 @@ class Sidebar extends Component {
             overflowY: 'auto'
           }
         }}
-        sidebarClassName="sidebar-editor">
+        sidebarClassName={height}>
         {this.props.children}
       </ReactSidebar>
     )
@@ -77,7 +81,8 @@ class Sidebar extends Component {
 
 function mapStateToProps (state) {
   return {
-    open: getSidebarVisible(state)
+    open: getSidebarVisible(state),
+    headerOpen: getNavHeaderVisible(state)
   }
 }
 


### PR DESCRIPTION
Dynamically size editor sidebar to match header expanded/contracted states

## Expanded header:
![expandedheader](https://user-images.githubusercontent.com/7971187/38970865-44022f9a-43db-11e8-9704-d4a1a8108038.png)

## Contracted header before:
![before](https://user-images.githubusercontent.com/7971187/38970890-77899bd2-43db-11e8-8200-d85633aa48b1.png)

## Contracted header after:
![contractedheader](https://user-images.githubusercontent.com/7971187/38970870-4c0d1c90-43db-11e8-9d33-ac764bdfd42c.png)
## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
