### PR TITLE
fix: mock ant design buttons, re-enable storyshot tests

### DIFF
--- a/server/zanata-frontend/src/.storybook-editor/__snapshots__/storyshots-editor.test.js.snap
+++ b/server/zanata-frontend/src/.storybook-editor/__snapshots__/storyshots-editor.test.js.snap
@@ -7555,3 +7555,158 @@ exports[`Editor Storyshots TextDiff default 1`] = `
   </span>
 </div>
 `;
+
+exports[`Editor Storyshots Validation default 1`] = `
+<div>
+  <h2>
+    Validation Messages Default
+  </h2>
+  <div
+    className="TextflowValidation"
+  >
+    <div
+      className="ant-collapse"
+      style={undefined}
+    >
+      <div
+        className="ant-collapse-item"
+        id={undefined}
+        role="tablist"
+        style={undefined}
+      >
+        <div
+          aria-expanded={false}
+          className="ant-collapse-header"
+          onClick={[Function]}
+          role="tab"
+        >
+          <i
+            className="arrow"
+          />
+          Warnings: 0, Errors: 1
+        </div>
+      </div>
+    </div>
+  </div>
+  <h2>
+    Validation Messages with Description Tooltip
+  </h2>
+  <div
+    className="TextflowValidation"
+  >
+    <div
+      className="ant-collapse"
+      style={undefined}
+    >
+      <div
+        className="ant-collapse-item"
+        id={undefined}
+        role="tablist"
+        style={undefined}
+      >
+        <div
+          aria-expanded={false}
+          className="ant-collapse-header"
+          onClick={[Function]}
+          role="tab"
+        >
+          <i
+            className="arrow"
+          />
+          Warnings: 1, Errors: 0
+        </div>
+      </div>
+    </div>
+  </div>
+  <h2>
+    Validation Messages Warnings
+  </h2>
+  <div
+    className="TextflowValidation"
+  >
+    <div
+      className="ant-collapse"
+      style={undefined}
+    >
+      <div
+        className="ant-collapse-item"
+        id={undefined}
+        role="tablist"
+        style={undefined}
+      >
+        <div
+          aria-expanded={false}
+          className="ant-collapse-header"
+          onClick={[Function]}
+          role="tab"
+        >
+          <i
+            className="arrow"
+          />
+          Warnings: 2, Errors: 0
+        </div>
+      </div>
+    </div>
+  </div>
+  <h2>
+    Validation Messages Errors
+  </h2>
+  <div
+    className="TextflowValidation"
+  >
+    <div
+      className="ant-collapse"
+      style={undefined}
+    >
+      <div
+        className="ant-collapse-item"
+        id={undefined}
+        role="tablist"
+        style={undefined}
+      >
+        <div
+          aria-expanded={false}
+          className="ant-collapse-header"
+          onClick={[Function]}
+          role="tab"
+        >
+          <i
+            className="arrow"
+          />
+          Warnings: 0, Errors: 2
+        </div>
+      </div>
+    </div>
+  </div>
+  <h2>
+    Validation Messages Mixed
+  </h2>
+  <div
+    className="TextflowValidation"
+  >
+    <div
+      className="ant-collapse"
+      style={undefined}
+    >
+      <div
+        className="ant-collapse-item"
+        id={undefined}
+        role="tablist"
+        style={undefined}
+      >
+        <div
+          aria-expanded={false}
+          className="ant-collapse-header"
+          onClick={[Function]}
+          role="tab"
+        >
+          <i
+            className="arrow"
+          />
+          Warnings: 2, Errors: 2
+        </div>
+      </div>
+    </div>
+  </div>
+</div>
+`;

--- a/server/zanata-frontend/src/.storybook-frontend/__snapshots__/storyshots-frontend.test.js.snap
+++ b/server/zanata-frontend/src/.storybook-frontend/__snapshots__/storyshots-frontend.test.js.snap
@@ -481,6 +481,18 @@ exports[`Frontend Storyshots Breadcrumbs default 1`] = `
 </span>
 `;
 
+exports[`Frontend Storyshots Button default 1`] = `
+<div
+  className="ant-layout"
+>
+  <Button
+    type="primary"
+  >
+    Primary style
+  </Button>
+</div>
+`;
+
 exports[`Frontend Storyshots Dropdown default 1`] = `
 <div>
   <h2>
@@ -19368,6 +19380,4623 @@ exports[`Frontend Storyshots RejectionsForm read only 1`] = `
 </form>
 `;
 
+exports[`Frontend Storyshots Sidebar AboutPage 1`] = `
+<div>
+  <div
+    className="bstrapReact"
+    id="pvSidebar"
+  >
+    <div
+      className="sidebar accordion"
+    >
+      <div
+        className="sidebar-wrapper"
+      >
+        <div
+          className="sidebar-container"
+        >
+          <div
+            className="sidebar-content"
+          >
+            <a
+              className="accordion-section-title"
+              onClick={[Function]}
+            >
+              <span
+                className="iconProject"
+              >
+                <svg
+                  className="s2"
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "<use xlink:href=\\"#Icon-project\\" />",
+                    }
+                  }
+                  style={
+                    Object {
+                      "fill": "currentColor",
+                    }
+                  }
+                />
+              </span>
+              <span
+                className="projtitle"
+              >
+                Zanata Server
+              </span>
+              <svg
+                className="hide-desktop down"
+              >
+                <use
+                  xlinkHref="#Icon-chevron-down"
+                />
+              </svg>
+            </a>
+            <div
+              className="accordion-section-content"
+              id="accordion-1"
+            >
+              <ul
+                className="nav nav-pills nav-stacked"
+                role={null}
+              >
+                <li
+                  className="active"
+                  role="presentation"
+                  style={undefined}
+                >
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    role="button"
+                  >
+                    <span
+                      className="iconSidebar"
+                    >
+                      <svg
+                        className="s1"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<use xlink:href=\\"#Icon-users\\" />",
+                          }
+                        }
+                        style={
+                          Object {
+                            "fill": "currentColor",
+                          }
+                        }
+                      />
+                    </span>
+                    People
+                  </a>
+                </li>
+                <li
+                  className=""
+                  role="presentation"
+                  style={undefined}
+                >
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    role="button"
+                  >
+                    <span
+                      className="iconSidebar"
+                    >
+                      <svg
+                        className="s1"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<use xlink:href=\\"#Icon-glossary\\" />",
+                          }
+                        }
+                        style={
+                          Object {
+                            "fill": "currentColor",
+                          }
+                        }
+                      />
+                    </span>
+                    Glossary
+                  </a>
+                </li>
+                <li
+                  className=""
+                  role="presentation"
+                  style={undefined}
+                >
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    role="button"
+                  >
+                    <span
+                      className="iconSidebar"
+                    >
+                      <svg
+                        className="s1"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<use xlink:href=\\"#Icon-info\\" />",
+                          }
+                        }
+                        style={
+                          Object {
+                            "fill": "currentColor",
+                          }
+                        }
+                      />
+                    </span>
+                    About
+                  </a>
+                </li>
+                <li
+                  className=""
+                  role="presentation"
+                  style={undefined}
+                >
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    role="button"
+                  >
+                    <span
+                      className="iconSidebar"
+                    >
+                      <svg
+                        className="s1"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<use xlink:href=\\"#Icon-settings\\" />",
+                          }
+                        }
+                        style={
+                          Object {
+                            "fill": "currentColor",
+                          }
+                        }
+                      />
+                    </span>
+                    Settings 
+                  </a>
+                </li>
+              </ul>
+              <div
+                className="dropdown btn-group"
+              >
+                <button
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="btn-sm btn-default dropdown-toggle btn btn-default"
+                  disabled={false}
+                  id="optionsDropdown"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  type="button"
+                >
+                  Options
+                   
+                  <span
+                    className="caret"
+                  />
+                </button>
+                <ul
+                  aria-labelledby="optionsDropdown"
+                  className="dropdown-menu"
+                  role="menu"
+                >
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                    >
+                      Copy translations
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                    >
+                      Merge translations
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                    >
+                      Copy to new version
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                    >
+                      Download config file
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                    >
+                      Export project to TMX
+                    </a>
+                  </li>
+                </ul>
+              </div>
+              <div
+                className="processing well"
+              >
+                <p
+                  className="task-title"
+                >
+                  Task title
+                </p>
+                <p>
+                  <span>
+                    Processing document 
+                    <span
+                      className="count"
+                    >
+                      1 of 10
+                    </span>
+                     
+                    <span
+                      className="count-pc"
+                    >
+                      12.50%
+                    </span>
+                  </span>
+                </p>
+                <div
+                  className="progress-striped progress"
+                >
+                  <div
+                    aria-valuemax={100}
+                    aria-valuemin={0}
+                    aria-valuenow={12.5}
+                    className="progress-bar"
+                    role="progressbar"
+                    style={
+                      Object {
+                        "width": "12.5%",
+                      }
+                    }
+                  />
+                </div>
+                <Button
+                  className="btn-danger btn-sm"
+                >
+                  Stop
+                </Button>
+              </div>
+              <div
+                id="sidebarVersion"
+              >
+                <div
+                  className="sidebarVersion-inline"
+                >
+                  <span
+                    className="sidebarVersion-title"
+                  >
+                    <span
+                      className=""
+                    >
+                      <svg
+                        className="s2"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<use xlink:href=\\"#Icon-version\\" />",
+                          }
+                        }
+                        style={
+                          Object {
+                            "fill": "currentColor",
+                          }
+                        }
+                      />
+                    </span>
+                    <span
+                      className="versionHeading"
+                    >
+                      VERSION
+                    </span>
+                  </span>
+                  <div
+                    className="dropdown btn-group"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      className="btn-sm btn-default dropdown-toggle btn btn-default"
+                      disabled={false}
+                      id="version-dropdown"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="button"
+                      type="button"
+                    >
+                      master
+                       
+                      <span
+                        className="caret"
+                      />
+                    </button>
+                    <ul
+                      aria-labelledby="version-dropdown"
+                      className="dropdown-menu"
+                      role="menu"
+                    >
+                      <li
+                        className=""
+                        role="presentation"
+                        style={undefined}
+                      >
+                        <a
+                          href="#"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          role="menuitem"
+                          tabIndex="-1"
+                        >
+                          release
+                        </a>
+                      </li>
+                      <li
+                        className=""
+                        role="presentation"
+                        style={undefined}
+                      >
+                        <a
+                          href="#"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          role="menuitem"
+                          tabIndex="-1"
+                        >
+                          test-1
+                        </a>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+                <p
+                  className="sidebarVersion-settings"
+                >
+                  <a
+                    href=""
+                  >
+                    Version settings
+                  </a>
+                </p>
+                <div
+                  className="sidebarVersion-percent"
+                >
+                  <p>
+                    <span
+                      className="percent"
+                    >
+                      10%
+                    </span>
+                     translated
+                  </p>
+                </div>
+                <div
+                  className="progress"
+                >
+                  <div
+                    aria-valuemax={100}
+                    aria-valuemin={0}
+                    aria-valuenow={10}
+                    className="progress-bar-success progress-bar"
+                    role="progressbar"
+                    style={
+                      Object {
+                        "width": "10%",
+                      }
+                    }
+                  />
+                  <div
+                    aria-valuemax={100}
+                    aria-valuemin={0}
+                    aria-valuenow={7}
+                    className="progress-bar-warning progress-bar"
+                    role="progressbar"
+                    style={
+                      Object {
+                        "width": "7%",
+                      }
+                    }
+                  />
+                  <div
+                    aria-valuemax={100}
+                    aria-valuemin={0}
+                    aria-valuenow={3}
+                    className="progress-bar-danger progress-bar"
+                    role="progressbar"
+                    style={
+                      Object {
+                        "width": "3%",
+                      }
+                    }
+                  />
+                  <div
+                    aria-valuemax={100}
+                    aria-valuemin={0}
+                    aria-valuenow={10}
+                    className="progress-bar-info progress-bar"
+                    role="progressbar"
+                    style={
+                      Object {
+                        "width": "10%",
+                      }
+                    }
+                  />
+                </div>
+                <ul
+                  className="v-links nav nav-pills nav-stacked"
+                  role={null}
+                >
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      role="button"
+                    >
+                      Languages
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      role="button"
+                    >
+                      Documents
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      role="button"
+                    >
+                      Groups 
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="flexTab wideView"
+  >
+    <h2>
+      About
+    </h2>
+    <p>
+      This is one rocking project version. This is the best project version ever.
+    </p>
+    <a
+      href="https://www.google.com"
+    >
+      <span
+        className=""
+      >
+        <svg
+          className="n1"
+          dangerouslySetInnerHTML={
+            Object {
+              "__html": "<use xlink:href=\\"#Icon-link\\" />",
+            }
+          }
+          style={
+            Object {
+              "fill": "currentColor",
+            }
+          }
+        />
+      </span>
+      Our awesome webpage
+    </a>
+  </div>
+</div>
+`;
+
+exports[`Frontend Storyshots Sidebar DocumentsPage 1`] = `
+<div>
+  <div
+    className="bstrapReact"
+    id="pvSidebar"
+  >
+    <div
+      className="sidebar accordion"
+    >
+      <div
+        className="sidebar-wrapper"
+      >
+        <div
+          className="sidebar-container"
+        >
+          <div
+            className="sidebar-content"
+          >
+            <a
+              className="accordion-section-title"
+              onClick={[Function]}
+            >
+              <span
+                className="iconProject"
+              >
+                <svg
+                  className="s2"
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "<use xlink:href=\\"#Icon-project\\" />",
+                    }
+                  }
+                  style={
+                    Object {
+                      "fill": "currentColor",
+                    }
+                  }
+                />
+              </span>
+              <span
+                className="projtitle"
+              >
+                Zanata Server
+              </span>
+              <svg
+                className="hide-desktop down"
+              >
+                <use
+                  xlinkHref="#Icon-chevron-down"
+                />
+              </svg>
+            </a>
+            <div
+              className="accordion-section-content"
+              id="accordion-1"
+            >
+              <ul
+                className="nav nav-pills nav-stacked"
+                role={null}
+              >
+                <li
+                  className="active"
+                  role="presentation"
+                  style={undefined}
+                >
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    role="button"
+                  >
+                    <span
+                      className="iconSidebar"
+                    >
+                      <svg
+                        className="s1"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<use xlink:href=\\"#Icon-users\\" />",
+                          }
+                        }
+                        style={
+                          Object {
+                            "fill": "currentColor",
+                          }
+                        }
+                      />
+                    </span>
+                    People
+                  </a>
+                </li>
+                <li
+                  className=""
+                  role="presentation"
+                  style={undefined}
+                >
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    role="button"
+                  >
+                    <span
+                      className="iconSidebar"
+                    >
+                      <svg
+                        className="s1"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<use xlink:href=\\"#Icon-glossary\\" />",
+                          }
+                        }
+                        style={
+                          Object {
+                            "fill": "currentColor",
+                          }
+                        }
+                      />
+                    </span>
+                    Glossary
+                  </a>
+                </li>
+                <li
+                  className=""
+                  role="presentation"
+                  style={undefined}
+                >
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    role="button"
+                  >
+                    <span
+                      className="iconSidebar"
+                    >
+                      <svg
+                        className="s1"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<use xlink:href=\\"#Icon-info\\" />",
+                          }
+                        }
+                        style={
+                          Object {
+                            "fill": "currentColor",
+                          }
+                        }
+                      />
+                    </span>
+                    About
+                  </a>
+                </li>
+                <li
+                  className=""
+                  role="presentation"
+                  style={undefined}
+                >
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    role="button"
+                  >
+                    <span
+                      className="iconSidebar"
+                    >
+                      <svg
+                        className="s1"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<use xlink:href=\\"#Icon-settings\\" />",
+                          }
+                        }
+                        style={
+                          Object {
+                            "fill": "currentColor",
+                          }
+                        }
+                      />
+                    </span>
+                    Settings 
+                  </a>
+                </li>
+              </ul>
+              <div
+                className="dropdown btn-group"
+              >
+                <button
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="btn-sm btn-default dropdown-toggle btn btn-default"
+                  disabled={false}
+                  id="optionsDropdown"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  type="button"
+                >
+                  Options
+                   
+                  <span
+                    className="caret"
+                  />
+                </button>
+                <ul
+                  aria-labelledby="optionsDropdown"
+                  className="dropdown-menu"
+                  role="menu"
+                >
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                    >
+                      Copy translations
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                    >
+                      Merge translations
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                    >
+                      Copy to new version
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                    >
+                      Download config file
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                    >
+                      Export project to TMX
+                    </a>
+                  </li>
+                </ul>
+              </div>
+              <div
+                className="processing well"
+              >
+                <p
+                  className="task-title"
+                >
+                  Task title
+                </p>
+                <p>
+                  <span>
+                    Processing document 
+                    <span
+                      className="count"
+                    >
+                      1 of 10
+                    </span>
+                     
+                    <span
+                      className="count-pc"
+                    >
+                      12.50%
+                    </span>
+                  </span>
+                </p>
+                <div
+                  className="progress-striped progress"
+                >
+                  <div
+                    aria-valuemax={100}
+                    aria-valuemin={0}
+                    aria-valuenow={12.5}
+                    className="progress-bar"
+                    role="progressbar"
+                    style={
+                      Object {
+                        "width": "12.5%",
+                      }
+                    }
+                  />
+                </div>
+                <Button
+                  className="btn-danger btn-sm"
+                >
+                  Stop
+                </Button>
+              </div>
+              <div
+                id="sidebarVersion"
+              >
+                <div
+                  className="sidebarVersion-inline"
+                >
+                  <span
+                    className="sidebarVersion-title"
+                  >
+                    <span
+                      className=""
+                    >
+                      <svg
+                        className="s2"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<use xlink:href=\\"#Icon-version\\" />",
+                          }
+                        }
+                        style={
+                          Object {
+                            "fill": "currentColor",
+                          }
+                        }
+                      />
+                    </span>
+                    <span
+                      className="versionHeading"
+                    >
+                      VERSION
+                    </span>
+                  </span>
+                  <div
+                    className="dropdown btn-group"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      className="btn-sm btn-default dropdown-toggle btn btn-default"
+                      disabled={false}
+                      id="version-dropdown"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="button"
+                      type="button"
+                    >
+                      master
+                       
+                      <span
+                        className="caret"
+                      />
+                    </button>
+                    <ul
+                      aria-labelledby="version-dropdown"
+                      className="dropdown-menu"
+                      role="menu"
+                    >
+                      <li
+                        className=""
+                        role="presentation"
+                        style={undefined}
+                      >
+                        <a
+                          href="#"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          role="menuitem"
+                          tabIndex="-1"
+                        >
+                          release
+                        </a>
+                      </li>
+                      <li
+                        className=""
+                        role="presentation"
+                        style={undefined}
+                      >
+                        <a
+                          href="#"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          role="menuitem"
+                          tabIndex="-1"
+                        >
+                          test-1
+                        </a>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+                <p
+                  className="sidebarVersion-settings"
+                >
+                  <a
+                    href=""
+                  >
+                    Version settings
+                  </a>
+                </p>
+                <div
+                  className="sidebarVersion-percent"
+                >
+                  <p>
+                    <span
+                      className="percent"
+                    >
+                      10%
+                    </span>
+                     translated
+                  </p>
+                </div>
+                <div
+                  className="progress"
+                >
+                  <div
+                    aria-valuemax={100}
+                    aria-valuemin={0}
+                    aria-valuenow={10}
+                    className="progress-bar-success progress-bar"
+                    role="progressbar"
+                    style={
+                      Object {
+                        "width": "10%",
+                      }
+                    }
+                  />
+                  <div
+                    aria-valuemax={100}
+                    aria-valuemin={0}
+                    aria-valuenow={7}
+                    className="progress-bar-warning progress-bar"
+                    role="progressbar"
+                    style={
+                      Object {
+                        "width": "7%",
+                      }
+                    }
+                  />
+                  <div
+                    aria-valuemax={100}
+                    aria-valuemin={0}
+                    aria-valuenow={3}
+                    className="progress-bar-danger progress-bar"
+                    role="progressbar"
+                    style={
+                      Object {
+                        "width": "3%",
+                      }
+                    }
+                  />
+                  <div
+                    aria-valuemax={100}
+                    aria-valuemin={0}
+                    aria-valuenow={10}
+                    className="progress-bar-info progress-bar"
+                    role="progressbar"
+                    style={
+                      Object {
+                        "width": "10%",
+                      }
+                    }
+                  />
+                </div>
+                <ul
+                  className="v-links nav nav-pills nav-stacked"
+                  role={null}
+                >
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      role="button"
+                    >
+                      Languages
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      role="button"
+                    >
+                      Documents
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      role="button"
+                    >
+                      Groups 
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="flexTab wideView"
+  >
+    <h2>
+      Documents
+    </h2>
+    <div
+      className="toolbar"
+    >
+      <div
+        className="searchBox form-group"
+      >
+        <span
+          className="input-group"
+        >
+          <input
+            className="form-control"
+            id={undefined}
+            type="text"
+            value="Search documents"
+          />
+          <span
+            className="input-group-addon"
+          >
+            <span
+              className=""
+              title="search"
+            >
+              <svg
+                className="s1"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<use xlink:href=\\"#Icon-search\\" />",
+                  }
+                }
+                style={
+                  Object {
+                    "fill": "currentColor",
+                  }
+                }
+              />
+            </span>
+          </span>
+        </span>
+      </div>
+      <div
+        className="sortItems"
+      >
+        <select
+          className="form-control"
+          id="sort-options"
+          type={undefined}
+        >
+          return
+          <option>
+            Last modified
+          </option>
+          <option>
+            Alphabetical
+          </option>
+        </select>
+      </div>
+      <div
+        className="showItems u-pullRight"
+      >
+        <span>
+          Show
+        </span>
+        <select
+          className="form-control"
+          id="page-size-options"
+          type={undefined}
+        >
+          return
+          <option>
+            10
+          </option>
+          <option>
+            25
+          </option>
+          <option>
+            50
+          </option>
+          <option>
+            100
+          </option>
+        </select>
+      </div>
+      <div
+        className="pageCount col-xs-7 col-sm-8 col-md-12"
+      >
+        <ul
+          className="pagination pagination-md"
+        >
+          <li
+            className="disabled"
+            style={undefined}
+          >
+            <a
+              href="#"
+              onClick={[Function]}
+              role="button"
+              style={
+                Object {
+                  "pointerEvents": "none",
+                }
+              }
+              tabIndex={-1}
+            >
+              <span
+                aria-label="Previous"
+              >
+                ‹
+              </span>
+            </a>
+          </li>
+          <li
+            className="active"
+            style={undefined}
+          >
+            <a
+              href="#"
+              onClick={[Function]}
+              role="button"
+            >
+              1
+            </a>
+          </li>
+          <li
+            className="disabled"
+            style={undefined}
+          >
+            <a
+              href="#"
+              onClick={[Function]}
+              role="button"
+              style={
+                Object {
+                  "pointerEvents": "none",
+                }
+              }
+              tabIndex={-1}
+            >
+              <span
+                aria-label="Next"
+              >
+                ›
+              </span>
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+    <table
+      className="table table-striped table-hover"
+    >
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Translated
+          </th>
+          <th>
+            Last modified
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            <a
+              href=""
+            >
+              MobyDick.txt
+            </a>
+          </td>
+          <td>
+            100%
+          </td>
+          <td>
+            3 days ago
+          </td>
+        </tr>
+        <tr>
+          <td
+            className="progRow"
+            colSpan="3"
+          >
+            <div
+              className="progress"
+            >
+              <div
+                aria-valuemax={100}
+                aria-valuemin={0}
+                aria-valuenow={100}
+                className="progress-bar-success progress-bar"
+                role="progressbar"
+                style={
+                  Object {
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href=""
+            >
+              A-really-long-filename-to-test.txt
+            </a>
+          </td>
+          <td>
+            33%
+          </td>
+          <td>
+            5 days ago
+          </td>
+        </tr>
+        <tr>
+          <td
+            className="progRow"
+            colSpan="3"
+          >
+            <div
+              className="progress"
+            >
+              <div
+                aria-valuemax={100}
+                aria-valuemin={0}
+                aria-valuenow={33}
+                className="progress-bar-success progress-bar"
+                role="progressbar"
+                style={
+                  Object {
+                    "width": "33%",
+                  }
+                }
+              />
+              <div
+                aria-valuemax={100}
+                aria-valuemin={0}
+                aria-valuenow={7}
+                className="progress-bar-warning progress-bar"
+                role="progressbar"
+                style={
+                  Object {
+                    "width": "7%",
+                  }
+                }
+              />
+              <div
+                aria-valuemax={100}
+                aria-valuemin={0}
+                aria-valuenow={3}
+                className="progress-bar-danger progress-bar"
+                role="progressbar"
+                style={
+                  Object {
+                    "width": "3%",
+                  }
+                }
+              />
+              <div
+                aria-valuemax={100}
+                aria-valuemin={0}
+                aria-valuenow={10}
+                className="progress-bar-info progress-bar"
+                role="progressbar"
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              />
+            </div>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            <a
+              href=""
+            >
+              Day Of The Triffids.txt
+            </a>
+          </td>
+          <td>
+            10%
+          </td>
+          <td>
+            12 days ago
+          </td>
+        </tr>
+        <tr>
+          <td
+            className="progRow"
+            colSpan="3"
+          >
+            <div
+              className="progress"
+            >
+              <div
+                aria-valuemax={100}
+                aria-valuemin={0}
+                aria-valuenow={10}
+                className="progress-bar-success progress-bar"
+                role="progressbar"
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              />
+              <div
+                aria-valuemax={100}
+                aria-valuemin={0}
+                aria-valuenow={7}
+                className="progress-bar-warning progress-bar"
+                role="progressbar"
+                style={
+                  Object {
+                    "width": "7%",
+                  }
+                }
+              />
+              <div
+                aria-valuemax={100}
+                aria-valuemin={0}
+                aria-valuenow={33}
+                className="progress-bar-danger progress-bar"
+                role="progressbar"
+                style={
+                  Object {
+                    "width": "33%",
+                  }
+                }
+              />
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`Frontend Storyshots Sidebar GroupsPage 1`] = `
+<div>
+  <div
+    className="bstrapReact"
+    id="pvSidebar"
+  >
+    <div
+      className="sidebar accordion"
+    >
+      <div
+        className="sidebar-wrapper"
+      >
+        <div
+          className="sidebar-container"
+        >
+          <div
+            className="sidebar-content"
+          >
+            <a
+              className="accordion-section-title"
+              onClick={[Function]}
+            >
+              <span
+                className="iconProject"
+              >
+                <svg
+                  className="s2"
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "<use xlink:href=\\"#Icon-project\\" />",
+                    }
+                  }
+                  style={
+                    Object {
+                      "fill": "currentColor",
+                    }
+                  }
+                />
+              </span>
+              <span
+                className="projtitle"
+              >
+                Zanata Server
+              </span>
+              <svg
+                className="hide-desktop down"
+              >
+                <use
+                  xlinkHref="#Icon-chevron-down"
+                />
+              </svg>
+            </a>
+            <div
+              className="accordion-section-content"
+              id="accordion-1"
+            >
+              <ul
+                className="nav nav-pills nav-stacked"
+                role={null}
+              >
+                <li
+                  className="active"
+                  role="presentation"
+                  style={undefined}
+                >
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    role="button"
+                  >
+                    <span
+                      className="iconSidebar"
+                    >
+                      <svg
+                        className="s1"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<use xlink:href=\\"#Icon-users\\" />",
+                          }
+                        }
+                        style={
+                          Object {
+                            "fill": "currentColor",
+                          }
+                        }
+                      />
+                    </span>
+                    People
+                  </a>
+                </li>
+                <li
+                  className=""
+                  role="presentation"
+                  style={undefined}
+                >
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    role="button"
+                  >
+                    <span
+                      className="iconSidebar"
+                    >
+                      <svg
+                        className="s1"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<use xlink:href=\\"#Icon-glossary\\" />",
+                          }
+                        }
+                        style={
+                          Object {
+                            "fill": "currentColor",
+                          }
+                        }
+                      />
+                    </span>
+                    Glossary
+                  </a>
+                </li>
+                <li
+                  className=""
+                  role="presentation"
+                  style={undefined}
+                >
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    role="button"
+                  >
+                    <span
+                      className="iconSidebar"
+                    >
+                      <svg
+                        className="s1"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<use xlink:href=\\"#Icon-info\\" />",
+                          }
+                        }
+                        style={
+                          Object {
+                            "fill": "currentColor",
+                          }
+                        }
+                      />
+                    </span>
+                    About
+                  </a>
+                </li>
+                <li
+                  className=""
+                  role="presentation"
+                  style={undefined}
+                >
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    role="button"
+                  >
+                    <span
+                      className="iconSidebar"
+                    >
+                      <svg
+                        className="s1"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<use xlink:href=\\"#Icon-settings\\" />",
+                          }
+                        }
+                        style={
+                          Object {
+                            "fill": "currentColor",
+                          }
+                        }
+                      />
+                    </span>
+                    Settings 
+                  </a>
+                </li>
+              </ul>
+              <div
+                className="dropdown btn-group"
+              >
+                <button
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="btn-sm btn-default dropdown-toggle btn btn-default"
+                  disabled={false}
+                  id="optionsDropdown"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  type="button"
+                >
+                  Options
+                   
+                  <span
+                    className="caret"
+                  />
+                </button>
+                <ul
+                  aria-labelledby="optionsDropdown"
+                  className="dropdown-menu"
+                  role="menu"
+                >
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                    >
+                      Copy translations
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                    >
+                      Merge translations
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                    >
+                      Copy to new version
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                    >
+                      Download config file
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                    >
+                      Export project to TMX
+                    </a>
+                  </li>
+                </ul>
+              </div>
+              <div
+                className="processing well"
+              >
+                <p
+                  className="task-title"
+                >
+                  Task title
+                </p>
+                <p>
+                  <span>
+                    Processing document 
+                    <span
+                      className="count"
+                    >
+                      1 of 10
+                    </span>
+                     
+                    <span
+                      className="count-pc"
+                    >
+                      12.50%
+                    </span>
+                  </span>
+                </p>
+                <div
+                  className="progress-striped progress"
+                >
+                  <div
+                    aria-valuemax={100}
+                    aria-valuemin={0}
+                    aria-valuenow={12.5}
+                    className="progress-bar"
+                    role="progressbar"
+                    style={
+                      Object {
+                        "width": "12.5%",
+                      }
+                    }
+                  />
+                </div>
+                <Button
+                  className="btn-danger btn-sm"
+                >
+                  Stop
+                </Button>
+              </div>
+              <div
+                id="sidebarVersion"
+              >
+                <div
+                  className="sidebarVersion-inline"
+                >
+                  <span
+                    className="sidebarVersion-title"
+                  >
+                    <span
+                      className=""
+                    >
+                      <svg
+                        className="s2"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<use xlink:href=\\"#Icon-version\\" />",
+                          }
+                        }
+                        style={
+                          Object {
+                            "fill": "currentColor",
+                          }
+                        }
+                      />
+                    </span>
+                    <span
+                      className="versionHeading"
+                    >
+                      VERSION
+                    </span>
+                  </span>
+                  <div
+                    className="dropdown btn-group"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      className="btn-sm btn-default dropdown-toggle btn btn-default"
+                      disabled={false}
+                      id="version-dropdown"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="button"
+                      type="button"
+                    >
+                      master
+                       
+                      <span
+                        className="caret"
+                      />
+                    </button>
+                    <ul
+                      aria-labelledby="version-dropdown"
+                      className="dropdown-menu"
+                      role="menu"
+                    >
+                      <li
+                        className=""
+                        role="presentation"
+                        style={undefined}
+                      >
+                        <a
+                          href="#"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          role="menuitem"
+                          tabIndex="-1"
+                        >
+                          release
+                        </a>
+                      </li>
+                      <li
+                        className=""
+                        role="presentation"
+                        style={undefined}
+                      >
+                        <a
+                          href="#"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          role="menuitem"
+                          tabIndex="-1"
+                        >
+                          test-1
+                        </a>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+                <p
+                  className="sidebarVersion-settings"
+                >
+                  <a
+                    href=""
+                  >
+                    Version settings
+                  </a>
+                </p>
+                <div
+                  className="sidebarVersion-percent"
+                >
+                  <p>
+                    <span
+                      className="percent"
+                    >
+                      10%
+                    </span>
+                     translated
+                  </p>
+                </div>
+                <div
+                  className="progress"
+                >
+                  <div
+                    aria-valuemax={100}
+                    aria-valuemin={0}
+                    aria-valuenow={10}
+                    className="progress-bar-success progress-bar"
+                    role="progressbar"
+                    style={
+                      Object {
+                        "width": "10%",
+                      }
+                    }
+                  />
+                  <div
+                    aria-valuemax={100}
+                    aria-valuemin={0}
+                    aria-valuenow={7}
+                    className="progress-bar-warning progress-bar"
+                    role="progressbar"
+                    style={
+                      Object {
+                        "width": "7%",
+                      }
+                    }
+                  />
+                  <div
+                    aria-valuemax={100}
+                    aria-valuemin={0}
+                    aria-valuenow={3}
+                    className="progress-bar-danger progress-bar"
+                    role="progressbar"
+                    style={
+                      Object {
+                        "width": "3%",
+                      }
+                    }
+                  />
+                  <div
+                    aria-valuemax={100}
+                    aria-valuemin={0}
+                    aria-valuenow={10}
+                    className="progress-bar-info progress-bar"
+                    role="progressbar"
+                    style={
+                      Object {
+                        "width": "10%",
+                      }
+                    }
+                  />
+                </div>
+                <ul
+                  className="v-links nav nav-pills nav-stacked"
+                  role={null}
+                >
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      role="button"
+                    >
+                      Languages
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      role="button"
+                    >
+                      Documents
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      role="button"
+                    >
+                      Groups 
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="flexTab wideView"
+  >
+    <h2>
+      Groups
+    </h2>
+    <div
+      className="toolbar"
+    >
+      <div
+        className="searchBox form-group"
+      >
+        <span
+          className="input-group"
+        >
+          <input
+            className="form-control"
+            id={undefined}
+            type="text"
+            value="Search groups"
+          />
+          <span
+            className="input-group-addon"
+          >
+            <span
+              className=""
+              title="search"
+            >
+              <svg
+                className="s1"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<use xlink:href=\\"#Icon-search\\" />",
+                  }
+                }
+                style={
+                  Object {
+                    "fill": "currentColor",
+                  }
+                }
+              />
+            </span>
+          </span>
+        </span>
+      </div>
+      <div
+        className="sortItems"
+      >
+        <select
+          className="form-control"
+          id="sort-options"
+          type={undefined}
+        >
+          return
+          <option>
+            Last active
+          </option>
+          <option>
+            Alphabetical
+          </option>
+        </select>
+      </div>
+      <div
+        className="showItems u-pullRight"
+      >
+        <span>
+          Show
+        </span>
+        <select
+          className="form-control"
+          id="page-size-options"
+          type={undefined}
+        >
+          return
+          <option>
+            10
+          </option>
+          <option>
+            25
+          </option>
+          <option>
+            50
+          </option>
+          <option>
+            100
+          </option>
+        </select>
+      </div>
+      <div
+        className="pageCount col-xs-7 col-sm-8 col-md-12"
+      >
+        <ul
+          className="pagination pagination-md"
+        >
+          <li
+            className="disabled"
+            style={undefined}
+          >
+            <a
+              href="#"
+              onClick={[Function]}
+              role="button"
+              style={
+                Object {
+                  "pointerEvents": "none",
+                }
+              }
+              tabIndex={-1}
+            >
+              <span
+                aria-label="Previous"
+              >
+                ‹
+              </span>
+            </a>
+          </li>
+          <li
+            className="active"
+            style={undefined}
+          >
+            <a
+              href="#"
+              onClick={[Function]}
+              role="button"
+            >
+              1
+            </a>
+          </li>
+          <li
+            className="disabled"
+            style={undefined}
+          >
+            <a
+              href="#"
+              onClick={[Function]}
+              role="button"
+              style={
+                Object {
+                  "pointerEvents": "none",
+                }
+              }
+              tabIndex={-1}
+            >
+              <span
+                aria-label="Next"
+              >
+                ›
+              </span>
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+    <table
+      className="table table-striped table-hover"
+    >
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Members
+          </th>
+          <th>
+            Last active
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            Zanata fanatics
+          </td>
+          <td>
+            320
+          </td>
+          <td>
+            3 days ago
+          </td>
+        </tr>
+        <tr>
+          <td>
+            Japanese translator
+          </td>
+          <td>
+            17
+          </td>
+          <td>
+            5 days ago
+          </td>
+        </tr>
+        <tr>
+          <td>
+            Word nerds
+          </td>
+          <td>
+            58
+          </td>
+          <td>
+            12 days ago
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`Frontend Storyshots Sidebar LanguagesPage 1`] = `
+<div>
+  <div
+    className="bstrapReact"
+    id="pvSidebar"
+  >
+    <div
+      className="sidebar accordion"
+    >
+      <div
+        className="sidebar-wrapper"
+      >
+        <div
+          className="sidebar-container"
+        >
+          <div
+            className="sidebar-content"
+          >
+            <a
+              className="accordion-section-title"
+              onClick={[Function]}
+            >
+              <span
+                className="iconProject"
+              >
+                <svg
+                  className="s2"
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "<use xlink:href=\\"#Icon-project\\" />",
+                    }
+                  }
+                  style={
+                    Object {
+                      "fill": "currentColor",
+                    }
+                  }
+                />
+              </span>
+              <span
+                className="projtitle"
+              >
+                Zanata Server
+              </span>
+              <svg
+                className="hide-desktop down"
+              >
+                <use
+                  xlinkHref="#Icon-chevron-down"
+                />
+              </svg>
+            </a>
+            <div
+              className="accordion-section-content"
+              id="accordion-1"
+            >
+              <ul
+                className="nav nav-pills nav-stacked"
+                role={null}
+              >
+                <li
+                  className="active"
+                  role="presentation"
+                  style={undefined}
+                >
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    role="button"
+                  >
+                    <span
+                      className="iconSidebar"
+                    >
+                      <svg
+                        className="s1"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<use xlink:href=\\"#Icon-users\\" />",
+                          }
+                        }
+                        style={
+                          Object {
+                            "fill": "currentColor",
+                          }
+                        }
+                      />
+                    </span>
+                    People
+                  </a>
+                </li>
+                <li
+                  className=""
+                  role="presentation"
+                  style={undefined}
+                >
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    role="button"
+                  >
+                    <span
+                      className="iconSidebar"
+                    >
+                      <svg
+                        className="s1"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<use xlink:href=\\"#Icon-glossary\\" />",
+                          }
+                        }
+                        style={
+                          Object {
+                            "fill": "currentColor",
+                          }
+                        }
+                      />
+                    </span>
+                    Glossary
+                  </a>
+                </li>
+                <li
+                  className=""
+                  role="presentation"
+                  style={undefined}
+                >
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    role="button"
+                  >
+                    <span
+                      className="iconSidebar"
+                    >
+                      <svg
+                        className="s1"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<use xlink:href=\\"#Icon-info\\" />",
+                          }
+                        }
+                        style={
+                          Object {
+                            "fill": "currentColor",
+                          }
+                        }
+                      />
+                    </span>
+                    About
+                  </a>
+                </li>
+                <li
+                  className=""
+                  role="presentation"
+                  style={undefined}
+                >
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    role="button"
+                  >
+                    <span
+                      className="iconSidebar"
+                    >
+                      <svg
+                        className="s1"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<use xlink:href=\\"#Icon-settings\\" />",
+                          }
+                        }
+                        style={
+                          Object {
+                            "fill": "currentColor",
+                          }
+                        }
+                      />
+                    </span>
+                    Settings 
+                  </a>
+                </li>
+              </ul>
+              <div
+                className="dropdown btn-group"
+              >
+                <button
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="btn-sm btn-default dropdown-toggle btn btn-default"
+                  disabled={false}
+                  id="optionsDropdown"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  type="button"
+                >
+                  Options
+                   
+                  <span
+                    className="caret"
+                  />
+                </button>
+                <ul
+                  aria-labelledby="optionsDropdown"
+                  className="dropdown-menu"
+                  role="menu"
+                >
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                    >
+                      Copy translations
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                    >
+                      Merge translations
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                    >
+                      Copy to new version
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                    >
+                      Download config file
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                    >
+                      Export project to TMX
+                    </a>
+                  </li>
+                </ul>
+              </div>
+              <div
+                className="processing well"
+              >
+                <p
+                  className="task-title"
+                >
+                  Task title
+                </p>
+                <p>
+                  <span>
+                    Processing document 
+                    <span
+                      className="count"
+                    >
+                      1 of 10
+                    </span>
+                     
+                    <span
+                      className="count-pc"
+                    >
+                      12.50%
+                    </span>
+                  </span>
+                </p>
+                <div
+                  className="progress-striped progress"
+                >
+                  <div
+                    aria-valuemax={100}
+                    aria-valuemin={0}
+                    aria-valuenow={12.5}
+                    className="progress-bar"
+                    role="progressbar"
+                    style={
+                      Object {
+                        "width": "12.5%",
+                      }
+                    }
+                  />
+                </div>
+                <Button
+                  className="btn-danger btn-sm"
+                >
+                  Stop
+                </Button>
+              </div>
+              <div
+                id="sidebarVersion"
+              >
+                <div
+                  className="sidebarVersion-inline"
+                >
+                  <span
+                    className="sidebarVersion-title"
+                  >
+                    <span
+                      className=""
+                    >
+                      <svg
+                        className="s2"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<use xlink:href=\\"#Icon-version\\" />",
+                          }
+                        }
+                        style={
+                          Object {
+                            "fill": "currentColor",
+                          }
+                        }
+                      />
+                    </span>
+                    <span
+                      className="versionHeading"
+                    >
+                      VERSION
+                    </span>
+                  </span>
+                  <div
+                    className="dropdown btn-group"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      className="btn-sm btn-default dropdown-toggle btn btn-default"
+                      disabled={false}
+                      id="version-dropdown"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="button"
+                      type="button"
+                    >
+                      master
+                       
+                      <span
+                        className="caret"
+                      />
+                    </button>
+                    <ul
+                      aria-labelledby="version-dropdown"
+                      className="dropdown-menu"
+                      role="menu"
+                    >
+                      <li
+                        className=""
+                        role="presentation"
+                        style={undefined}
+                      >
+                        <a
+                          href="#"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          role="menuitem"
+                          tabIndex="-1"
+                        >
+                          release
+                        </a>
+                      </li>
+                      <li
+                        className=""
+                        role="presentation"
+                        style={undefined}
+                      >
+                        <a
+                          href="#"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          role="menuitem"
+                          tabIndex="-1"
+                        >
+                          test-1
+                        </a>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+                <p
+                  className="sidebarVersion-settings"
+                >
+                  <a
+                    href=""
+                  >
+                    Version settings
+                  </a>
+                </p>
+                <div
+                  className="sidebarVersion-percent"
+                >
+                  <p>
+                    <span
+                      className="percent"
+                    >
+                      10%
+                    </span>
+                     translated
+                  </p>
+                </div>
+                <div
+                  className="progress"
+                >
+                  <div
+                    aria-valuemax={100}
+                    aria-valuemin={0}
+                    aria-valuenow={10}
+                    className="progress-bar-success progress-bar"
+                    role="progressbar"
+                    style={
+                      Object {
+                        "width": "10%",
+                      }
+                    }
+                  />
+                  <div
+                    aria-valuemax={100}
+                    aria-valuemin={0}
+                    aria-valuenow={7}
+                    className="progress-bar-warning progress-bar"
+                    role="progressbar"
+                    style={
+                      Object {
+                        "width": "7%",
+                      }
+                    }
+                  />
+                  <div
+                    aria-valuemax={100}
+                    aria-valuemin={0}
+                    aria-valuenow={3}
+                    className="progress-bar-danger progress-bar"
+                    role="progressbar"
+                    style={
+                      Object {
+                        "width": "3%",
+                      }
+                    }
+                  />
+                  <div
+                    aria-valuemax={100}
+                    aria-valuemin={0}
+                    aria-valuenow={10}
+                    className="progress-bar-info progress-bar"
+                    role="progressbar"
+                    style={
+                      Object {
+                        "width": "10%",
+                      }
+                    }
+                  />
+                </div>
+                <ul
+                  className="v-links nav nav-pills nav-stacked"
+                  role={null}
+                >
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      role="button"
+                    >
+                      Languages
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      role="button"
+                    >
+                      Documents
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      role="button"
+                    >
+                      Groups 
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="flexTab wideView"
+  >
+    <h2>
+      Languages
+    </h2>
+    <div
+      className="toolbar"
+    >
+      <div
+        className="searchBox form-group"
+      >
+        <span
+          className="input-group"
+        >
+          <input
+            className="form-control"
+            id={undefined}
+            type="text"
+            value="Search languages"
+          />
+          <span
+            className="input-group-addon"
+          >
+            <span
+              className=""
+              title="search"
+            >
+              <svg
+                className="s1"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<use xlink:href=\\"#Icon-search\\" />",
+                  }
+                }
+                style={
+                  Object {
+                    "fill": "currentColor",
+                  }
+                }
+              />
+            </span>
+          </span>
+        </span>
+      </div>
+      <div
+        className="sortItems"
+      >
+        <select
+          className="form-control"
+          id="sort-options"
+          type={undefined}
+        >
+          return
+          <option>
+            Last active
+          </option>
+          <option>
+            Alphabetical
+          </option>
+        </select>
+      </div>
+      <div
+        className="showItems u-pullRight"
+      >
+        <span>
+          Show
+        </span>
+        <select
+          className="form-control"
+          id="page-size-options"
+          type={undefined}
+        >
+          return
+          <option>
+            10
+          </option>
+          <option>
+            25
+          </option>
+          <option>
+            50
+          </option>
+          <option>
+            100
+          </option>
+        </select>
+      </div>
+      <div
+        className="pageCount col-xs-7 col-sm-8 col-md-12"
+      >
+        <ul
+          className="pagination pagination-md"
+        >
+          <li
+            className="disabled"
+            style={undefined}
+          >
+            <a
+              href="#"
+              onClick={[Function]}
+              role="button"
+              style={
+                Object {
+                  "pointerEvents": "none",
+                }
+              }
+              tabIndex={-1}
+            >
+              <span
+                aria-label="Previous"
+              >
+                ‹
+              </span>
+            </a>
+          </li>
+          <li
+            className="active"
+            style={undefined}
+          >
+            <a
+              href="#"
+              onClick={[Function]}
+              role="button"
+            >
+              1
+            </a>
+          </li>
+          <li
+            className="disabled"
+            style={undefined}
+          >
+            <a
+              href="#"
+              onClick={[Function]}
+              role="button"
+              style={
+                Object {
+                  "pointerEvents": "none",
+                }
+              }
+              tabIndex={-1}
+            >
+              <span
+                aria-label="Next"
+              >
+                ›
+              </span>
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+    <table
+      className="table table-striped table-hover"
+    >
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Translated
+          </th>
+          <th>
+            Last modified
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            Assamese
+          </td>
+          <td>
+            100%
+          </td>
+          <td>
+            3 days ago
+          </td>
+        </tr>
+        <tr>
+          <td
+            className="progRow"
+            colSpan="3"
+          >
+            <div
+              className="progress"
+            >
+              <div
+                aria-valuemax={100}
+                aria-valuemin={0}
+                aria-valuenow={100}
+                className="progress-bar-success progress-bar"
+                role="progressbar"
+                style={
+                  Object {
+                    "width": "100%",
+                  }
+                }
+              />
+            </div>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            French
+          </td>
+          <td>
+            33%
+          </td>
+          <td>
+            5 days ago
+          </td>
+        </tr>
+        <tr>
+          <td
+            className="progRow"
+            colSpan="3"
+          >
+            <div
+              className="progress"
+            >
+              <div
+                aria-valuemax={100}
+                aria-valuemin={0}
+                aria-valuenow={33}
+                className="progress-bar-success progress-bar"
+                role="progressbar"
+                style={
+                  Object {
+                    "width": "33%",
+                  }
+                }
+              />
+              <div
+                aria-valuemax={100}
+                aria-valuemin={0}
+                aria-valuenow={7}
+                className="progress-bar-warning progress-bar"
+                role="progressbar"
+                style={
+                  Object {
+                    "width": "7%",
+                  }
+                }
+              />
+              <div
+                aria-valuemax={100}
+                aria-valuemin={0}
+                aria-valuenow={3}
+                className="progress-bar-danger progress-bar"
+                role="progressbar"
+                style={
+                  Object {
+                    "width": "3%",
+                  }
+                }
+              />
+              <div
+                aria-valuemax={100}
+                aria-valuemin={0}
+                aria-valuenow={10}
+                className="progress-bar-info progress-bar"
+                role="progressbar"
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              />
+            </div>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            German
+          </td>
+          <td>
+            10%
+          </td>
+          <td>
+            12 days ago
+          </td>
+        </tr>
+        <tr>
+          <td
+            className="progRow"
+            colSpan="3"
+          >
+            <div
+              className="progress"
+            >
+              <div
+                aria-valuemax={100}
+                aria-valuemin={0}
+                aria-valuenow={10}
+                className="progress-bar-success progress-bar"
+                role="progressbar"
+                style={
+                  Object {
+                    "width": "10%",
+                  }
+                }
+              />
+              <div
+                aria-valuemax={100}
+                aria-valuemin={0}
+                aria-valuenow={7}
+                className="progress-bar-warning progress-bar"
+                role="progressbar"
+                style={
+                  Object {
+                    "width": "7%",
+                  }
+                }
+              />
+              <div
+                aria-valuemax={100}
+                aria-valuemin={0}
+                aria-valuenow={33}
+                className="progress-bar-danger progress-bar"
+                role="progressbar"
+                style={
+                  Object {
+                    "width": "33%",
+                  }
+                }
+              />
+            </div>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`Frontend Storyshots Sidebar PeoplePage 1`] = `
+<div>
+  <div
+    className="bstrapReact"
+    id="pvSidebar"
+  >
+    <div
+      className="sidebar accordion"
+    >
+      <div
+        className="sidebar-wrapper"
+      >
+        <div
+          className="sidebar-container"
+        >
+          <div
+            className="sidebar-content"
+          >
+            <a
+              className="accordion-section-title"
+              onClick={[Function]}
+            >
+              <span
+                className="iconProject"
+              >
+                <svg
+                  className="s2"
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "<use xlink:href=\\"#Icon-project\\" />",
+                    }
+                  }
+                  style={
+                    Object {
+                      "fill": "currentColor",
+                    }
+                  }
+                />
+              </span>
+              <span
+                className="projtitle"
+              >
+                Zanata Server
+              </span>
+              <svg
+                className="hide-desktop down"
+              >
+                <use
+                  xlinkHref="#Icon-chevron-down"
+                />
+              </svg>
+            </a>
+            <div
+              className="accordion-section-content"
+              id="accordion-1"
+            >
+              <ul
+                className="nav nav-pills nav-stacked"
+                role={null}
+              >
+                <li
+                  className="active"
+                  role="presentation"
+                  style={undefined}
+                >
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    role="button"
+                  >
+                    <span
+                      className="iconSidebar"
+                    >
+                      <svg
+                        className="s1"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<use xlink:href=\\"#Icon-users\\" />",
+                          }
+                        }
+                        style={
+                          Object {
+                            "fill": "currentColor",
+                          }
+                        }
+                      />
+                    </span>
+                    People
+                  </a>
+                </li>
+                <li
+                  className=""
+                  role="presentation"
+                  style={undefined}
+                >
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    role="button"
+                  >
+                    <span
+                      className="iconSidebar"
+                    >
+                      <svg
+                        className="s1"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<use xlink:href=\\"#Icon-glossary\\" />",
+                          }
+                        }
+                        style={
+                          Object {
+                            "fill": "currentColor",
+                          }
+                        }
+                      />
+                    </span>
+                    Glossary
+                  </a>
+                </li>
+                <li
+                  className=""
+                  role="presentation"
+                  style={undefined}
+                >
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    role="button"
+                  >
+                    <span
+                      className="iconSidebar"
+                    >
+                      <svg
+                        className="s1"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<use xlink:href=\\"#Icon-info\\" />",
+                          }
+                        }
+                        style={
+                          Object {
+                            "fill": "currentColor",
+                          }
+                        }
+                      />
+                    </span>
+                    About
+                  </a>
+                </li>
+                <li
+                  className=""
+                  role="presentation"
+                  style={undefined}
+                >
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    role="button"
+                  >
+                    <span
+                      className="iconSidebar"
+                    >
+                      <svg
+                        className="s1"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<use xlink:href=\\"#Icon-settings\\" />",
+                          }
+                        }
+                        style={
+                          Object {
+                            "fill": "currentColor",
+                          }
+                        }
+                      />
+                    </span>
+                    Settings 
+                  </a>
+                </li>
+              </ul>
+              <div
+                className="dropdown btn-group"
+              >
+                <button
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="btn-sm btn-default dropdown-toggle btn btn-default"
+                  disabled={false}
+                  id="optionsDropdown"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  type="button"
+                >
+                  Options
+                   
+                  <span
+                    className="caret"
+                  />
+                </button>
+                <ul
+                  aria-labelledby="optionsDropdown"
+                  className="dropdown-menu"
+                  role="menu"
+                >
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                    >
+                      Copy translations
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                    >
+                      Merge translations
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                    >
+                      Copy to new version
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                    >
+                      Download config file
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                    >
+                      Export project to TMX
+                    </a>
+                  </li>
+                </ul>
+              </div>
+              <div
+                className="processing well"
+              >
+                <p
+                  className="task-title"
+                >
+                  Task title
+                </p>
+                <p>
+                  <span>
+                    Processing document 
+                    <span
+                      className="count"
+                    >
+                      1 of 10
+                    </span>
+                     
+                    <span
+                      className="count-pc"
+                    >
+                      12.50%
+                    </span>
+                  </span>
+                </p>
+                <div
+                  className="progress-striped progress"
+                >
+                  <div
+                    aria-valuemax={100}
+                    aria-valuemin={0}
+                    aria-valuenow={12.5}
+                    className="progress-bar"
+                    role="progressbar"
+                    style={
+                      Object {
+                        "width": "12.5%",
+                      }
+                    }
+                  />
+                </div>
+                <Button
+                  className="btn-danger btn-sm"
+                >
+                  Stop
+                </Button>
+              </div>
+              <div
+                id="sidebarVersion"
+              >
+                <div
+                  className="sidebarVersion-inline"
+                >
+                  <span
+                    className="sidebarVersion-title"
+                  >
+                    <span
+                      className=""
+                    >
+                      <svg
+                        className="s2"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<use xlink:href=\\"#Icon-version\\" />",
+                          }
+                        }
+                        style={
+                          Object {
+                            "fill": "currentColor",
+                          }
+                        }
+                      />
+                    </span>
+                    <span
+                      className="versionHeading"
+                    >
+                      VERSION
+                    </span>
+                  </span>
+                  <div
+                    className="dropdown btn-group"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      className="btn-sm btn-default dropdown-toggle btn btn-default"
+                      disabled={false}
+                      id="version-dropdown"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="button"
+                      type="button"
+                    >
+                      master
+                       
+                      <span
+                        className="caret"
+                      />
+                    </button>
+                    <ul
+                      aria-labelledby="version-dropdown"
+                      className="dropdown-menu"
+                      role="menu"
+                    >
+                      <li
+                        className=""
+                        role="presentation"
+                        style={undefined}
+                      >
+                        <a
+                          href="#"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          role="menuitem"
+                          tabIndex="-1"
+                        >
+                          release
+                        </a>
+                      </li>
+                      <li
+                        className=""
+                        role="presentation"
+                        style={undefined}
+                      >
+                        <a
+                          href="#"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          role="menuitem"
+                          tabIndex="-1"
+                        >
+                          test-1
+                        </a>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+                <p
+                  className="sidebarVersion-settings"
+                >
+                  <a
+                    href=""
+                  >
+                    Version settings
+                  </a>
+                </p>
+                <div
+                  className="sidebarVersion-percent"
+                >
+                  <p>
+                    <span
+                      className="percent"
+                    >
+                      10%
+                    </span>
+                     translated
+                  </p>
+                </div>
+                <div
+                  className="progress"
+                >
+                  <div
+                    aria-valuemax={100}
+                    aria-valuemin={0}
+                    aria-valuenow={10}
+                    className="progress-bar-success progress-bar"
+                    role="progressbar"
+                    style={
+                      Object {
+                        "width": "10%",
+                      }
+                    }
+                  />
+                  <div
+                    aria-valuemax={100}
+                    aria-valuemin={0}
+                    aria-valuenow={7}
+                    className="progress-bar-warning progress-bar"
+                    role="progressbar"
+                    style={
+                      Object {
+                        "width": "7%",
+                      }
+                    }
+                  />
+                  <div
+                    aria-valuemax={100}
+                    aria-valuemin={0}
+                    aria-valuenow={3}
+                    className="progress-bar-danger progress-bar"
+                    role="progressbar"
+                    style={
+                      Object {
+                        "width": "3%",
+                      }
+                    }
+                  />
+                  <div
+                    aria-valuemax={100}
+                    aria-valuemin={0}
+                    aria-valuenow={10}
+                    className="progress-bar-info progress-bar"
+                    role="progressbar"
+                    style={
+                      Object {
+                        "width": "10%",
+                      }
+                    }
+                  />
+                </div>
+                <ul
+                  className="v-links nav nav-pills nav-stacked"
+                  role={null}
+                >
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      role="button"
+                    >
+                      Languages
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      role="button"
+                    >
+                      Documents
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      role="button"
+                    >
+                      Groups 
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="flexTab wideView"
+  >
+    <h2>
+      People
+    </h2>
+    <div>
+      <button
+        className="btn btn-primary"
+        disabled={false}
+        id="btn-people-add-new"
+        type="button"
+      >
+        <span
+          className="plusicon"
+          title="plus"
+        >
+          <svg
+            className="n1"
+            dangerouslySetInnerHTML={
+              Object {
+                "__html": "<use xlink:href=\\"#Icon-plus\\" />",
+              }
+            }
+            style={
+              Object {
+                "fill": "currentColor",
+              }
+            }
+          />
+        </span>
+          Add someone
+      </button>
+    </div>
+    <div
+      className="toolbar"
+    >
+      <div
+        className="searchBox form-group"
+      >
+        <span
+          className="input-group"
+        >
+          <input
+            className="form-control"
+            id={undefined}
+            type="text"
+            value="Search people"
+          />
+          <span
+            className="input-group-addon"
+          >
+            <span
+              className=""
+              title="search"
+            >
+              <svg
+                className="s1"
+                dangerouslySetInnerHTML={
+                  Object {
+                    "__html": "<use xlink:href=\\"#Icon-search\\" />",
+                  }
+                }
+                style={
+                  Object {
+                    "fill": "currentColor",
+                  }
+                }
+              />
+            </span>
+          </span>
+        </span>
+      </div>
+      <div
+        className="sortItems"
+      >
+        <select
+          className="form-control"
+          id="sort-options"
+          type={undefined}
+        >
+          return
+          <option>
+            Last active
+          </option>
+          <option>
+            Alphabetical
+          </option>
+        </select>
+      </div>
+      <div
+        className="showItems u-pullRight"
+      >
+        <span>
+          Show
+        </span>
+        <select
+          className="form-control"
+          id="page-size-options"
+          type={undefined}
+        >
+          return
+          <option>
+            10
+          </option>
+          <option>
+            25
+          </option>
+          <option>
+            50
+          </option>
+          <option>
+            100
+          </option>
+        </select>
+      </div>
+      <div
+        className="pageCount col-xs-7 col-sm-8 col-md-12"
+      >
+        <ul
+          className="pagination pagination-md"
+        >
+          <li
+            className="disabled"
+            style={undefined}
+          >
+            <a
+              href="#"
+              onClick={[Function]}
+              role="button"
+              style={
+                Object {
+                  "pointerEvents": "none",
+                }
+              }
+              tabIndex={-1}
+            >
+              <span
+                aria-label="Previous"
+              >
+                ‹
+              </span>
+            </a>
+          </li>
+          <li
+            className="active"
+            style={undefined}
+          >
+            <a
+              href="#"
+              onClick={[Function]}
+              role="button"
+            >
+              1
+            </a>
+          </li>
+          <li
+            className=""
+            style={undefined}
+          >
+            <a
+              href="#"
+              onClick={[Function]}
+              role="button"
+            >
+              2
+            </a>
+          </li>
+          <li
+            className=""
+            style={undefined}
+          >
+            <a
+              href="#"
+              onClick={[Function]}
+              role="button"
+            >
+              3
+            </a>
+          </li>
+          <li
+            className=""
+            style={undefined}
+          >
+            <a
+              href="#"
+              onClick={[Function]}
+              role="button"
+            >
+              4
+            </a>
+          </li>
+          <li
+            className=""
+            style={undefined}
+          >
+            <a
+              href="#"
+              onClick={[Function]}
+              role="button"
+            >
+              5
+            </a>
+          </li>
+          <li
+            className=""
+            style={undefined}
+          >
+            <a
+              href="#"
+              onClick={[Function]}
+              role="button"
+            >
+              6
+            </a>
+          </li>
+          <li
+            className=""
+            style={undefined}
+          >
+            <a
+              href="#"
+              onClick={[Function]}
+              role="button"
+            >
+              7
+            </a>
+          </li>
+          <li
+            className=""
+            style={undefined}
+          >
+            <a
+              href="#"
+              onClick={[Function]}
+              role="button"
+            >
+              8
+            </a>
+          </li>
+          <li
+            className=""
+            style={undefined}
+          >
+            <a
+              href="#"
+              onClick={[Function]}
+              role="button"
+            >
+              9
+            </a>
+          </li>
+          <li
+            className=""
+            style={undefined}
+          >
+            <a
+              href="#"
+              onClick={[Function]}
+              role="button"
+            >
+              10
+            </a>
+          </li>
+          <li
+            className=""
+            style={undefined}
+          >
+            <a
+              href="#"
+              onClick={[Function]}
+              role="button"
+            >
+              <span
+                aria-label="Next"
+              >
+                ›
+              </span>
+            </a>
+          </li>
+        </ul>
+      </div>
+    </div>
+    <table
+      className="table table-striped table-hover"
+    >
+      <thead>
+        <tr>
+          <th>
+            Name
+          </th>
+          <th>
+            Role
+          </th>
+          <th>
+             
+          </th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr>
+          <td>
+            Admin
+          </td>
+          <td>
+            Maintainer
+          </td>
+          <td>
+            <button
+              className="btn btn-default"
+              disabled={false}
+              type="button"
+            >
+              <span
+                className=""
+              >
+                <svg
+                  className="s0"
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "<use xlink:href=\\"#Icon-settings\\" />",
+                    }
+                  }
+                  style={
+                    Object {
+                      "fill": "currentColor",
+                    }
+                  }
+                />
+              </span>
+              Manage permissions
+            </button>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            Tux
+          </td>
+          <td>
+            Reviewer
+          </td>
+          <td>
+            <button
+              className="btn btn-default"
+              disabled={false}
+              type="button"
+            >
+              <span
+                className=""
+              >
+                <svg
+                  className="s0"
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "<use xlink:href=\\"#Icon-settings\\" />",
+                    }
+                  }
+                  style={
+                    Object {
+                      "fill": "currentColor",
+                    }
+                  }
+                />
+              </span>
+              Manage permissions
+            </button>
+          </td>
+        </tr>
+        <tr>
+          <td>
+            Alix
+          </td>
+          <td>
+            Translator
+          </td>
+          <td>
+            <button
+              className="btn btn-default"
+              disabled={false}
+              type="button"
+            >
+              <span
+                className=""
+              >
+                <svg
+                  className="s0"
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "<use xlink:href=\\"#Icon-settings\\" />",
+                    }
+                  }
+                  style={
+                    Object {
+                      "fill": "currentColor",
+                    }
+                  }
+                />
+              </span>
+              Manage permissions
+            </button>
+          </td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</div>
+`;
+
+exports[`Frontend Storyshots Sidebar default 1`] = `
+<div>
+  <div
+    className="bstrapReact"
+    id="pvSidebar"
+  >
+    <div
+      className="sidebar accordion"
+    >
+      <div
+        className="sidebar-wrapper"
+      >
+        <div
+          className="sidebar-container"
+        >
+          <div
+            className="sidebar-content"
+          >
+            <a
+              className="accordion-section-title"
+              onClick={[Function]}
+            >
+              <span
+                className="iconProject"
+              >
+                <svg
+                  className="s2"
+                  dangerouslySetInnerHTML={
+                    Object {
+                      "__html": "<use xlink:href=\\"#Icon-project\\" />",
+                    }
+                  }
+                  style={
+                    Object {
+                      "fill": "currentColor",
+                    }
+                  }
+                />
+              </span>
+              <span
+                className="projtitle"
+              >
+                Zanata Server
+              </span>
+              <svg
+                className="hide-desktop down"
+              >
+                <use
+                  xlinkHref="#Icon-chevron-down"
+                />
+              </svg>
+            </a>
+            <div
+              className="accordion-section-content"
+              id="accordion-1"
+            >
+              <ul
+                className="nav nav-pills nav-stacked"
+                role={null}
+              >
+                <li
+                  className="active"
+                  role="presentation"
+                  style={undefined}
+                >
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    role="button"
+                  >
+                    <span
+                      className="iconSidebar"
+                    >
+                      <svg
+                        className="s1"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<use xlink:href=\\"#Icon-users\\" />",
+                          }
+                        }
+                        style={
+                          Object {
+                            "fill": "currentColor",
+                          }
+                        }
+                      />
+                    </span>
+                    People
+                  </a>
+                </li>
+                <li
+                  className=""
+                  role="presentation"
+                  style={undefined}
+                >
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    role="button"
+                  >
+                    <span
+                      className="iconSidebar"
+                    >
+                      <svg
+                        className="s1"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<use xlink:href=\\"#Icon-glossary\\" />",
+                          }
+                        }
+                        style={
+                          Object {
+                            "fill": "currentColor",
+                          }
+                        }
+                      />
+                    </span>
+                    Glossary
+                  </a>
+                </li>
+                <li
+                  className=""
+                  role="presentation"
+                  style={undefined}
+                >
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    role="button"
+                  >
+                    <span
+                      className="iconSidebar"
+                    >
+                      <svg
+                        className="s1"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<use xlink:href=\\"#Icon-info\\" />",
+                          }
+                        }
+                        style={
+                          Object {
+                            "fill": "currentColor",
+                          }
+                        }
+                      />
+                    </span>
+                    About
+                  </a>
+                </li>
+                <li
+                  className=""
+                  role="presentation"
+                  style={undefined}
+                >
+                  <a
+                    href="#"
+                    onClick={[Function]}
+                    role="button"
+                  >
+                    <span
+                      className="iconSidebar"
+                    >
+                      <svg
+                        className="s1"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<use xlink:href=\\"#Icon-settings\\" />",
+                          }
+                        }
+                        style={
+                          Object {
+                            "fill": "currentColor",
+                          }
+                        }
+                      />
+                    </span>
+                    Settings 
+                  </a>
+                </li>
+              </ul>
+              <div
+                className="dropdown btn-group"
+              >
+                <button
+                  aria-expanded={false}
+                  aria-haspopup={true}
+                  className="btn-sm btn-default dropdown-toggle btn btn-default"
+                  disabled={false}
+                  id="optionsDropdown"
+                  onClick={[Function]}
+                  onKeyDown={[Function]}
+                  role="button"
+                  type="button"
+                >
+                  Options
+                   
+                  <span
+                    className="caret"
+                  />
+                </button>
+                <ul
+                  aria-labelledby="optionsDropdown"
+                  className="dropdown-menu"
+                  role="menu"
+                >
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                    >
+                      Copy translations
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                    >
+                      Merge translations
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                    >
+                      Copy to new version
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                    >
+                      Download config file
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="menuitem"
+                      tabIndex="-1"
+                    >
+                      Export project to TMX
+                    </a>
+                  </li>
+                </ul>
+              </div>
+              <div
+                className="processing well"
+              >
+                <p
+                  className="task-title"
+                >
+                  Task title
+                </p>
+                <p>
+                  <span>
+                    Processing document 
+                    <span
+                      className="count"
+                    >
+                      1 of 10
+                    </span>
+                     
+                    <span
+                      className="count-pc"
+                    >
+                      12.50%
+                    </span>
+                  </span>
+                </p>
+                <div
+                  className="progress-striped progress"
+                >
+                  <div
+                    aria-valuemax={100}
+                    aria-valuemin={0}
+                    aria-valuenow={12.5}
+                    className="progress-bar"
+                    role="progressbar"
+                    style={
+                      Object {
+                        "width": "12.5%",
+                      }
+                    }
+                  />
+                </div>
+                <Button
+                  className="btn-danger btn-sm"
+                >
+                  Stop
+                </Button>
+              </div>
+              <div
+                id="sidebarVersion"
+              >
+                <div
+                  className="sidebarVersion-inline"
+                >
+                  <span
+                    className="sidebarVersion-title"
+                  >
+                    <span
+                      className=""
+                    >
+                      <svg
+                        className="s2"
+                        dangerouslySetInnerHTML={
+                          Object {
+                            "__html": "<use xlink:href=\\"#Icon-version\\" />",
+                          }
+                        }
+                        style={
+                          Object {
+                            "fill": "currentColor",
+                          }
+                        }
+                      />
+                    </span>
+                    <span
+                      className="versionHeading"
+                    >
+                      VERSION
+                    </span>
+                  </span>
+                  <div
+                    className="dropdown btn-group"
+                  >
+                    <button
+                      aria-expanded={false}
+                      aria-haspopup={true}
+                      className="btn-sm btn-default dropdown-toggle btn btn-default"
+                      disabled={false}
+                      id="version-dropdown"
+                      onClick={[Function]}
+                      onKeyDown={[Function]}
+                      role="button"
+                      type="button"
+                    >
+                      master
+                       
+                      <span
+                        className="caret"
+                      />
+                    </button>
+                    <ul
+                      aria-labelledby="version-dropdown"
+                      className="dropdown-menu"
+                      role="menu"
+                    >
+                      <li
+                        className=""
+                        role="presentation"
+                        style={undefined}
+                      >
+                        <a
+                          href="#"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          role="menuitem"
+                          tabIndex="-1"
+                        >
+                          release
+                        </a>
+                      </li>
+                      <li
+                        className=""
+                        role="presentation"
+                        style={undefined}
+                      >
+                        <a
+                          href="#"
+                          onClick={[Function]}
+                          onKeyDown={[Function]}
+                          role="menuitem"
+                          tabIndex="-1"
+                        >
+                          test-1
+                        </a>
+                      </li>
+                    </ul>
+                  </div>
+                </div>
+                <p
+                  className="sidebarVersion-settings"
+                >
+                  <a
+                    href=""
+                  >
+                    Version settings
+                  </a>
+                </p>
+                <div
+                  className="sidebarVersion-percent"
+                >
+                  <p>
+                    <span
+                      className="percent"
+                    >
+                      10%
+                    </span>
+                     translated
+                  </p>
+                </div>
+                <div
+                  className="progress"
+                >
+                  <div
+                    aria-valuemax={100}
+                    aria-valuemin={0}
+                    aria-valuenow={10}
+                    className="progress-bar-success progress-bar"
+                    role="progressbar"
+                    style={
+                      Object {
+                        "width": "10%",
+                      }
+                    }
+                  />
+                  <div
+                    aria-valuemax={100}
+                    aria-valuemin={0}
+                    aria-valuenow={7}
+                    className="progress-bar-warning progress-bar"
+                    role="progressbar"
+                    style={
+                      Object {
+                        "width": "7%",
+                      }
+                    }
+                  />
+                  <div
+                    aria-valuemax={100}
+                    aria-valuemin={0}
+                    aria-valuenow={3}
+                    className="progress-bar-danger progress-bar"
+                    role="progressbar"
+                    style={
+                      Object {
+                        "width": "3%",
+                      }
+                    }
+                  />
+                  <div
+                    aria-valuemax={100}
+                    aria-valuemin={0}
+                    aria-valuenow={10}
+                    className="progress-bar-info progress-bar"
+                    role="progressbar"
+                    style={
+                      Object {
+                        "width": "10%",
+                      }
+                    }
+                  />
+                </div>
+                <ul
+                  className="v-links nav nav-pills nav-stacked"
+                  role={null}
+                >
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      role="button"
+                    >
+                      Languages
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      role="button"
+                    >
+                      Documents
+                    </a>
+                  </li>
+                  <li
+                    className=""
+                    role="presentation"
+                    style={undefined}
+                  >
+                    <a
+                      href="#"
+                      onClick={[Function]}
+                      role="button"
+                    >
+                      Groups 
+                    </a>
+                  </li>
+                </ul>
+              </div>
+            </div>
+          </div>
+        </div>
+      </div>
+    </div>
+  </div>
+  <div
+    className="flexTab"
+  >
+    <p>
+      This sidebar example has the active tag applied to both the People and Languages pages to provide examples of how this design handles sidebar links.
+    </p>
+    <p>
+      The sidebar nav has been implemented using  
+      <a
+        href="https://react-bootstrap.github.io/components.html#navs"
+      >
+        react bootstrap components
+      </a>
+      .
+    </p>
+  </div>
+</div>
+`;
+
 exports[`Frontend Storyshots Table default 1`] = `
 <span>
   <h2>
@@ -19866,6 +24495,58 @@ exports[`Frontend Storyshots TextInput default 1`] = `
     type={undefined}
     value={undefined}
   />
+</span>
+`;
+
+exports[`Frontend Storyshots Tooltip default 1`] = `
+<span>
+  <div
+    className="ant-layout"
+  >
+    <h2>
+      <img
+        src="https://i.imgur.com/v4qLk4p.png"
+        width="42px"
+      />
+      Tooltip
+    </h2>
+    <div
+      className="well well-lg"
+    >
+      Tooltip component for a more stylish alternative to that anchor tag 
+      <code>
+        title
+      </code>
+       attribute. Attach and position tooltips with 
+      <code>
+        OverlayTrigger
+      </code>
+      .
+      <hr />
+      <ul>
+        <li>
+          <a
+            href="https://react-bootstrap.github.io/components.html#tooltips-props"
+          >
+            Props for react-bootstrap Tooltips
+          </a>
+        </li>
+      </ul>
+    </div>
+    <Button
+      className="btn-default"
+      onBlur={undefined}
+      onClick={undefined}
+      onContextMenu={undefined}
+      onFocus={undefined}
+      onMouseDown={undefined}
+      onMouseEnter={[Function]}
+      onMouseLeave={[Function]}
+      onTouchStart={undefined}
+    >
+      Holy guacamole!
+    </Button>
+  </div>
 </span>
 `;
 

--- a/server/zanata-frontend/src/app/components/Button/Button.story.js
+++ b/server/zanata-frontend/src/app/components/Button/Button.story.js
@@ -1,12 +1,15 @@
+/* global jest */
 // @ts-nocheck
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import Button from 'antd/lib/button'
 import Layout from 'antd/lib/layout'
 
+jest.mock('antd/lib/button', () => 'Button')
+
 storiesOf('Button', module)
-    .add('default (no test)', () => (
-        <Layout>
-          <Button type='primary'>Primary style</Button>
-        </Layout>
+    .add('default', () => (
+      <Layout>
+        <Button type='primary'>Primary style</Button>
+      </Layout>
     ))

--- a/server/zanata-frontend/src/app/components/Sidebar/Sidebar.story.js
+++ b/server/zanata-frontend/src/app/components/Sidebar/Sidebar.story.js
@@ -1,19 +1,22 @@
+/* global jest */
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import Sidebar from '.'
 import AboutPage from '../../containers/ProjectVersion/AboutPage'
 import PeoplePage from '../../containers/ProjectVersion/PeoplePage'
 import GroupsPage from '../../containers/ProjectVersion/GroupsPage'
-import LanguagesPage from "../../containers/ProjectVersion/LanguagesPage";
-import DocumentsPage from "../../containers/ProjectVersion/DocumentsPage";
+import LanguagesPage from '../../containers/ProjectVersion/LanguagesPage'
+import DocumentsPage from '../../containers/ProjectVersion/DocumentsPage'
 
 const aboutText = 'This is one rocking project version. This is the best' +
     ' project version ever.'
 const url = 'https://www.google.com'
 const linkname = 'Our awesome webpage'
 
+jest.mock('antd/lib/button', () => 'Button')
+
 storiesOf('Sidebar', module)
-    .add('default (no test)', () => (
+    .add('default', () => (
         <div>
           <Sidebar />
           <div className='flexTab'>
@@ -26,31 +29,31 @@ storiesOf('Sidebar', module)
           </div>
       </div>
     ))
-    .add('AboutPage (no test)', () => (
+    .add('AboutPage', () => (
         <div>
           <Sidebar />
           <AboutPage aboutText={aboutText} aboutLink={url} linkName={linkname} />
         </div>
     ))
-    .add('PeoplePage (no test)', () => (
+    .add('PeoplePage', () => (
         <div>
           <Sidebar />
           <PeoplePage />
         </div>
     ))
-    .add('GroupsPage (no test)', () => (
+    .add('GroupsPage', () => (
         <div>
           <Sidebar />
           <GroupsPage />
         </div>
     ))
-    .add('LanguagesPage (no test)', () => (
+    .add('LanguagesPage', () => (
         <div>
           <Sidebar />
           <LanguagesPage />
         </div>
     ))
-    .add('DocumentsPage (no test)', () => (
+    .add('DocumentsPage', () => (
         <div>
           <Sidebar />
           <DocumentsPage />

--- a/server/zanata-frontend/src/app/components/Tooltip/Tooltip.story.js
+++ b/server/zanata-frontend/src/app/components/Tooltip/Tooltip.story.js
@@ -1,3 +1,4 @@
+/* global jest */
 import React from 'react'
 import { storiesOf } from '@storybook/react'
 import { Well } from 'react-bootstrap'
@@ -5,8 +6,10 @@ import { Button, Tooltip, Layout } from 'antd'
 
 const tooltip = <span id='tooltip'><strong>Tooltip ahoy!</strong></span>;
 
+jest.mock('antd/lib/button', () => 'Button')
+
 storiesOf('Tooltip', module)
-    .add('default (no test)', () => (
+    .add('default', () => (
         <span>
           <Layout>
           <h2><img src="https://i.imgur.com/v4qLk4p.png" width="42px" />Tooltip</h2>

--- a/server/zanata-frontend/src/app/editor/components/Validation/Validation.story.js
+++ b/server/zanata-frontend/src/app/editor/components/Validation/Validation.story.js
@@ -80,7 +80,7 @@ const validations =
  * See .storybook/README.md for info on the component storybook.
  */
 storiesOf('Validation', module)
-  .add('default (no test)', () => (
+  .add('default', () => (
     <div>
       <h2>Validation Messages Default</h2>
       <Validation messages={messages.slice(0, 1)}


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2545

Including some Ant Design components in storybooks causes the generated Storyshot tests to fail.
Mocking the offending components in the storybooks with jest resolves this issue, ie:
```jest.mock('antd/lib/button', () => 'Button')```

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
