### PR TITLE
fix(ZNTA-2554): remove ant design badge component

### DIFF
--- a/server/zanata-frontend/src/app/components/TMX/TMXExportModal.js
+++ b/server/zanata-frontend/src/app/components/TMX/TMXExportModal.js
@@ -5,8 +5,6 @@ import * as PropTypes from 'prop-types'
 import {size} from 'lodash'
 import {connect} from 'react-redux'
 import {Icon} from '../index'
-import Badge from 'antd/lib/badge'
-import 'antd/lib/badge/style/index.less'
 import Button from 'antd/lib/button'
 import 'antd/lib/button/style/index.less'
 import Col from 'antd/lib/col'
@@ -114,10 +112,9 @@ class TMXExportModal extends Component {
             </Tooltip>
           </Col>
           <Col span={6}>
-            <Tooltip title={`${srcLang.docCount} documents`}>
-              <Badge count={srcLang.docCount} offset={[-5, 9]}>
-                <Icon name='document' className='n1' /><span>Documents</span>
-              </Badge>
+            <Tooltip title={`${srcLang.docCount} Documents`}>
+              <Icon name='document' className='n1' /> <span>
+              {srcLang.docCount} Documents</span>
             </Tooltip>
           </Col>
           <Col span={6}>

--- a/server/zanata-frontend/src/app/styles/antd.less
+++ b/server/zanata-frontend/src/app/styles/antd.less
@@ -1,2 +1,9 @@
 @import "~antd/dist/antd.less";
 @import "./ant-theme-vars.less";
+
+// Override new-zanata modal namespace styles
+.ant-modal-close {
+  border: none !important;
+  background-color: initial !important;
+  padding: initial !important;
+}


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2553

The Ant Design badge styles appeared to cause a bug which affected the layout of the TMX Export modal, removed this component to resolve the issue.
![tmxexportnobadge](https://user-images.githubusercontent.com/7971187/40293529-b066b6c2-5d14-11e8-90db-e21a10fea6dc.png)

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
