### PR TITLE
fix(ZNTA-544): include user content in emails as plain text

### DIFF
--- a/server/services/src/main/java/org/zanata/email/ContactAdminAnonymousEmailStrategy.java
+++ b/server/services/src/main/java/org/zanata/email/ContactAdminAnonymousEmailStrategy.java
@@ -24,7 +24,7 @@ import javax.mail.internet.InternetAddress;
 import javaslang.collection.Map;
 import org.zanata.i18n.Messages;
 import com.google.common.base.Optional;
-import org.zanata.util.HtmlUtil;
+import static org.zanata.util.HtmlUtil.textToSafeHtml;
 
 public class ContactAdminAnonymousEmailStrategy extends VelocityEmailStrategy {
     private final String ipAddress;
@@ -52,8 +52,8 @@ public class ContactAdminAnonymousEmailStrategy extends VelocityEmailStrategy {
             InternetAddress[] toAddresses) {
         Map<String, Object> context =
                 super.makeContext(genericContext, toAddresses);
-        return context.put("ipAddress", ipAddress).put("htmlMessage",
-                HtmlUtil.escapeAndSanitizeHtml(htmlMessage));
+        return context.put("ipAddress", ipAddress)
+                .put("safeHtmlMessage", textToSafeHtml(htmlMessage));
     }
 
     @java.beans.ConstructorProperties({ "ipAddress", "userSubject",

--- a/server/services/src/main/java/org/zanata/email/ContactAdminAnonymousEmailStrategy.java
+++ b/server/services/src/main/java/org/zanata/email/ContactAdminAnonymousEmailStrategy.java
@@ -52,8 +52,9 @@ public class ContactAdminAnonymousEmailStrategy extends VelocityEmailStrategy {
             InternetAddress[] toAddresses) {
         Map<String, Object> context =
                 super.makeContext(genericContext, toAddresses);
-        String safeHTML = HtmlUtil.SANITIZER.sanitize(htmlMessage);
-        return context.put("ipAddress", ipAddress).put("htmlMessage", safeHTML);
+        String plainText = HtmlUtil.htmlToText(
+                HtmlUtil.SANITIZER.sanitize(htmlMessage));
+        return context.put("ipAddress", ipAddress).put("htmlMessage", plainText);
     }
 
     @java.beans.ConstructorProperties({ "ipAddress", "userSubject",

--- a/server/services/src/main/java/org/zanata/email/ContactAdminAnonymousEmailStrategy.java
+++ b/server/services/src/main/java/org/zanata/email/ContactAdminAnonymousEmailStrategy.java
@@ -52,9 +52,8 @@ public class ContactAdminAnonymousEmailStrategy extends VelocityEmailStrategy {
             InternetAddress[] toAddresses) {
         Map<String, Object> context =
                 super.makeContext(genericContext, toAddresses);
-        String plainText = HtmlUtil.htmlToText(
-                HtmlUtil.SANITIZER.sanitize(htmlMessage));
-        return context.put("ipAddress", ipAddress).put("htmlMessage", plainText);
+        return context.put("ipAddress", ipAddress).put("htmlMessage",
+                HtmlUtil.escapeAndSanitizeHtml(htmlMessage));
     }
 
     @java.beans.ConstructorProperties({ "ipAddress", "userSubject",

--- a/server/services/src/main/java/org/zanata/email/ContactAdminAnonymousEmailStrategy.java
+++ b/server/services/src/main/java/org/zanata/email/ContactAdminAnonymousEmailStrategy.java
@@ -29,7 +29,7 @@ import static org.zanata.util.HtmlUtil.textToSafeHtml;
 public class ContactAdminAnonymousEmailStrategy extends VelocityEmailStrategy {
     private final String ipAddress;
     private final String userSubject;
-    private final String htmlMessage;
+    private final String userMessage;
 
     @Override
     public String getBodyResourceName() {
@@ -53,15 +53,15 @@ public class ContactAdminAnonymousEmailStrategy extends VelocityEmailStrategy {
         Map<String, Object> context =
                 super.makeContext(genericContext, toAddresses);
         return context.put("ipAddress", ipAddress)
-                .put("safeHtmlMessage", textToSafeHtml(htmlMessage));
+                .put("safeHtmlMessage", textToSafeHtml(userMessage));
     }
 
     @java.beans.ConstructorProperties({ "ipAddress", "userSubject",
-            "htmlMessage" })
+            "userMessage" })
     public ContactAdminAnonymousEmailStrategy(final String ipAddress,
-            final String userSubject, final String htmlMessage) {
+            final String userSubject, final String userMessage) {
         this.ipAddress = ipAddress;
         this.userSubject = userSubject;
-        this.htmlMessage = htmlMessage;
+        this.userMessage = userMessage;
     }
 }

--- a/server/services/src/main/java/org/zanata/email/ContactAdminEmailStrategy.java
+++ b/server/services/src/main/java/org/zanata/email/ContactAdminEmailStrategy.java
@@ -59,11 +59,9 @@ public class ContactAdminEmailStrategy extends VelocityEmailStrategy {
             InternetAddress[] toAddresses) {
         Map<String, Object> context =
                 super.makeContext(genericContext, toAddresses);
-        String plainText = HtmlUtil.htmlToText(
-                HtmlUtil.SANITIZER.sanitize(htmlMessage));
         return context.put("fromLoginName", fromLoginName)
                 .put("fromName", fromName).put("replyEmail", replyEmail)
-                .put("htmlMessage", plainText);
+                .put("htmlMessage", HtmlUtil.escapeAndSanitizeHtml(htmlMessage));
     }
 
     @java.beans.ConstructorProperties({ "fromLoginName", "fromName",

--- a/server/services/src/main/java/org/zanata/email/ContactAdminEmailStrategy.java
+++ b/server/services/src/main/java/org/zanata/email/ContactAdminEmailStrategy.java
@@ -36,7 +36,7 @@ public class ContactAdminEmailStrategy extends VelocityEmailStrategy {
     private final String fromName;
     private final String replyEmail;
     private final String userSubject;
-    private final String htmlMessage;
+    private final String userMessage;
 
     @Override
     public String getBodyResourceName() {
@@ -61,18 +61,18 @@ public class ContactAdminEmailStrategy extends VelocityEmailStrategy {
                 super.makeContext(genericContext, toAddresses);
         return context.put("fromLoginName", fromLoginName)
                 .put("fromName", fromName).put("replyEmail", replyEmail)
-                .put("safeHtmlMessage", textToSafeHtml(htmlMessage));
+                .put("safeHtmlMessage", textToSafeHtml(userMessage));
     }
 
     @java.beans.ConstructorProperties({ "fromLoginName", "fromName",
-            "replyEmail", "userSubject", "htmlMessage" })
+            "replyEmail", "userSubject", "userMessage" })
     public ContactAdminEmailStrategy(final String fromLoginName,
             final String fromName, final String replyEmail,
-            final String userSubject, final String htmlMessage) {
+            final String userSubject, final String userMessage) {
         this.fromLoginName = fromLoginName;
         this.fromName = fromName;
         this.replyEmail = replyEmail;
         this.userSubject = userSubject;
-        this.htmlMessage = htmlMessage;
+        this.userMessage = userMessage;
     }
 }

--- a/server/services/src/main/java/org/zanata/email/ContactAdminEmailStrategy.java
+++ b/server/services/src/main/java/org/zanata/email/ContactAdminEmailStrategy.java
@@ -59,10 +59,11 @@ public class ContactAdminEmailStrategy extends VelocityEmailStrategy {
             InternetAddress[] toAddresses) {
         Map<String, Object> context =
                 super.makeContext(genericContext, toAddresses);
-        String safeHTML = HtmlUtil.SANITIZER.sanitize(htmlMessage);
+        String plainText = HtmlUtil.htmlToText(
+                HtmlUtil.SANITIZER.sanitize(htmlMessage));
         return context.put("fromLoginName", fromLoginName)
                 .put("fromName", fromName).put("replyEmail", replyEmail)
-                .put("htmlMessage", safeHTML);
+                .put("htmlMessage", plainText);
     }
 
     @java.beans.ConstructorProperties({ "fromLoginName", "fromName",

--- a/server/services/src/main/java/org/zanata/email/ContactAdminEmailStrategy.java
+++ b/server/services/src/main/java/org/zanata/email/ContactAdminEmailStrategy.java
@@ -23,9 +23,9 @@ package org.zanata.email;
 import com.google.common.base.Optional;
 import javaslang.collection.Map;
 import org.zanata.i18n.Messages;
-import org.zanata.util.HtmlUtil;
 import javax.mail.internet.InternetAddress;
 import static org.zanata.email.Addresses.getReplyTo;
+import static org.zanata.util.HtmlUtil.textToSafeHtml;
 
 /**
  * @author Sean Flanigan
@@ -61,7 +61,7 @@ public class ContactAdminEmailStrategy extends VelocityEmailStrategy {
                 super.makeContext(genericContext, toAddresses);
         return context.put("fromLoginName", fromLoginName)
                 .put("fromName", fromName).put("replyEmail", replyEmail)
-                .put("htmlMessage", HtmlUtil.escapeAndSanitizeHtml(htmlMessage));
+                .put("safeHtmlMessage", textToSafeHtml(htmlMessage));
     }
 
     @java.beans.ConstructorProperties({ "fromLoginName", "fromName",

--- a/server/services/src/main/java/org/zanata/email/ContactLanguageCoordinatorEmailStrategy.java
+++ b/server/services/src/main/java/org/zanata/email/ContactLanguageCoordinatorEmailStrategy.java
@@ -63,13 +63,14 @@ public class ContactLanguageCoordinatorEmailStrategy extends
             InternetAddress[] toAddresses) {
         Map<String, Object> context =
                 super.makeContext(genericContext, toAddresses);
-        String safeHTML = HtmlUtil.SANITIZER.sanitize(htmlMessage);
+        String plainText = HtmlUtil.htmlToText(
+                HtmlUtil.SANITIZER.sanitize(htmlMessage));
         return context.put("receiver", receiver)
                 .put("fromLoginName", fromLoginName)
                 .put("fromName", fromName).put("replyEmail", replyEmail)
                 .put("localeId", localeId)
                 .put("localeNativeName", localeNativeName)
-                .put("htmlMessage", safeHTML);
+                .put("htmlMessage", plainText);
     }
 
     @java.beans.ConstructorProperties({ "receiver", "fromLoginName", "fromName",

--- a/server/services/src/main/java/org/zanata/email/ContactLanguageCoordinatorEmailStrategy.java
+++ b/server/services/src/main/java/org/zanata/email/ContactLanguageCoordinatorEmailStrategy.java
@@ -40,7 +40,7 @@ public class ContactLanguageCoordinatorEmailStrategy extends
     private final String userSubject;
     private final String localeId;
     private final String localeNativeName;
-    private final String htmlMessage;
+    private final String userMessage;
 
     @Override
     public String getBodyResourceName() {
@@ -68,17 +68,17 @@ public class ContactLanguageCoordinatorEmailStrategy extends
                 .put("fromName", fromName).put("replyEmail", replyEmail)
                 .put("localeId", localeId)
                 .put("localeNativeName", localeNativeName)
-                .put("safeHtmlMessage", textToSafeHtml(htmlMessage));
+                .put("safeHtmlMessage", textToSafeHtml(userMessage));
     }
 
     @java.beans.ConstructorProperties({ "receiver", "fromLoginName", "fromName",
             "replyEmail", "userSubject", "localeId", "localeNativeName",
-            "htmlMessage" })
+            "userMessage" })
     public ContactLanguageCoordinatorEmailStrategy(final String receiver,
             final String fromLoginName,
             final String fromName, final String replyEmail,
             final String userSubject, final String localeId,
-            final String localeNativeName, final String htmlMessage) {
+            final String localeNativeName, final String userMessage) {
         this.receiver = receiver;
         this.fromLoginName = fromLoginName;
         this.fromName = fromName;
@@ -86,6 +86,6 @@ public class ContactLanguageCoordinatorEmailStrategy extends
         this.userSubject = userSubject;
         this.localeId = localeId;
         this.localeNativeName = localeNativeName;
-        this.htmlMessage = htmlMessage;
+        this.userMessage = userMessage;
     }
 }

--- a/server/services/src/main/java/org/zanata/email/ContactLanguageCoordinatorEmailStrategy.java
+++ b/server/services/src/main/java/org/zanata/email/ContactLanguageCoordinatorEmailStrategy.java
@@ -23,9 +23,9 @@ package org.zanata.email;
 import com.google.common.base.Optional;
 import javaslang.collection.Map;
 import org.zanata.i18n.Messages;
-import org.zanata.util.HtmlUtil;
 import javax.mail.internet.InternetAddress;
 import static org.zanata.email.Addresses.getReplyTo;
+import static org.zanata.util.HtmlUtil.textToSafeHtml;
 
 /**
  * @author Sean Flanigan
@@ -68,7 +68,7 @@ public class ContactLanguageCoordinatorEmailStrategy extends
                 .put("fromName", fromName).put("replyEmail", replyEmail)
                 .put("localeId", localeId)
                 .put("localeNativeName", localeNativeName)
-                .put("htmlMessage", HtmlUtil.escapeAndSanitizeHtml(htmlMessage));
+                .put("safeHtmlMessage", textToSafeHtml(htmlMessage));
     }
 
     @java.beans.ConstructorProperties({ "receiver", "fromLoginName", "fromName",

--- a/server/services/src/main/java/org/zanata/email/ContactLanguageCoordinatorEmailStrategy.java
+++ b/server/services/src/main/java/org/zanata/email/ContactLanguageCoordinatorEmailStrategy.java
@@ -63,14 +63,12 @@ public class ContactLanguageCoordinatorEmailStrategy extends
             InternetAddress[] toAddresses) {
         Map<String, Object> context =
                 super.makeContext(genericContext, toAddresses);
-        String plainText = HtmlUtil.htmlToText(
-                HtmlUtil.SANITIZER.sanitize(htmlMessage));
         return context.put("receiver", receiver)
                 .put("fromLoginName", fromLoginName)
                 .put("fromName", fromName).put("replyEmail", replyEmail)
                 .put("localeId", localeId)
                 .put("localeNativeName", localeNativeName)
-                .put("htmlMessage", plainText);
+                .put("htmlMessage", HtmlUtil.escapeAndSanitizeHtml(htmlMessage));
     }
 
     @java.beans.ConstructorProperties({ "receiver", "fromLoginName", "fromName",

--- a/server/services/src/main/java/org/zanata/email/ContactLanguageTeamMembersEmailStrategy.java
+++ b/server/services/src/main/java/org/zanata/email/ContactLanguageTeamMembersEmailStrategy.java
@@ -22,8 +22,9 @@ package org.zanata.email;
 
 import javaslang.collection.Map;
 import org.zanata.i18n.Messages;
-import org.zanata.util.HtmlUtil;
 import javax.mail.internet.InternetAddress;
+
+import static org.zanata.util.HtmlUtil.SANITIZER;
 
 /**
  * @author Alex Eng <a href="aeng@redhat.com">aeng@redhat.com</a>
@@ -53,10 +54,9 @@ public class ContactLanguageTeamMembersEmailStrategy extends
             InternetAddress[] toAddresses) {
         Map<String, Object> context =
                 super.makeContext(genericContext, toAddresses);
-        String safeHTML = HtmlUtil.SANITIZER.sanitize(htmlMessage);
         return context.put("contactCoordinatorLink", contactCoordinatorLink)
                 .put("localeNativeName", localeNativeName)
-                .put("htmlMessage", safeHTML);
+                .put("safeHtmlMessage", SANITIZER.sanitize(htmlMessage));
     }
 
     @java.beans.ConstructorProperties({ "fromLoginName", "userSubject",

--- a/server/services/src/main/java/org/zanata/email/ContactLanguageTeamMembersEmailStrategy.java
+++ b/server/services/src/main/java/org/zanata/email/ContactLanguageTeamMembersEmailStrategy.java
@@ -22,9 +22,11 @@ package org.zanata.email;
 
 import javaslang.collection.Map;
 import org.zanata.i18n.Messages;
+import org.zanata.util.HtmlUtil;
+
 import javax.mail.internet.InternetAddress;
 
-import static org.zanata.util.HtmlUtil.SANITIZER;
+import static org.zanata.util.HtmlUtil.textToSafeHtml;
 
 /**
  * @author Alex Eng <a href="aeng@redhat.com">aeng@redhat.com</a>
@@ -56,7 +58,7 @@ public class ContactLanguageTeamMembersEmailStrategy extends
                 super.makeContext(genericContext, toAddresses);
         return context.put("contactCoordinatorLink", contactCoordinatorLink)
                 .put("localeNativeName", localeNativeName)
-                .put("safeHtmlMessage", SANITIZER.sanitize(userMessage));
+                .put("safeHtmlMessage", textToSafeHtml(userMessage));
     }
 
     @java.beans.ConstructorProperties({ "fromLoginName", "userSubject",

--- a/server/services/src/main/java/org/zanata/email/ContactLanguageTeamMembersEmailStrategy.java
+++ b/server/services/src/main/java/org/zanata/email/ContactLanguageTeamMembersEmailStrategy.java
@@ -35,7 +35,7 @@ public class ContactLanguageTeamMembersEmailStrategy extends
     private final String userSubject;
     private final String localeId;
     private final String localeNativeName;
-    private final String htmlMessage;
+    private final String userMessage;
     private final String contactCoordinatorLink;
 
     @Override
@@ -56,21 +56,21 @@ public class ContactLanguageTeamMembersEmailStrategy extends
                 super.makeContext(genericContext, toAddresses);
         return context.put("contactCoordinatorLink", contactCoordinatorLink)
                 .put("localeNativeName", localeNativeName)
-                .put("safeHtmlMessage", SANITIZER.sanitize(htmlMessage));
+                .put("safeHtmlMessage", SANITIZER.sanitize(userMessage));
     }
 
     @java.beans.ConstructorProperties({ "fromLoginName", "userSubject",
-            "localeId", "localeNativeName", "htmlMessage",
+            "localeId", "localeNativeName", "userMessage",
             "contactCoordinatorLink" })
     public ContactLanguageTeamMembersEmailStrategy(final String fromLoginName,
             final String userSubject, final String localeId,
-            final String localeNativeName, final String htmlMessage,
+            final String localeNativeName, final String userMessage,
             final String contactCoordinatorLink) {
         this.fromLoginName = fromLoginName;
         this.userSubject = userSubject;
         this.localeId = localeId;
         this.localeNativeName = localeNativeName;
-        this.htmlMessage = htmlMessage;
+        this.userMessage = userMessage;
         this.contactCoordinatorLink = contactCoordinatorLink;
     }
 }

--- a/server/services/src/main/java/org/zanata/email/DeclineLanguageRequestEmailStrategy.java
+++ b/server/services/src/main/java/org/zanata/email/DeclineLanguageRequestEmailStrategy.java
@@ -2,8 +2,9 @@ package org.zanata.email;
 
 import javaslang.collection.Map;
 import org.zanata.i18n.Messages;
-import org.zanata.util.HtmlUtil;
 import javax.mail.internet.InternetAddress;
+
+import static org.zanata.util.HtmlUtil.SANITIZER;
 
 /**
  * @author Alex Eng <a href="aeng@redhat.com">aeng@redhat.com</a>
@@ -31,11 +32,10 @@ public class DeclineLanguageRequestEmailStrategy extends VelocityEmailStrategy {
             InternetAddress[] toAddresses) {
         Map<String, Object> context =
                 super.makeContext(genericContext, toAddresses);
-        String safeHTML = HtmlUtil.SANITIZER.sanitize(htmlMessage);
         return context.put("toName", toName).put("roles", roles)
                 .put("localeDisplayName", localeDisplayName)
                 .put("contactCoordinatorLink", contactCoordinatorLink)
-                .put("htmlMessage", safeHTML);
+                .put("safeHtmlMessage", SANITIZER.sanitize(htmlMessage));
     }
 
     @java.beans.ConstructorProperties({ "toName", "roles",

--- a/server/services/src/main/java/org/zanata/email/DeclineLanguageRequestEmailStrategy.java
+++ b/server/services/src/main/java/org/zanata/email/DeclineLanguageRequestEmailStrategy.java
@@ -14,7 +14,7 @@ public class DeclineLanguageRequestEmailStrategy extends VelocityEmailStrategy {
     private final String roles;
     private final String contactCoordinatorLink;
     private final String localeDisplayName;
-    private final String htmlMessage;
+    private final String userMessage;
 
     @Override
     public String getSubject(Messages msgs) {
@@ -35,18 +35,18 @@ public class DeclineLanguageRequestEmailStrategy extends VelocityEmailStrategy {
         return context.put("toName", toName).put("roles", roles)
                 .put("localeDisplayName", localeDisplayName)
                 .put("contactCoordinatorLink", contactCoordinatorLink)
-                .put("safeHtmlMessage", SANITIZER.sanitize(htmlMessage));
+                .put("safeHtmlMessage", SANITIZER.sanitize(userMessage));
     }
 
     @java.beans.ConstructorProperties({ "toName", "roles",
-            "contactCoordinatorLink", "localeDisplayName", "htmlMessage" })
+            "contactCoordinatorLink", "localeDisplayName", "userMessage" })
     public DeclineLanguageRequestEmailStrategy(final String toName,
             final String roles, final String contactCoordinatorLink,
-            final String localeDisplayName, final String htmlMessage) {
+            final String localeDisplayName, final String userMessage) {
         this.toName = toName;
         this.roles = roles;
         this.contactCoordinatorLink = contactCoordinatorLink;
         this.localeDisplayName = localeDisplayName;
-        this.htmlMessage = htmlMessage;
+        this.userMessage = userMessage;
     }
 }

--- a/server/services/src/main/java/org/zanata/email/DeclineLanguageRequestEmailStrategy.java
+++ b/server/services/src/main/java/org/zanata/email/DeclineLanguageRequestEmailStrategy.java
@@ -4,7 +4,7 @@ import javaslang.collection.Map;
 import org.zanata.i18n.Messages;
 import javax.mail.internet.InternetAddress;
 
-import static org.zanata.util.HtmlUtil.SANITIZER;
+import static org.zanata.util.HtmlUtil.textToSafeHtml;
 
 /**
  * @author Alex Eng <a href="aeng@redhat.com">aeng@redhat.com</a>
@@ -35,7 +35,7 @@ public class DeclineLanguageRequestEmailStrategy extends VelocityEmailStrategy {
         return context.put("toName", toName).put("roles", roles)
                 .put("localeDisplayName", localeDisplayName)
                 .put("contactCoordinatorLink", contactCoordinatorLink)
-                .put("safeHtmlMessage", SANITIZER.sanitize(userMessage));
+                .put("safeHtmlMessage", textToSafeHtml(userMessage));
     }
 
     @java.beans.ConstructorProperties({ "toName", "roles",

--- a/server/services/src/main/java/org/zanata/email/RequestToJoinLanguageEmailStrategy.java
+++ b/server/services/src/main/java/org/zanata/email/RequestToJoinLanguageEmailStrategy.java
@@ -25,6 +25,7 @@ import javaslang.collection.Map;
 import org.zanata.i18n.Messages;
 import org.zanata.util.HtmlUtil;
 import javax.mail.internet.InternetAddress;
+
 import static org.zanata.email.Addresses.getReplyTo;
 
 /**
@@ -63,12 +64,13 @@ public class RequestToJoinLanguageEmailStrategy extends VelocityEmailStrategy {
             InternetAddress[] toAddresses) {
         Map<String, Object> context =
                 super.makeContext(genericContext, toAddresses);
-        String safeHTML = HtmlUtil.SANITIZER.sanitize(htmlMessage);
+        String plainText = HtmlUtil.htmlToText(
+                HtmlUtil.SANITIZER.sanitize(htmlMessage));
         return context.put("fromLoginName", fromLoginName)
                 .put("fromName", fromName).put("replyEmail", replyEmail)
                 .put("localeId", localeId)
                 .put("localeNativeName", localeNativeName)
-                .put("htmlMessage", safeHTML)
+                .put("htmlMessage", plainText)
                 .put("requestAsTranslator", requestAsTranslator)
                 .put("requestAsReviewer", requestAsReviewer)
                 .put("requestAsCoordinator", requestAsCoordinator);

--- a/server/services/src/main/java/org/zanata/email/RequestToJoinLanguageEmailStrategy.java
+++ b/server/services/src/main/java/org/zanata/email/RequestToJoinLanguageEmailStrategy.java
@@ -38,7 +38,7 @@ public class RequestToJoinLanguageEmailStrategy extends VelocityEmailStrategy {
     private final String replyEmail;
     private final String localeId;
     private final String localeNativeName;
-    private final String htmlMessage;
+    private final String userMessage;
     private final boolean requestAsTranslator;
     private final boolean requestAsReviewer;
     private final boolean requestAsCoordinator;
@@ -68,20 +68,20 @@ public class RequestToJoinLanguageEmailStrategy extends VelocityEmailStrategy {
                 .put("fromName", fromName).put("replyEmail", replyEmail)
                 .put("localeId", localeId)
                 .put("localeNativeName", localeNativeName)
-                .put("safeHtmlMessage", textToSafeHtml(htmlMessage))
+                .put("safeHtmlMessage", textToSafeHtml(userMessage))
                 .put("requestAsTranslator", requestAsTranslator)
                 .put("requestAsReviewer", requestAsReviewer)
                 .put("requestAsCoordinator", requestAsCoordinator);
     }
 
     @java.beans.ConstructorProperties({ "fromLoginName", "fromName",
-            "replyEmail", "localeId", "localeNativeName", "htmlMessage",
+            "replyEmail", "localeId", "localeNativeName", "userMessage",
             "requestAsTranslator", "requestAsReviewer",
             "requestAsCoordinator" })
     public RequestToJoinLanguageEmailStrategy(final String fromLoginName,
             final String fromName, final String replyEmail,
             final String localeId, final String localeNativeName,
-            final String htmlMessage, final boolean requestAsTranslator,
+            final String userMessage, final boolean requestAsTranslator,
             final boolean requestAsReviewer,
             final boolean requestAsCoordinator) {
         this.fromLoginName = fromLoginName;
@@ -89,7 +89,7 @@ public class RequestToJoinLanguageEmailStrategy extends VelocityEmailStrategy {
         this.replyEmail = replyEmail;
         this.localeId = localeId;
         this.localeNativeName = localeNativeName;
-        this.htmlMessage = htmlMessage;
+        this.userMessage = userMessage;
         this.requestAsTranslator = requestAsTranslator;
         this.requestAsReviewer = requestAsReviewer;
         this.requestAsCoordinator = requestAsCoordinator;

--- a/server/services/src/main/java/org/zanata/email/RequestToJoinLanguageEmailStrategy.java
+++ b/server/services/src/main/java/org/zanata/email/RequestToJoinLanguageEmailStrategy.java
@@ -23,10 +23,10 @@ package org.zanata.email;
 import com.google.common.base.Optional;
 import javaslang.collection.Map;
 import org.zanata.i18n.Messages;
-import org.zanata.util.HtmlUtil;
 import javax.mail.internet.InternetAddress;
 
 import static org.zanata.email.Addresses.getReplyTo;
+import static org.zanata.util.HtmlUtil.textToSafeHtml;
 
 /**
  * @author Sean Flanigan
@@ -68,7 +68,7 @@ public class RequestToJoinLanguageEmailStrategy extends VelocityEmailStrategy {
                 .put("fromName", fromName).put("replyEmail", replyEmail)
                 .put("localeId", localeId)
                 .put("localeNativeName", localeNativeName)
-                .put("htmlMessage", HtmlUtil.escapeAndSanitizeHtml(htmlMessage))
+                .put("safeHtmlMessage", textToSafeHtml(htmlMessage))
                 .put("requestAsTranslator", requestAsTranslator)
                 .put("requestAsReviewer", requestAsReviewer)
                 .put("requestAsCoordinator", requestAsCoordinator);

--- a/server/services/src/main/java/org/zanata/email/RequestToJoinLanguageEmailStrategy.java
+++ b/server/services/src/main/java/org/zanata/email/RequestToJoinLanguageEmailStrategy.java
@@ -64,13 +64,11 @@ public class RequestToJoinLanguageEmailStrategy extends VelocityEmailStrategy {
             InternetAddress[] toAddresses) {
         Map<String, Object> context =
                 super.makeContext(genericContext, toAddresses);
-        String plainText = HtmlUtil.htmlToText(
-                HtmlUtil.SANITIZER.sanitize(htmlMessage));
         return context.put("fromLoginName", fromLoginName)
                 .put("fromName", fromName).put("replyEmail", replyEmail)
                 .put("localeId", localeId)
                 .put("localeNativeName", localeNativeName)
-                .put("htmlMessage", plainText)
+                .put("htmlMessage", HtmlUtil.escapeAndSanitizeHtml(htmlMessage))
                 .put("requestAsTranslator", requestAsTranslator)
                 .put("requestAsReviewer", requestAsReviewer)
                 .put("requestAsCoordinator", requestAsCoordinator);

--- a/server/services/src/main/java/org/zanata/email/RequestToJoinVersionGroupEmailStrategy.java
+++ b/server/services/src/main/java/org/zanata/email/RequestToJoinVersionGroupEmailStrategy.java
@@ -63,12 +63,13 @@ public class RequestToJoinVersionGroupEmailStrategy extends
             InternetAddress[] toAddresses) {
         Map<String, Object> context =
                 super.makeContext(genericContext, toAddresses);
-        String safeHTML = HtmlUtil.SANITIZER.sanitize(htmlMessage);
+        String plainText = HtmlUtil.htmlToText(
+                HtmlUtil.SANITIZER.sanitize(htmlMessage));
         return context.put("fromLoginName", fromLoginName)
                 .put("fromName", fromName).put("replyEmail", replyEmail)
                 .put("groupName", groupName).put("versionGroupSlug", groupSlug)
                 .put("projectIterationIds", projectIterationIds)
-                .put("htmlMessage", safeHTML);
+                .put("htmlMessage", plainText);
     }
 
     @java.beans.ConstructorProperties({ "fromLoginName", "fromName",

--- a/server/services/src/main/java/org/zanata/email/RequestToJoinVersionGroupEmailStrategy.java
+++ b/server/services/src/main/java/org/zanata/email/RequestToJoinVersionGroupEmailStrategy.java
@@ -63,13 +63,11 @@ public class RequestToJoinVersionGroupEmailStrategy extends
             InternetAddress[] toAddresses) {
         Map<String, Object> context =
                 super.makeContext(genericContext, toAddresses);
-        String plainText = HtmlUtil.htmlToText(
-                HtmlUtil.SANITIZER.sanitize(htmlMessage));
         return context.put("fromLoginName", fromLoginName)
                 .put("fromName", fromName).put("replyEmail", replyEmail)
                 .put("groupName", groupName).put("versionGroupSlug", groupSlug)
                 .put("projectIterationIds", projectIterationIds)
-                .put("htmlMessage", plainText);
+                .put("htmlMessage", HtmlUtil.escapeAndSanitizeHtml(htmlMessage));
     }
 
     @java.beans.ConstructorProperties({ "fromLoginName", "fromName",

--- a/server/services/src/main/java/org/zanata/email/RequestToJoinVersionGroupEmailStrategy.java
+++ b/server/services/src/main/java/org/zanata/email/RequestToJoinVersionGroupEmailStrategy.java
@@ -41,7 +41,7 @@ public class RequestToJoinVersionGroupEmailStrategy extends
     private final String groupName;
     private final String groupSlug;
     private final Collection<ProjectIterationId> projectIterationIds;
-    private final String htmlMessage;
+    private final String userMessage;
 
     @Override
     public String getBodyResourceName() {
@@ -67,23 +67,23 @@ public class RequestToJoinVersionGroupEmailStrategy extends
                 .put("fromName", fromName).put("replyEmail", replyEmail)
                 .put("groupName", groupName).put("versionGroupSlug", groupSlug)
                 .put("projectIterationIds", projectIterationIds)
-                .put("safeHtmlMessage", textToSafeHtml(htmlMessage));
+                .put("safeHtmlMessage", textToSafeHtml(userMessage));
     }
 
     @java.beans.ConstructorProperties({ "fromLoginName", "fromName",
             "replyEmail", "groupName", "groupSlug", "projectIterationIds",
-            "htmlMessage" })
+            "userMessage" })
     public RequestToJoinVersionGroupEmailStrategy(final String fromLoginName,
             final String fromName, final String replyEmail,
             final String groupName, final String groupSlug,
             final Collection<ProjectIterationId> projectIterationIds,
-            final String htmlMessage) {
+            final String userMessage) {
         this.fromLoginName = fromLoginName;
         this.fromName = fromName;
         this.replyEmail = replyEmail;
         this.groupName = groupName;
         this.groupSlug = groupSlug;
         this.projectIterationIds = projectIterationIds;
-        this.htmlMessage = htmlMessage;
+        this.userMessage = userMessage;
     }
 }

--- a/server/services/src/main/java/org/zanata/email/RequestToJoinVersionGroupEmailStrategy.java
+++ b/server/services/src/main/java/org/zanata/email/RequestToJoinVersionGroupEmailStrategy.java
@@ -23,11 +23,11 @@ package org.zanata.email;
 import com.google.common.base.Optional;
 import javaslang.collection.Map;
 import org.zanata.i18n.Messages;
-import org.zanata.util.HtmlUtil;
 import org.zanata.webtrans.shared.model.ProjectIterationId;
 import javax.mail.internet.InternetAddress;
 import java.util.Collection;
 import static org.zanata.email.Addresses.getReplyTo;
+import static org.zanata.util.HtmlUtil.textToSafeHtml;
 
 /**
  * @author Sean Flanigan
@@ -67,7 +67,7 @@ public class RequestToJoinVersionGroupEmailStrategy extends
                 .put("fromName", fromName).put("replyEmail", replyEmail)
                 .put("groupName", groupName).put("versionGroupSlug", groupSlug)
                 .put("projectIterationIds", projectIterationIds)
-                .put("htmlMessage", HtmlUtil.escapeAndSanitizeHtml(htmlMessage));
+                .put("safeHtmlMessage", textToSafeHtml(htmlMessage));
     }
 
     @java.beans.ConstructorProperties({ "fromLoginName", "fromName",

--- a/server/services/src/main/java/org/zanata/util/HtmlUtil.java
+++ b/server/services/src/main/java/org/zanata/util/HtmlUtil.java
@@ -21,6 +21,7 @@
 package org.zanata.util;
 
 import net.htmlparser.jericho.*;
+import org.apache.commons.lang.StringEscapeUtils;
 import org.owasp.html.HtmlPolicyBuilder;
 import org.owasp.html.PolicyFactory;
 
@@ -60,5 +61,9 @@ public class HtmlUtil {
         Segment htmlSeg = new Segment(htmlSource, 0, htmlSource.length());
         Renderer htmlRend = new Renderer(htmlSeg);
         return htmlRend.toString();
+    }
+
+    public static String escapeAndSanitizeHtml(String html) {
+        return SANITIZER.sanitize(StringEscapeUtils.escapeHtml(html));
     }
 }

--- a/server/services/src/main/java/org/zanata/util/HtmlUtil.java
+++ b/server/services/src/main/java/org/zanata/util/HtmlUtil.java
@@ -63,7 +63,7 @@ public class HtmlUtil {
         return htmlRend.toString();
     }
 
-    public static String escapeAndSanitizeHtml(String html) {
-        return SANITIZER.sanitize(StringEscapeUtils.escapeHtml(html));
+    public static String textToSafeHtml(String text) {
+        return SANITIZER.sanitize(StringEscapeUtils.escapeHtml(text));
     }
 }

--- a/server/services/src/main/resources/org/zanata/email/templates/decline_language_team_request.vm
+++ b/server/services/src/main/resources/org/zanata/email/templates/decline_language_team_request.vm
@@ -2,6 +2,6 @@
 
 <p>$msgs.format("jsf.email.languageteam.request.reject.message", $roles, $localeDisplayName)</p>
 <hr/>
-$htmlMessage
+$safeHtmlMessage
 <hr/>
 <p>$msgs.format("jsf.email.languageteam.permission.howToReply", $contactCoordinatorLink)</p>

--- a/server/services/src/main/resources/org/zanata/email/templates/email_admin.vm
+++ b/server/services/src/main/resources/org/zanata/email/templates/email_admin.vm
@@ -2,6 +2,6 @@
 
 <p>$msgs.format("jsf.email.admin.UserMessageIntro", $fromName, $fromLoginName)</p>
 <hr/>
-$htmlMessage
+$safeHtmlMessage
 <hr/>
 <p>$msgs.format("jsf.email.ReplyInstructions", $fromName, $replyEmail)</p>

--- a/server/services/src/main/resources/org/zanata/email/templates/email_admin_anonymous.vm
+++ b/server/services/src/main/resources/org/zanata/email/templates/email_admin_anonymous.vm
@@ -2,4 +2,4 @@
 
 <p>$msgs.format("jsf.email.admin.AnonymousUserMessageIntro", $ipAddress)</p>
 <hr/>
-$htmlMessage
+$safeHtmlMessage

--- a/server/services/src/main/resources/org/zanata/email/templates/email_coordinator.vm
+++ b/server/services/src/main/resources/org/zanata/email/templates/email_coordinator.vm
@@ -2,7 +2,7 @@
 <p>$msgs.format("jsf.email.coordinator.UserMessageIntro",
     $fromName, $fromLoginName, $localeId, $localeNativeName)</p>
 <hr/>
-$htmlMessage
+$safeHtmlMessage
 <hr/>
 <p>$msgs.format("jsf.email.coordinator.ResponseInstructions",
     $localeId, $fromName, $replyEmail)</p>

--- a/server/services/src/main/resources/org/zanata/email/templates/email_language_team_members.vm
+++ b/server/services/src/main/resources/org/zanata/email/templates/email_language_team_members.vm
@@ -1,4 +1,4 @@
 <p>$msgs.get("jsf.email.language.members.DearMember")</p>
-$htmlMessage
+$safeHtmlMessage
 <hr/>
 <p>$msgs.format("jsf.email.languageteam.permission.howToReply", $contactCoordinatorLink)</p>

--- a/server/services/src/main/resources/org/zanata/email/templates/email_request_to_join_group.vm
+++ b/server/services/src/main/resources/org/zanata/email/templates/email_request_to_join_group.vm
@@ -11,10 +11,10 @@
   #end
 </ul>
 
-#if ($htmlMessage)
+#if ($safeHtmlMessage)
 <p>$msgs.format("jsf.email.UserMessageIntro", $fromName)</p>
 <hr/>
-$htmlMessage
+$safeHtmlMessage
 <hr/>
 #end
 

--- a/server/services/src/main/resources/org/zanata/email/templates/email_request_to_join_language.vm
+++ b/server/services/src/main/resources/org/zanata/email/templates/email_request_to_join_language.vm
@@ -29,10 +29,10 @@
   #end
 </p>
 
-#if ($htmlMessage)
+#if ($safeHtmlMessage)
   <p>$msgs.format("jsf.email.UserMessageIntro", $fromLoginName)</p>
   <hr/>
-  $htmlMessage
+  $safeHtmlMessage
   <hr/>
 #end
 

--- a/server/services/src/test/java/org/zanata/email/VelocityEmailStrategyTest.java
+++ b/server/services/src/test/java/org/zanata/email/VelocityEmailStrategyTest.java
@@ -34,6 +34,7 @@ import org.junit.Test;
 import org.zanata.common.ProjectType;
 import org.zanata.i18n.Messages;
 import org.zanata.i18n.MessagesFactory;
+import org.zanata.util.HtmlUtil;
 import org.zanata.webtrans.shared.model.ProjectIterationId;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
@@ -199,8 +200,7 @@ public class VelocityEmailStrategyTest {
 
         assertThat(html).contains(msgs.format(
             "jsf.email.admin.UserMessageIntro", fromName, fromLoginName));
-        assertThat(html).contains(
-                htmlMessage);
+        assertThat(html).contains(HtmlUtil.htmlToText(htmlMessage));
     }
 
     @Test
@@ -272,8 +272,7 @@ public class VelocityEmailStrategyTest {
         assertThat(html).contains(msgs.format(
                 "jsf.email.coordinator.UserMessageIntro",
                 fromName, fromLoginName, localeId, localeNativeName));
-        assertThat(html).contains(
-                htmlMessage);
+        assertThat(html).contains(HtmlUtil.htmlToText(htmlMessage));
         assertThat(html).contains(
                 testServerPath + "/language/view/" + localeId);
     }
@@ -342,7 +341,7 @@ public class VelocityEmailStrategyTest {
         assertThat(html).contains(msgs.format(
                 "jsf.email.joinrequest.UserRequestingToJoin",
                 fromName, fromLoginName, localeId, localeNativeName));
-        assertThat(html).contains(htmlMessage);
+        assertThat(html).contains(HtmlUtil.htmlToText(htmlMessage));
         assertThat(html).contains(
                 testServerPath + "/language/view/" + localeId);
     }
@@ -398,8 +397,7 @@ public class VelocityEmailStrategyTest {
         assertThat(html).contains(msgs.format(
                 "jsf.email.joingrouprequest.RequestingToJoinGroup",
                 fromName, fromLoginName, versionGroupName));
-        assertThat(html).contains(
-                htmlMessage);
+        assertThat(html).contains(HtmlUtil.htmlToText(htmlMessage));
         assertThat(html).contains(
                 testServerPath + "/version-group/view/" + versionGroupSlug);
     }

--- a/server/services/src/test/java/org/zanata/email/VelocityEmailStrategyTest.java
+++ b/server/services/src/test/java/org/zanata/email/VelocityEmailStrategyTest.java
@@ -105,7 +105,7 @@ public class VelocityEmailStrategyTest {
     String userSubject = "USER_SUBJECT[测试]";
     String localeId = "LOCALE_ID";
     String localeNativeName = "LOCALE_NAME[测试]";
-    String htmlMessage = "some <b>HTML</b>";
+    String userMessage = "some <b>HTML</b>";
 
     public VelocityEmailStrategyTest() throws UnsupportedEncodingException {
         toAddr = Addresses.getAddress(toAddress, toName);
@@ -186,7 +186,7 @@ public class VelocityEmailStrategyTest {
         VelocityEmailStrategy strategy =
                 new ContactAdminEmailStrategy(
                         fromLoginName, fromName, replyEmail, userSubject,
-                        htmlMessage);
+                        userMessage);
 
         builder.buildMessage(message, strategy, toAddresses, Lists.newArrayList("contactAdmin test"));
 
@@ -207,7 +207,7 @@ public class VelocityEmailStrategyTest {
     public void contactAdminAnonymous() throws Exception {
         String ipAddress = "101.20.30.40";
         VelocityEmailStrategy strategy = new ContactAdminAnonymousEmailStrategy(
-                ipAddress, userSubject, htmlMessage);
+                ipAddress, userSubject, userMessage);
 
         builder.buildMessage(message, strategy, toAddresses,
                 Lists.newArrayList("contactAdminAnonymous test"));
@@ -233,7 +233,7 @@ public class VelocityEmailStrategyTest {
         VelocityEmailStrategy strategy =
             new DeclineLanguageRequestEmailStrategy(
                 toName, roles, contactCoordinatorLink, localeDisplayName,
-                htmlMessage);
+                    userMessage);
 
         builder.buildMessage(message, strategy, toAddresses,
             Lists.newArrayList("declineLanguageRequest test"));
@@ -247,7 +247,7 @@ public class VelocityEmailStrategyTest {
 
         assertThat(html).contains(msgs.format(
             "jsf.email.languageteam.request.reject.message", roles, localeDisplayName));
-        assertThat(html).contains(htmlMessage);
+        assertThat(html).contains(userMessage);
     }
 
     @Test
@@ -255,7 +255,7 @@ public class VelocityEmailStrategyTest {
         VelocityEmailStrategy strategy =
                 new ContactLanguageCoordinatorEmailStrategy(receiver,
                         fromLoginName, fromName, replyEmail, userSubject,
-                        localeId, localeNativeName, htmlMessage);
+                        localeId, localeNativeName, userMessage);
 
         builder.buildMessage(message, strategy, toAddresses,
             Lists.newArrayList("contactLanguageCoordinator test"));
@@ -325,7 +325,7 @@ public class VelocityEmailStrategyTest {
         VelocityEmailStrategy strategy =
                 new RequestToJoinLanguageEmailStrategy(
                         fromLoginName, fromName, replyEmail,
-                        localeId, localeNativeName, htmlMessage,
+                        localeId, localeNativeName, userMessage,
                         true, true, true);
 
         builder.buildMessage(message, strategy, toAddresses,
@@ -352,7 +352,7 @@ public class VelocityEmailStrategyTest {
         String contactAdminLink = "link";
         VelocityEmailStrategy strategy =
             new ContactLanguageTeamMembersEmailStrategy(
-                fromLoginName, subject, localeId, localeNativeName, htmlMessage,
+                fromLoginName, subject, localeId, localeNativeName, userMessage,
                 contactAdminLink);
 
         builder.buildMessage(message, strategy, toAddresses,
@@ -365,7 +365,7 @@ public class VelocityEmailStrategyTest {
         String html = extractHtmlPart(message);
         checkGenericTemplate(html);
 
-        assertThat(html).contains(htmlMessage);
+        assertThat(html).contains(userMessage);
         assertThat(html).contains(contactAdminLink);
     }
 
@@ -382,7 +382,7 @@ public class VelocityEmailStrategyTest {
                 new RequestToJoinVersionGroupEmailStrategy(
                         fromLoginName, fromName, replyEmail,
                         versionGroupName, versionGroupSlug,
-                        projectIterIds, htmlMessage);
+                        projectIterIds, userMessage);
 
         builder.buildMessage(message, strategy, toAddresses,
             Lists.newArrayList("requestToJoinVersionGroup test"));

--- a/server/services/src/test/java/org/zanata/email/VelocityEmailStrategyTest.java
+++ b/server/services/src/test/java/org/zanata/email/VelocityEmailStrategyTest.java
@@ -70,7 +70,6 @@ public class VelocityEmailStrategyTest {
     String testServerPath = "https://zanata.example.com";
     InternetAddress toAddr;
     InternetAddress[] toAddresses;
-    private String expectedUserMessage = "some &lt;b&gt;HTML&lt;/b&gt;";
 
     private MessagesFactory msgsFactory = new MessagesFactory() {
         private static final long serialVersionUID = 1L;
@@ -106,6 +105,7 @@ public class VelocityEmailStrategyTest {
     String localeId = "LOCALE_ID";
     String localeNativeName = "LOCALE_NAME[测试]";
     private String userMessage = "some <b>HTML</b>";
+    private String expectedUserMessage = "some &lt;b&gt;HTML&lt;/b&gt;";
 
     public VelocityEmailStrategyTest() throws UnsupportedEncodingException {
         toAddr = Addresses.getAddress(toAddress, toName);
@@ -247,7 +247,7 @@ public class VelocityEmailStrategyTest {
 
         assertThat(html).contains(msgs.format(
             "jsf.email.languageteam.request.reject.message", roles, localeDisplayName));
-        assertThat(html).contains(userMessage);
+        assertThat(html).contains(expectedUserMessage);
     }
 
     @Test
@@ -365,7 +365,7 @@ public class VelocityEmailStrategyTest {
         String html = extractHtmlPart(message);
         checkGenericTemplate(html);
 
-        assertThat(html).contains(userMessage);
+        assertThat(html).contains(expectedUserMessage);
         assertThat(html).contains(contactAdminLink);
     }
 

--- a/server/services/src/test/java/org/zanata/email/VelocityEmailStrategyTest.java
+++ b/server/services/src/test/java/org/zanata/email/VelocityEmailStrategyTest.java
@@ -71,6 +71,7 @@ public class VelocityEmailStrategyTest {
     String testServerPath = "https://zanata.example.com";
     InternetAddress toAddr;
     InternetAddress[] toAddresses;
+    String expectedUserMessage = "some &lt;b&gt;HTML&lt;/b&gt;";
 
     private MessagesFactory msgsFactory = new MessagesFactory() {
         private static final long serialVersionUID = 1L;
@@ -200,7 +201,7 @@ public class VelocityEmailStrategyTest {
 
         assertThat(html).contains(msgs.format(
             "jsf.email.admin.UserMessageIntro", fromName, fromLoginName));
-        assertThat(html).contains(HtmlUtil.htmlToText(htmlMessage));
+        assertThat(html).contains(expectedUserMessage);
     }
 
     @Test
@@ -221,7 +222,7 @@ public class VelocityEmailStrategyTest {
 
         assertThat(html).contains(msgs.format(
                 "jsf.email.admin.AnonymousUserMessageIntro", ipAddress));
-        assertThat(html).contains(htmlMessage);
+        assertThat(html).contains(expectedUserMessage);
     }
 
     @Test
@@ -272,7 +273,7 @@ public class VelocityEmailStrategyTest {
         assertThat(html).contains(msgs.format(
                 "jsf.email.coordinator.UserMessageIntro",
                 fromName, fromLoginName, localeId, localeNativeName));
-        assertThat(html).contains(HtmlUtil.htmlToText(htmlMessage));
+        assertThat(html).contains(expectedUserMessage);
         assertThat(html).contains(
                 testServerPath + "/language/view/" + localeId);
     }
@@ -341,7 +342,7 @@ public class VelocityEmailStrategyTest {
         assertThat(html).contains(msgs.format(
                 "jsf.email.joinrequest.UserRequestingToJoin",
                 fromName, fromLoginName, localeId, localeNativeName));
-        assertThat(html).contains(HtmlUtil.htmlToText(htmlMessage));
+        assertThat(html).contains(expectedUserMessage);
         assertThat(html).contains(
                 testServerPath + "/language/view/" + localeId);
     }
@@ -397,7 +398,7 @@ public class VelocityEmailStrategyTest {
         assertThat(html).contains(msgs.format(
                 "jsf.email.joingrouprequest.RequestingToJoinGroup",
                 fromName, fromLoginName, versionGroupName));
-        assertThat(html).contains(HtmlUtil.htmlToText(htmlMessage));
+        assertThat(html).contains("some &lt;b&gt;HTML&lt;/b&gt;");
         assertThat(html).contains(
                 testServerPath + "/version-group/view/" + versionGroupSlug);
     }

--- a/server/services/src/test/java/org/zanata/email/VelocityEmailStrategyTest.java
+++ b/server/services/src/test/java/org/zanata/email/VelocityEmailStrategyTest.java
@@ -34,7 +34,6 @@ import org.junit.Test;
 import org.zanata.common.ProjectType;
 import org.zanata.i18n.Messages;
 import org.zanata.i18n.MessagesFactory;
-import org.zanata.util.HtmlUtil;
 import org.zanata.webtrans.shared.model.ProjectIterationId;
 import com.google.common.base.Joiner;
 import com.google.common.collect.Lists;
@@ -71,7 +70,7 @@ public class VelocityEmailStrategyTest {
     String testServerPath = "https://zanata.example.com";
     InternetAddress toAddr;
     InternetAddress[] toAddresses;
-    String expectedUserMessage = "some &lt;b&gt;HTML&lt;/b&gt;";
+    private String expectedUserMessage = "some &lt;b&gt;HTML&lt;/b&gt;";
 
     private MessagesFactory msgsFactory = new MessagesFactory() {
         private static final long serialVersionUID = 1L;

--- a/server/services/src/test/java/org/zanata/email/VelocityEmailStrategyTest.java
+++ b/server/services/src/test/java/org/zanata/email/VelocityEmailStrategyTest.java
@@ -105,7 +105,7 @@ public class VelocityEmailStrategyTest {
     String userSubject = "USER_SUBJECT[测试]";
     String localeId = "LOCALE_ID";
     String localeNativeName = "LOCALE_NAME[测试]";
-    String userMessage = "some <b>HTML</b>";
+    private String userMessage = "some <b>HTML</b>";
 
     public VelocityEmailStrategyTest() throws UnsupportedEncodingException {
         toAddr = Addresses.getAddress(toAddress, toName);

--- a/server/services/src/test/java/org/zanata/util/HtmlUtilTest.java
+++ b/server/services/src/test/java/org/zanata/util/HtmlUtilTest.java
@@ -72,4 +72,15 @@ public class HtmlUtilTest {
                 "contain a link <http://example.com/> .");
     }
 
+    @Test
+    public void testTextToSafeHtml() {
+        String input = "<p>This is <b>meant</b> to <br/>contain a " +
+                "<a href='http://example.com/'>link</a>.</p>";
+        String actual = textToSafeHtml(input);
+        assertThat(actual).isEqualTo(
+                "&lt;p&gt;This is &lt;b&gt;meant&lt;/b&gt; to " +
+                "&lt;br/&gt;contain a &lt;a href&#61;&#39;" +
+                "http://example.com/&#39;&gt;link&lt;/a&gt;.&lt;/p&gt;");
+    }
+
 }


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-544

User messages should be plaintext, to avoid malicious links hidden in anchors

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
