### PR TITLE
fix: glossary UI icon and project name overlap

### DIFF
--- a/server/zanata-frontend/src/app/containers/Glossary/ViewHeader.js
+++ b/server/zanata-frontend/src/app/containers/Glossary/ViewHeader.js
@@ -140,7 +140,7 @@ class ViewHeader extends Component {
       <div className='projectLink'>
         <Link icon='project' link={projectUrl} useHref>
           <Row>
-            <Icon type='folder-open' className='s1 iconProject' />
+            <Icon type='folder-open' className='iconProject' />
             <span className='hidden-lesm'>{project.name}</span>
           </Row>
         </Link>


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2550

Fixed the icon and project name overlap on glossary page
's1' bstrapReact class clashed with ant design icon styles

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
