### PR TITLE
fix(ZNTA-2517) add ellipsis to delete group modal

### DIFF
--- a/server/zanata-war/src/main/webapp/WEB-INF/layout/version-group/delete_group_confirmation_modal.xhtml
+++ b/server/zanata-war/src/main/webapp/WEB-INF/layout/version-group/delete_group_confirmation_modal.xhtml
@@ -30,9 +30,12 @@
     role="dialog" >
     <div class="modal__dialog l--constrain-medium">
       <header class="modal__header">
-        <h2 class="modal__title">#{msgs.format('jsf.DeleteConfirmation', 'group', entityName)}</h2>
-        <button class="modal__close button--link" data-dismiss="modal"><i
-          class="i i--huge i--cancel"></i></button>
+        <h2 class="modal__title ellipsis">
+          #{msgs.format('jsf.DeleteConfirmation', 'group', entityName)}
+        </h2>
+        <button class="modal__close button--link" data-dismiss="modal">
+          <i class="i i--huge i--cancel"></i>
+        </button>
       </header>
 
 


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2517

fix(ZNTA-2517) add ellipsis to handle long group names in delete group modal

![deletemodalellipsis](https://user-images.githubusercontent.com/18179401/40285673-5a17946c-5ce2-11e8-96f4-7c555d69e1bd.png)

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
