### PR TITLE
refactor(ZNTA-2508): add aria-label to antd buttons

### DIFF
--- a/server/zanata-frontend/src/app/components/DraggableVersionPanels/DraggableVersionPanels.test.js
+++ b/server/zanata-frontend/src/app/components/DraggableVersionPanels/DraggableVersionPanels.test.js
@@ -29,7 +29,7 @@ describe('DraggableVersionPanels', () => {
         {'ver1'} <span className='u-textMuted'> {'meikai1'}
         </span> <LockIcon status={'ACTIVE'} />
         {" "}
-        <Button className='close rm-version-btn btn-xs'
+        <Button className='close rm-version-btn btn-xs' aria-label='button'
           onClick={callback} icon='close' />
       </ListGroupItem>
     )

--- a/server/zanata-frontend/src/app/components/DraggableVersionPanels/index.tsx
+++ b/server/zanata-frontend/src/app/components/DraggableVersionPanels/index.tsx
@@ -47,7 +47,7 @@ export class Item extends Component<ItemProps, {}> {
       {version.id} <span className="u-textMuted"> {projectSlug}
       </span> <LockIcon status={version.status} />
       {" "}
-      <Button className="close rm-version-btn btn-xs"
+      <Button className="close rm-version-btn btn-xs" aria-label="button"
         onClick={this.removeVersion} icon="close" />
     </ListGroupItem>
   }

--- a/server/zanata-frontend/src/app/components/Notification/component.js
+++ b/server/zanata-frontend/src/app/components/Notification/component.js
@@ -80,7 +80,7 @@ class Notification extends Component {
             <Row>
               <ButtonGroup className='u-pullRight'>
                 <Button className='btn-primary'
-                  id='btn-notification-close'
+                  id='btn-notification-close' aria-label="button"
                   onClick={this.clearMessage}>
                   Close
                 </Button>

--- a/server/zanata-frontend/src/app/containers/Admin/Review.js
+++ b/server/zanata-frontend/src/app/containers/Admin/Review.js
@@ -93,7 +93,7 @@ class AdminReview extends Component {
         {criteriaList}
         {newEntryForm}
         <div className='rejection-btns'>
-          <Button type="primary" icon="plus"
+          <Button type="primary" icon="plus" aria-label="button"
             onClick={this.showAddNewEntryForm()}>
           New review criteria entry</Button>
         </div>

--- a/server/zanata-frontend/src/app/containers/Explore/TeaserListHeader.jsx
+++ b/server/zanata-frontend/src/app/containers/Explore/TeaserListHeader.jsx
@@ -43,7 +43,8 @@ const TeaserListHeader = ({
           <div className='teaserHeader-inner'>
             <div className='teaserHeader-pagination'>
               <Button icon='left' className='btn-link iconsHeader'
-                disabled={currentPage === 1}
+                aria-label='button'
+                disabled={currentPage === 1} aria-label={}
                 onClick={() => {
                   updatePage(type, currentPage, totalPage, false)
                 }} />

--- a/server/zanata-frontend/src/app/containers/Explore/TeaserListHeader.jsx
+++ b/server/zanata-frontend/src/app/containers/Explore/TeaserListHeader.jsx
@@ -44,12 +44,13 @@ const TeaserListHeader = ({
             <div className='teaserHeader-pagination'>
               <Button icon='left' className='btn-link iconsHeader'
                 aria-label='button'
-                disabled={currentPage === 1} aria-label={}
+                disabled={currentPage === 1}
                 onClick={() => {
                   updatePage(type, currentPage, totalPage, false)
                 }} />
               <span className='pageCurrent'>{currentPage} of {totalPage}</span>
               <Button icon='right' className='btn-link iconsHeader'
+                aria-label='button'
                 disabled={currentPage === totalPage}
                 onClick={() => {
                   updatePage(type, currentPage, totalPage, false)

--- a/server/zanata-frontend/src/app/containers/Explore/index.js
+++ b/server/zanata-frontend/src/app/containers/Explore/index.js
@@ -158,7 +158,7 @@ class Explore extends Component {
             />
             <Button
               className='btn-link' disabled={isEmpty(searchText)}
-              onClick={this.handleClearSearch}>
+              onClick={this.handleClearSearch} aria-label="button">
               Cancel
             </Button>
           </div>

--- a/server/zanata-frontend/src/app/containers/Glossary/index.js
+++ b/server/zanata-frontend/src/app/containers/Glossary/index.js
@@ -230,13 +230,13 @@ class Glossary extends Component {
                 {displayPaging &&
                   <div className='u-pullRight glossaryPaging'>
                     <Button className='btn-link' disabled={currentPage <= 1}
-                      title='First page' icon='left'
+                      title='First page' icon='left' aria-label='button'
                       onClick={() => {
                         gotoFirstPage(currentPage, totalPage)
                       }}
                     />
                     <Button className='btn-link' disabled={currentPage <= 1}
-                      title='Previous page' icon='left'
+                      title='Previous page' icon='left' aria-label='button'
                       onClick={
                       () => {
                         gotoPreviousPage(currentPage, totalPage)
@@ -245,14 +245,14 @@ class Glossary extends Component {
                     <span className='u-textNeutral-top'>
                       {currentPage} of {totalPage}
                     </span>
-                    <Button className='btn-link'
+                    <Button className='btn-link' aria-label='button'
                       disabled={currentPage === totalPage}
                       title='Next page' icon='right'
                       onClick={() => {
                         gotoNextPage(currentPage, totalPage)
                       }}
                     />
-                    <Button className='btn-link'
+                    <Button className='btn-link' aria-label='button'
                       disabled={currentPage === totalPage}
                       title='Last page' icon='right'
                       onClick={() => {

--- a/server/zanata-frontend/src/app/containers/Languages/index.js
+++ b/server/zanata-frontend/src/app/containers/Languages/index.js
@@ -128,6 +128,7 @@ class Languages extends Component {
                 <div>
                   <Button type="primary" icon="plus"
                     id="btn-language-add-new"
+                    aria-label="button"
                     onClick={handleOnDisplayNewLanguage}>
                   Add new language</Button>
                   <NewLanguageModal />

--- a/server/zanata-frontend/src/app/containers/UserProfile/CalendarMonthMatrix.jsx
+++ b/server/zanata-frontend/src/app/containers/UserProfile/CalendarMonthMatrix.jsx
@@ -94,7 +94,7 @@ const CalendarMonthMatrix = ({
         </div>
         {selectedDay &&
         (<div>
-          <Button className='btn-link btn-clear'
+          <Button className='btn-link btn-clear' aria-label='button'
             onClick={() => handleSelectedDayChanged(null)}>
             Clear selection
           </Button>

--- a/server/zanata-frontend/src/app/containers/UserProfile/RecentContributions.jsx
+++ b/server/zanata-frontend/src/app/containers/UserProfile/RecentContributions.jsx
@@ -74,7 +74,7 @@ class RecentContributions extends React.Component {
           <h2 className='userProfile-recentContributions'>
           Recent Contributions</h2>
           <div className='dateRange-container'>
-            <Button className='btn-link u-pullRight'
+            <Button className='btn-link u-pullRight' aria-label='button'
               onClick={() => this.onToggleShowDateRange()}>
               <span className='dateRange-textField'>
                 <TextInput editable={false} value={displayDateRange} />
@@ -99,11 +99,11 @@ class RecentContributions extends React.Component {
                 </Modal.Body>
                 <Modal.Footer>
                   <span className='u-pullRight'>
-                    <Button className='btn-link'
+                    <Button className='btn-link' aria-label='button'
                       onClick={() => this.onToggleShowDateRange()}>
                       Cancel
                     </Button>
-                    <Button className='btn-primary'
+                    <Button className='btn-primary' aria-label='button'
                       onClick={
                       () => handleDateRangeChanged(this.state.dateRange)}>
                       Apply


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2508

To test the appropriate of antd buttons and align with accessibility (a11y) standards for buttons, `aria-label="button"` was added to every antd button in frontend

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
