### PR TITLE
fix: AddLanguageTest selenium ids

### DIFF
--- a/server/functional-test/src/main/java/org/zanata/page/administration/AddLanguagePage.java
+++ b/server/functional-test/src/main/java/org/zanata/page/administration/AddLanguagePage.java
@@ -42,6 +42,7 @@ public class AddLanguagePage extends BasePage {
     private By languageOption = By.name("new-language-displayName");
     private By newLanguageName = By.id("displayName");
     private By newLanguageNativeName = By.id("nativeName");
+    private By pluralForms = By.id("pluralForms");
 
     public AddLanguagePage(final WebDriver driver) {
         super(driver);
@@ -55,6 +56,45 @@ public class AddLanguagePage extends BasePage {
     public AddLanguagePage enterSearchLanguage(String language) {
         log.info("Enter language {}", language);
         enterText(localeId, language);
+        // Pause for a moment, as quick actions can break here
+        slightPause();
+        return new AddLanguagePage(getDriver());
+    }
+
+    /**
+     * Enter a string into the language search field
+     * @param language string to enter
+     * @return new AddLanguagePage
+     */
+    public AddLanguagePage enterLanguageName(String language) {
+        log.info("Enter language name {}", language);
+        enterText(newLanguageName, language);
+        // Pause for a moment, as quick actions can break here
+        slightPause();
+        return new AddLanguagePage(getDriver());
+    }
+
+    /**
+     * Enter a string into the language search field
+     * @param language string to enter
+     * @return new AddLanguagePage
+     */
+    public AddLanguagePage enterLanguageNativeName(String language) {
+        log.info("Enter language native name {}", language);
+        enterText(newLanguageNativeName, language);
+        // Pause for a moment, as quick actions can break here
+        slightPause();
+        return new AddLanguagePage(getDriver());
+    }
+
+    /**
+     * Enter a string into the language search field
+     * @param language string to enter
+     * @return new AddLanguagePage
+     */
+    public AddLanguagePage enterLanguagePlurals(String language) {
+        log.info("Enter plurals {}", language);
+        enterText(pluralForms, language);
         // Pause for a moment, as quick actions can break here
         slightPause();
         return new AddLanguagePage(getDriver());
@@ -102,8 +142,8 @@ public class AddLanguagePage extends BasePage {
      */
     public AddLanguagePage enableLanguageByDefault() {
         log.info("Click Enable by default");
-        if (!readyElement(enabledByDefaultCheckbox).isSelected()) {
-            clickElement(enabledByDefaultCheckbox);
+        if (!existingElement(enabledByDefaultCheckbox).isSelected()) {
+            getDriver().findElement(enabledByDefaultCheckbox).click();
         }
         return new AddLanguagePage(getDriver());
     }
@@ -114,8 +154,9 @@ public class AddLanguagePage extends BasePage {
      */
     public AddLanguagePage disableLanguageByDefault() {
         log.info("Click Disable by default");
-        if (readyElement(enabledByDefaultCheckbox).isSelected()) {
-            clickElement(enabledByDefaultCheckbox);
+        if (existingElement(enabledByDefaultCheckbox).isSelected()) {
+            getDriver().findElement(enabledByDefaultCheckbox).click();
+//            clickElement(enabledByDefaultCheckbox);
         }
         return new AddLanguagePage(getDriver());
     }

--- a/server/functional-test/src/main/java/org/zanata/page/administration/AddLanguagePage.java
+++ b/server/functional-test/src/main/java/org/zanata/page/administration/AddLanguagePage.java
@@ -40,8 +40,8 @@ public class AddLanguagePage extends BasePage {
     private By enabledByDefaultCheckbox = By.id("chk-new-language-enabled");
     private By pluralsWarning = By.id("new-language-pluralforms-warning");
     private By languageOption = By.name("new-language-displayName");
-    private By newLanguageName = By.id("new-language-name");
-    private By newLanguageNativeName = By.id("new-language-nativeName");
+    private By newLanguageName = By.id("displayName");
+    private By newLanguageNativeName = By.id("nativeName");
 
     public AddLanguagePage(final WebDriver driver) {
         super(driver);

--- a/server/functional-test/src/test/java/org/zanata/feature/language/AddLanguageTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/language/AddLanguageTest.java
@@ -67,6 +67,9 @@ public class AddLanguageTest extends ZanataTestCase {
         languagesPage = languagesPage
                 .clickAddNewLanguage()
                 .enterSearchLanguage(language)
+                .enterLanguageName("Goa'uld")
+                .enterLanguageNativeName("Kek mattet")
+                .enterLanguagePlurals("nplurals=2; plural=(n != 1)")
                 .expectPluralsWarning()
                 .saveLanguage();
 
@@ -110,6 +113,9 @@ public class AddLanguageTest extends ZanataTestCase {
                 .clickAddNewLanguage()
                 .enterSearchLanguage(language)
                 .expectPluralsWarning()
+                .enterLanguageName("ta' Hol")
+                .enterLanguageNativeName("tlhIngan")
+                .enterLanguagePlurals("nplurals=2; plural=(n != 1)")
                 .disableLanguageByDefault()
                 .saveLanguage();
 

--- a/server/zanata-frontend/src/app/containers/Languages/NewLanguageModal.js
+++ b/server/zanata-frontend/src/app/containers/Languages/NewLanguageModal.js
@@ -211,7 +211,7 @@ class NewLanguageModal extends Component {
                 message: 'Please input a Language Display Name'}]
             })(
               <Input
-                id='new-language-name'
+                // id='new-language-name' set by getFieldDecorator
                 maxLength={100}
                 onChange={(e) => this.updateField('displayName', e)}
                 placeholder='Display name' />
@@ -224,7 +224,7 @@ class NewLanguageModal extends Component {
                 message: 'Please input a Language Native Name'}]
             })(
               <Input
-                id='new-language-nativeName'
+                // id='new-language-nativeName' set by getFieldDecorator
                 maxLength={100}
                 onChange={(e) => this.updateField('nativeName', e)}
                 placeholder='Native name' />

--- a/server/zanata-frontend/src/app/containers/Languages/NewLanguageModal.js
+++ b/server/zanata-frontend/src/app/containers/Languages/NewLanguageModal.js
@@ -211,7 +211,7 @@ class NewLanguageModal extends Component {
                 message: 'Please input a Language Display Name'}]
             })(
               <Input
-                // id='new-language-name' set by getFieldDecorator
+                // id='displayName' set by getFieldDecorator
                 maxLength={100}
                 onChange={(e) => this.updateField('displayName', e)}
                 placeholder='Display name' />
@@ -224,7 +224,7 @@ class NewLanguageModal extends Component {
                 message: 'Please input a Language Native Name'}]
             })(
               <Input
-                // id='new-language-nativeName' set by getFieldDecorator
+                // id='nativeName' set by getFieldDecorator
                 maxLength={100}
                 onChange={(e) => this.updateField('nativeName', e)}
                 placeholder='Native name' />


### PR DESCRIPTION
JIRA issue URL: N/A

Ant Design form validation getFieldDecorator method overrides the input id's, update selenium test ids to match the overridden form id's in the add language modal.

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
