### PR TITLE
test(ZNTA-2555): fix assertion descriptions

### DIFF
--- a/client/zanata-rest-client/src/test/java/org/zanata/rest/client/AccountClientTest.java
+++ b/client/zanata-rest-client/src/test/java/org/zanata/rest/client/AccountClientTest.java
@@ -55,8 +55,9 @@ public class AccountClientTest {
     public void testPut() throws Exception {
         Response response =
                 client.put("admin", new Account("a@b.c", "d", "e", "f"));
-        assertThat(response.getStatus()).isEqualTo(201)
-                .as("server returns successful status code");
+        assertThat(response.getStatus())
+                .as("server returns successful status code")
+                .isEqualTo(201);
     }
 }
 

--- a/client/zanata-rest-client/src/test/java/org/zanata/rest/client/GlossaryClientTest.java
+++ b/client/zanata-rest-client/src/test/java/org/zanata/rest/client/GlossaryClientTest.java
@@ -53,8 +53,9 @@ public class GlossaryClientTest {
         List<GlossaryEntry> glossaryEntries = new ArrayList<>();
         Response response = client.post(glossaryEntries, LocaleId.DE,
                 GlossaryResource.GLOBAL_QUALIFIED_NAME);
-        assertThat(response.getStatus()).isEqualTo(200)
-                .as("server returns successful status code");
+        assertThat(response.getStatus())
+                .as("server returns successful status code")
+                .isEqualTo(200);
     }
 }
 

--- a/client/zanata-rest-client/src/test/java/org/zanata/rest/client/ProjectIterationClientTest.java
+++ b/client/zanata-rest-client/src/test/java/org/zanata/rest/client/ProjectIterationClientTest.java
@@ -53,7 +53,9 @@ public class ProjectIterationClientTest {
     @Test
     public void testPut() throws Exception {
         Response response = client.put(new ProjectIteration("1.1"));
-        assertThat(response.getStatus()).isEqualTo(201).as("server returns successful status code");
+        assertThat(response.getStatus())
+                .as("server returns successful status code")
+                .isEqualTo(201);
     }
 
     @Test

--- a/server/functional-test/src/test/java/org/zanata/feature/account/ChangePasswordTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/account/ChangePasswordTest.java
@@ -55,17 +55,20 @@ public class ChangePasswordTest extends ZanataTestCase {
                 .enterOldPassword("translator")
                 .enterNewPassword("newpassword")
                 .clickUpdatePasswordButton();
-        dashboard.expectNotification(DashboardAccountTab.PASSWORD_UPDATE_SUCCESS);
+        dashboard.expectNotification(
+                DashboardAccountTab.PASSWORD_UPDATE_SUCCESS);
         dashboard.logout();
 
-        assertThat(new BasicWorkFlow().goToHome().hasLoggedIn()).isFalse()
-                .as("User is logged out");
+        assertThat(new BasicWorkFlow().goToHome().hasLoggedIn())
+                .as("User is logged out")
+                .isFalse();
 
         DashboardBasePage dashboardPage = new LoginWorkFlow()
                 .signIn("translator", "newpassword");
 
-        assertThat(dashboardPage.hasLoggedIn()).isTrue()
-                .as("User has logged in with the new password");
+        assertThat(dashboardPage.hasLoggedIn())
+                .as("User has logged in with the new password")
+                .isTrue();
     }
 
     @Trace(summary = "The user must enter their current password correctly " +
@@ -81,8 +84,8 @@ public class ChangePasswordTest extends ZanataTestCase {
                 .clickUpdatePasswordButton();
 
         assertThat(dashboardAccountTab.getErrors())
-                .contains(DashboardAccountTab.INCORRECT_OLD_PASSWORD_ERROR)
-                .as("Old password is incorrect error is shown");
+                .as("Old password is incorrect error is shown")
+                .contains(DashboardAccountTab.INCORRECT_OLD_PASSWORD_ERROR);
     }
 
     @Trace(summary = "The user must enter a non-empty new password " +
@@ -96,8 +99,8 @@ public class ChangePasswordTest extends ZanataTestCase {
                 .clickUpdatePasswordButton();
 
         assertThat(dashboardAccountTab.getErrors())
-                .contains(DashboardAccountTab.FIELD_EMPTY_ERROR)
-                .as("Empty password message displayed");
+                .as("Empty password message displayed")
+                .contains(DashboardAccountTab.FIELD_EMPTY_ERROR);
     }
 
     @Trace(summary = "The user must enter a new password of between 6 and " +
@@ -114,7 +117,7 @@ public class ChangePasswordTest extends ZanataTestCase {
                 .clickUpdatePasswordButton();
 
         assertThat(dashboardAccountTab.getErrors())
-                .contains(DashboardAccountTab.PASSWORD_LENGTH_ERROR)
-                .as("Incorrect password length message displayed");
+                .as("Incorrect password length message displayed")
+                .contains(DashboardAccountTab.PASSWORD_LENGTH_ERROR);
     }
 }

--- a/server/functional-test/src/test/java/org/zanata/feature/account/EmailValidationTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/account/EmailValidationTest.java
@@ -71,16 +71,16 @@ public class EmailValidationTest extends ZanataTestCase {
         registerPage = registerPage.enterEmail("notproper@").registerFailure();
 
         assertThat(registerPage.getErrors())
-                .contains(RegisterPage.MALFORMED_EMAIL_ERROR)
-                .as("The email formation error is displayed");
+                .as("The email formation error is displayed")
+                .contains(RegisterPage.MALFORMED_EMAIL_ERROR);
 
         registerPage = registerPage.clearFields()
                 .enterEmail("admin@example.com")
                 .registerFailure();
 
         assertThat(registerPage.getErrors())
-                .contains(RegisterPage.EMAIL_TAKEN)
-                .as("The user needs to provide a unique email address");
+                .as("The user needs to provide a unique email address")
+                .contains(RegisterPage.EMAIL_TAKEN);
     }
 
     @Trace(summary = "The user must provide a unique email address to " +
@@ -92,7 +92,7 @@ public class EmailValidationTest extends ZanataTestCase {
                 .registerFailure();
 
         assertThat(registerPage.getErrors())
-                .contains(RegisterPage.EMAIL_TAKEN)
-                .as("The user needs to provide a unique email address");
+                .as("The user needs to provide a unique email address")
+                .contains(RegisterPage.EMAIL_TAKEN);
     }
 }

--- a/server/functional-test/src/test/java/org/zanata/feature/account/InactiveUserLoginTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/account/InactiveUserLoginTest.java
@@ -102,12 +102,14 @@ public class InactiveUserLoginTest extends ZanataTestCase {
 
         assertThat(homePage.expectNotification(HomePage.SIGNUP_SUCCESS_MESSAGE))
                 .as("The message sent notification is displayed");
-        assertThat(hasEmailRule.getMessages().size()).isEqualTo(2)
-                .as("A second email was sent");
+        assertThat(hasEmailRule.getMessages().size())
+                .as("A second email was sent")
+                .isEqualTo(2);
 
         WiserMessage message = hasEmailRule.getMessages().get(1);
-        assertThat(EmailQuery.hasLink(message, ACTIVATE)).isTrue()
-                .as("The second email contains the activation link");
+        assertThat(EmailQuery.hasLink(message, ACTIVATE))
+                .as("The second email contains the activation link")
+                .isTrue();
 
         new BasicWorkFlow()
                 .goToUrl(EmailQuery.getLink(message, ACTIVATE), HomePage.class);
@@ -119,8 +121,9 @@ public class InactiveUserLoginTest extends ZanataTestCase {
          */
         assertThat(new LoginWorkFlow()
                 .signIn(usernamepassword, usernamepassword)
-                .loggedInAs()).isEqualTo(usernamepassword).as(
-                        "The user has validated their account and logged in");
+                .loggedInAs())
+                .as("The user has validated their account and logged in")
+                .isEqualTo(usernamepassword);
     }
 
     @Trace(summary = "The user can update the account activation email address",

--- a/server/functional-test/src/test/java/org/zanata/feature/account/ProfileTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/account/ProfileTest.java
@@ -55,20 +55,21 @@ public class ProfileTest extends ZanataTestCase {
                 .goToSettingsTab()
                 .goToSettingsClientTab();
 
-        assertThat(dashboardClientTab.getApiKey()).isEqualTo(adminsApiKey)
-                .as("The correct api key is present");
+        assertThat(dashboardClientTab.getApiKey())
+                .as("The correct api key is present")
+                .isEqualTo(adminsApiKey);
 
         assertThat(dashboardClientTab.getConfigurationDetails())
-                .contains("localhost.url=" + serverUrl)
-                .as("The configuration url is correct");
+                .as("The configuration url is correct")
+                .contains("localhost.url=" + serverUrl);
 
         assertThat(dashboardClientTab.getConfigurationDetails())
-                .contains("localhost.username=admin")
-                .as("The configuration username is correct");
+                .as("The configuration username is correct")
+                .contains("localhost.username=admin");
 
         assertThat(dashboardClientTab.getConfigurationDetails())
-                .contains("localhost.key=".concat(adminsApiKey))
-                .as("The configuration api key is correct");
+                .as("The configuration api key is correct")
+                .contains("localhost.key=".concat(adminsApiKey));
     }
 
     @Trace(summary = "The user can change their API key")
@@ -85,16 +86,18 @@ public class ProfileTest extends ZanataTestCase {
         dashboardClientTab = dashboardClientTab.pressApiKeyGenerateButton();
         dashboardClientTab.expectApiKeyChanged(currentApiKey);
 
-        assertThat(dashboardClientTab.getApiKey()).isNotEqualTo(currentApiKey)
-                .as("The user's api key is different");
+        assertThat(dashboardClientTab.getApiKey())
+                .as("The user's api key is different")
+                .isNotEqualTo(currentApiKey);
 
-        assertThat(dashboardClientTab.getApiKey()).isNotEmpty()
-                .as("The user's api key is not empty");
+        assertThat(dashboardClientTab.getApiKey())
+                .as("The user's api key is not empty")
+                .isNotEmpty();
 
         assertThat(dashboardClientTab.getConfigurationDetails())
+                .as("The configuration api key matches the label")
                 .contains("localhost.key="
-                        .concat(dashboardClientTab.getApiKey()))
-                .as("The configuration api key matches the label");
+                        .concat(dashboardClientTab.getApiKey()));
     }
 
     @Trace(summary = "The user can change their display name")
@@ -109,8 +112,9 @@ public class ProfileTest extends ZanataTestCase {
 
         dashboardProfileTab.expectUsernameChanged("translator");
 
-        assertThat(dashboardProfileTab.getUserFullName()).isEqualTo("Tranny")
-                .as("The user's name has been changed");
+        assertThat(dashboardProfileTab.getUserFullName())
+                .as("The user's name has been changed")
+                .isEqualTo("Tranny");
     }
 
     @Trace(summary = "The user's email address change is validated")
@@ -124,8 +128,8 @@ public class ProfileTest extends ZanataTestCase {
                 .clickUpdateEmailButton();
 
         assertThat(dashboardAccountTab.getErrors())
-                .contains(DashboardAccountTab.EMAIL_TAKEN_ERROR)
-                .as("The email is rejected, being already taken");
+                .as("The email is rejected, being already taken")
+                .contains(DashboardAccountTab.EMAIL_TAKEN_ERROR);
 
         dashboardAccountTab = dashboardAccountTab
                 .goToMyDashboard()
@@ -135,7 +139,7 @@ public class ProfileTest extends ZanataTestCase {
                 .clickUpdateEmailButton();
 
         assertThat(dashboardAccountTab.getErrors())
-                .contains(RegisterPage.MALFORMED_EMAIL_ERROR)
-                .as("The email is rejected, being of invalid format");
+                .as("The email is rejected, being of invalid format")
+                .contains(RegisterPage.MALFORMED_EMAIL_ERROR);
     }
 }

--- a/server/functional-test/src/test/java/org/zanata/feature/account/RegisterTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/account/RegisterTest.java
@@ -82,8 +82,8 @@ public class RegisterTest extends ZanataTestCase {
         SignInPage signInPage = registerPage.register();
 
         assertThat(signInPage.getNotificationMessage())
-                .isEqualTo(HomePage.SIGNUP_SUCCESS_MESSAGE)
-                .as("Sign up is successful");
+                .as("Sign up is successful")
+                .isEqualTo(HomePage.SIGNUP_SUCCESS_MESSAGE);
     }
 
     @Trace(summary = "The user must enter a username of between 3 and " +
@@ -98,22 +98,22 @@ public class RegisterTest extends ZanataTestCase {
         registerPage = registerPage.setFields(fields);
 
         assertThat(containsUsernameError(registerPage.getErrors()))
-                .isTrue()
-                .as("Size errors are shown for string too short");
+                .as("Size errors are shown for string too short")
+                .isTrue();
 
         fields.put("username", "testusername");
         registerPage = registerPage.setFields(fields);
 
         assertThat(containsUsernameError(registerPage.getErrors()))
-                .isFalse()
-                .as("Size errors are not shown");
+                .as("Size errors are not shown")
+                .isFalse();
 
         fields.put("username", "12345678901234567890a");
         registerPage = registerPage.setFields(fields);
 
         assertThat(containsUsernameError(registerPage.getErrors()))
-                .isTrue()
-                .as("Size errors are shown for string too long");
+                .as("Size errors are shown for string too long")
+                .isTrue();
     }
 
     @Trace(summary = "The user must enter a unique username to register",
@@ -126,8 +126,8 @@ public class RegisterTest extends ZanataTestCase {
         registerPage.defocus(registerPage.usernameField);
 
         assertThat(registerPage.getErrors())
-                .contains(RegisterPage.USERNAME_UNAVAILABLE_ERROR)
-                .as("Username not available message is shown");
+                .as("Username not available message is shown")
+                .contains(RegisterPage.USERNAME_UNAVAILABLE_ERROR);
     }
 
     /*

--- a/server/functional-test/src/test/java/org/zanata/feature/account/UsernameValidationTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/account/UsernameValidationTest.java
@@ -45,7 +45,7 @@ public class UsernameValidationTest extends ZanataTestCase {
         registerPage.defocus(registerPage.usernameField);
 
         assertThat(registerPage.getErrors())
-                .contains(RegisterPage.USERNAME_VALIDATION_ERROR)
-                .as("Username validation errors are shown");
+                .as("Username validation errors are shown")
+                .contains(RegisterPage.USERNAME_VALIDATION_ERROR);
     }
 }

--- a/server/functional-test/src/test/java/org/zanata/feature/account/comp/InactiveUserLoginCTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/account/comp/InactiveUserLoginCTest.java
@@ -54,8 +54,8 @@ public class InactiveUserLoginCTest extends ZanataTestCase {
                 .signInInactive(usernamepassword, usernamepassword);
 
         assertThat(inactiveAccountPage.getTitle())
-                .isEqualTo("Zanata: Account is not activated")
-                .as("The account is inactive");
+                .as("The account is inactive")
+                .isEqualTo("Zanata: Account is not activated");
 
         inactiveAccountPage = inactiveAccountPage
                 .enterNewEmail("notproper@")

--- a/server/functional-test/src/test/java/org/zanata/feature/account/comp/RegisterCTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/account/comp/RegisterCTest.java
@@ -62,12 +62,12 @@ public class RegisterCTest extends ZanataTestCase {
                 .setFields(fields)
                 .registerFailure();
 
-        assertThat(registerPage.getErrors(4)).containsExactly(
-                RegisterPage.USERDISPLAYNAME_LENGTH_ERROR,
-                RegisterPage.USERNAME_LENGTH_ERROR,
-                RegisterPage.REQUIRED_FIELD_ERROR,
-                RegisterPage.REQUIRED_FIELD_ERROR)
-                .as("Size indication or 'May not be empty' shows for all fields");
+        assertThat(registerPage.getErrors(4))
+                .as("Size indication or 'May not be empty' shows for all fields")
+                .containsExactly(RegisterPage.USERDISPLAYNAME_LENGTH_ERROR,
+                        RegisterPage.USERNAME_LENGTH_ERROR,
+                        RegisterPage.REQUIRED_FIELD_ERROR,
+                        RegisterPage.REQUIRED_FIELD_ERROR);
     }
 
     @Trace(summary = "The user can navigate to Login from Sign up, or to "
@@ -79,14 +79,14 @@ public class RegisterCTest extends ZanataTestCase {
                 .goToRegister();
 
         assertThat(registerPage.getPageTitle())
-                .isEqualTo("Sign up with Zanata")
-                .as("The user is sent to the register page");
+                .as("The user is sent to the register page")
+                .isEqualTo("Sign up with Zanata");
 
         SignInPage signInPage = registerPage.goToSignIn();
 
         assertThat(signInPage.getPageTitle())
-                .isEqualTo("Log in with your username")
-                .as("The user is sent to the log in page");
+                .as("The user is sent to the log in page")
+                .isEqualTo("Log in with your username");
     }
 
     @Trace(summary = "The user can show or hide the registration password content",
@@ -98,23 +98,23 @@ public class RegisterCTest extends ZanataTestCase {
                 .enterPassword("mypassword");
 
         assertThat(registerPage.getPasswordFieldType())
-                .isEqualTo("password")
-                .as("The password field starts as masked");
+                .as("The password field starts as masked")
+                .isEqualTo("password");
 
         registerPage = registerPage.clickPasswordShowToggle();
 
         assertThat(registerPage.getPasswordFieldType())
-                .isEqualTo("text")
-                .as("The password field is now not masked");
+                .as("The password field is now not masked")
+                .isEqualTo("text");
 
         registerPage = registerPage.clickPasswordShowToggle();
 
         assertThat(registerPage.getPasswordFieldType())
-                .isEqualTo("password")
-                .as("The password field is again masked");
+                .as("The password field is again masked")
+                .isEqualTo("password");
         assertThat(registerPage.getPassword())
-                .isEqualTo("mypassword")
-                .as("The password field did not lose the entered text");
+                .as("The password field did not lose the entered text")
+                .isEqualTo("mypassword");
     }
 
     @Trace(summary = "The user must provide a password to register via internal authentication",
@@ -133,14 +133,14 @@ public class RegisterCTest extends ZanataTestCase {
                 .registerFailure();
 
         assertThat(registerPage.getErrors())
-                .contains(RegisterPage.PASSWORD_LENGTH_ERROR)
-                .as("Password requires at least 6 characters");
+                .as("Password requires at least 6 characters")
+                .contains(RegisterPage.PASSWORD_LENGTH_ERROR);
 
         registerPage = registerPage.enterPassword(longPass).registerFailure();
 
         assertThat(registerPage.getErrors())
-                .contains(RegisterPage.PASSWORD_LENGTH_ERROR)
-                .as("The user must enter a password of at most 1024 characters");
+                .as("The user must enter a password of at most 1024 characters")
+                .contains(RegisterPage.PASSWORD_LENGTH_ERROR);
     }
 
     @Trace(summary = "The user must provide a name to register",
@@ -159,14 +159,14 @@ public class RegisterCTest extends ZanataTestCase {
                 .registerFailure();
 
         assertThat(registerPage.getErrors())
-                .contains(RegisterPage.USERDISPLAYNAME_LENGTH_ERROR)
-                .as("A name greater than 1 character must be specified");
+                .as("A name greater than 1 character must be specified")
+                .contains(RegisterPage.USERDISPLAYNAME_LENGTH_ERROR);
 
         registerPage = registerPage.enterName(longName).registerFailure();
 
         assertThat(registerPage.getErrors())
-                .contains(RegisterPage.USERDISPLAYNAME_LENGTH_ERROR)
-                .as("A name shorter than 81 characters is specified");
+                .as("A name shorter than 81 characters is specified")
+                .contains(RegisterPage.USERDISPLAYNAME_LENGTH_ERROR);
     }
 
     @Trace(summary = "The user must provide a username to register",
@@ -181,8 +181,8 @@ public class RegisterCTest extends ZanataTestCase {
                 .registerFailure();
 
         assertThat(containsUsernameError(registerPage.getErrors()))
-                .isTrue()
-                .as("A username must be specified");
+                .as("A username must be specified")
+                .isTrue();
     }
 
     @Trace(summary = "A username cannot be all underscores (RHBZ-981498)")
@@ -200,8 +200,8 @@ public class RegisterCTest extends ZanataTestCase {
         registerPage.defocus();
 
         assertThat(registerPage.getErrors())
-                .contains(RegisterPage.USERNAME_VALIDATION_ERROR)
-                .as("A username of all underscores is not valid");
+                .as("A username of all underscores is not valid")
+                .contains(RegisterPage.USERNAME_VALIDATION_ERROR);
     }
 
     /*

--- a/server/functional-test/src/test/java/org/zanata/feature/administration/AutoRoleAssignmentTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/administration/AutoRoleAssignmentTest.java
@@ -52,8 +52,8 @@ public class AutoRoleAssignmentTest extends ZanataTestCase {
                 .saveRoleAssignment();
 
         assertThat(roleAssignmentsPage.getRulesByPattern())
-                .contains(".+ransla.+")
-                .as("The rule was created");
+                .as("The rule was created")
+                .contains(".+ransla.+");
 
         roleAssignmentsPage.logout();
         {
@@ -65,7 +65,8 @@ public class AutoRoleAssignmentTest extends ZanataTestCase {
         assertThat(new LoginWorkFlow()
                 .signIn("translator", "translator")
                 .goToAdministration()
-                .getTitle()).isEqualTo("Zanata: Administration")
-                .as("The translator user was automatically given admin rights");
+                .getTitle())
+                .as("The translator user was automatically given admin rights")
+                .isEqualTo("Zanata: Administration");
     }
 }

--- a/server/functional-test/src/test/java/org/zanata/feature/administration/EditHomePageTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/administration/EditHomePageTest.java
@@ -43,8 +43,8 @@ public class EditHomePageTest extends ZanataTestCase {
     public void before() {
         new BasicWorkFlow().goToHome().deleteCookiesAndRefresh();
         assertThat(new LoginWorkFlow().signIn("admin", "admin").loggedInAs())
-                .isEqualTo("admin")
-                .as("Admin is logged in");
+                .as("Admin is logged in")
+                .isEqualTo("admin");
     }
 
     @Trace(summary = "The administrator can edit the home screen in " +
@@ -58,7 +58,7 @@ public class EditHomePageTest extends ZanataTestCase {
                 .update();
 
         assertThat(homePage.getMainBodyContent())
-                .isEqualTo("This text contains some markup")
-                .as("Homepage text has been updated");
+                .as("Homepage text has been updated")
+                .isEqualTo("This text contains some markup");
     }
 }

--- a/server/functional-test/src/test/java/org/zanata/feature/administration/EditTranslationMemoryTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/administration/EditTranslationMemoryTest.java
@@ -51,8 +51,8 @@ public class EditTranslationMemoryTest extends ZanataTestCase {
     public void before() {
         new BasicWorkFlow().goToHome().deleteCookiesAndRefresh();
         assertThat(new LoginWorkFlow().signIn("admin", "admin").loggedInAs())
-                .isEqualTo("admin")
-                .as("Admin is logged in");
+                .as("Admin is logged in")
+                .isEqualTo("admin");
     }
 
     @Trace(summary = "The administrator can create a new translation " +
@@ -68,16 +68,16 @@ public class EditTranslationMemoryTest extends ZanataTestCase {
 
         assertThat(translationMemoryPage
                 .expectNotification("Successfully created"))
-                .isTrue()
-                .as("The success message is displayed");
+                .as("The success message is displayed")
+                .isTrue();
 
         assertThat(translationMemoryPage.getListedTranslationMemorys())
-                .contains(newTMId)
-                .as("The new Translation Memory is listed");
+                .as("The new Translation Memory is listed")
+                .contains(newTMId);
 
         assertThat(translationMemoryPage.getDescription(newTMId))
-                .isEqualTo(tmDescription)
-                .as("The description is displayed correctly");
+                .as("The description is displayed correctly")
+                .isEqualTo(tmDescription);
     }
 
     @Trace(summary = "The administrator must use a unique identifier to " +
@@ -90,8 +90,8 @@ public class EditTranslationMemoryTest extends ZanataTestCase {
                 .createTranslationMemory(nonUniqueTMId);
 
         assertThat(tmMemoryPage.getListedTranslationMemorys())
-                .contains(nonUniqueTMId)
-                .as("The new Translation Memory is listed");
+                .as("The new Translation Memory is listed")
+                .contains(nonUniqueTMId);
 
         TranslationMemoryEditPage translationMemoryEditPage = tmMemoryPage
                 .clickCreateNew()
@@ -100,8 +100,8 @@ public class EditTranslationMemoryTest extends ZanataTestCase {
                 .clickSaveAndExpectFailure();
 
         assertThat(translationMemoryEditPage.getErrors())
-                .contains(TranslationMemoryPage.ID_UNAVAILABLE)
-                .as("The Id Is Not Available error is displayed");
+                .as("The Id Is Not Available error is displayed")
+                .contains(TranslationMemoryPage.ID_UNAVAILABLE);
 
         translationMemoryEditPage = translationMemoryEditPage
                 .clickSaveAndExpectFailure();
@@ -110,8 +110,8 @@ public class EditTranslationMemoryTest extends ZanataTestCase {
         translationMemoryEditPage.assertNoCriticalErrors();
 
         assertThat(translationMemoryEditPage.getErrors())
-                .contains(TranslationMemoryPage.ID_UNAVAILABLE)
-                .as("The Id Is Not Available error is displayed");
+                .as("The Id Is Not Available error is displayed")
+                .contains(TranslationMemoryPage.ID_UNAVAILABLE);
     }
 
     @Trace(summary = "The administrator can import data from a tmx data " +
@@ -129,8 +129,8 @@ public class EditTranslationMemoryTest extends ZanataTestCase {
                 .clickUploadButtonAndAcknowledge();
 
         assertThat(tmMemoryPage.getNumberOfEntries(importTMId))
-                .isEqualTo("1")
-                .as("The Translation Memory has one entry");
+                .as("The Translation Memory has one entry")
+                .isEqualTo("1");
     }
 
     /**
@@ -158,15 +158,15 @@ public class EditTranslationMemoryTest extends ZanataTestCase {
                 .createTranslationMemory(deleteTMId);
 
         assertThat(tmMemoryPage.getListedTranslationMemorys())
-                .contains(deleteTMId)
-                .as("The new Translation Memory is listed");
+                .as("The new Translation Memory is listed")
+                .contains(deleteTMId);
 
         tmMemoryPage = tmMemoryPage.clickOptions(deleteTMId)
                 .clickDeleteTmAndAccept(deleteTMId);
 
         assertThat(tmMemoryPage.getListedTranslationMemorys())
-                .doesNotContain(deleteTMId)
-                .as("The new Translation Memory is no longer listed");
+                .as("The new Translation Memory is no longer listed")
+                .doesNotContain(deleteTMId);
     }
 
     @Trace(summary = "The administrator can cancel the delete of a " +
@@ -179,15 +179,15 @@ public class EditTranslationMemoryTest extends ZanataTestCase {
                 .createTranslationMemory(dontDeleteTMId);
 
         assertThat(tmMemoryPage.getListedTranslationMemorys())
-                .contains(dontDeleteTMId)
-                .as("The new Translation Memory is listed");
+                .as("The new Translation Memory is listed")
+                .contains(dontDeleteTMId);
 
         tmMemoryPage = tmMemoryPage.clickOptions(dontDeleteTMId)
                 .clickDeleteTmAndCancel(dontDeleteTMId);
 
         assertThat(tmMemoryPage.getListedTranslationMemorys())
-                .contains(dontDeleteTMId)
-                .as("The new Translation Memory is still listed");
+                .as("The new Translation Memory is still listed")
+                .contains(dontDeleteTMId);
     }
 
     @Trace(summary = "The administrator can clear the content of a " +
@@ -205,8 +205,8 @@ public class EditTranslationMemoryTest extends ZanataTestCase {
                 .clickUploadButtonAndAcknowledge();
 
         assertThat(tmMemoryPage.getNumberOfEntries(clearTMId))
-                .isEqualTo("1")
-                .as("The TM has one item");
+                .as("The TM has one item")
+                .isEqualTo("1");
 
         tmMemoryPage = tmMemoryPage.clickOptions(clearTMId)
                 .clickClearTMAndAccept(clearTMId);
@@ -216,8 +216,8 @@ public class EditTranslationMemoryTest extends ZanataTestCase {
         tmMemoryPage.expectNumberOfEntries(0, clearTMId);
 
         assertThat(tmMemoryPage.getNumberOfEntries(clearTMId))
-                .isEqualTo("0")
-                .as("The translation memory entries is empty");
+                .as("The translation memory entries is empty")
+                .isEqualTo("0");
     }
 
     @Trace(summary = "The administrator can cancel clearing the content " +
@@ -235,15 +235,15 @@ public class EditTranslationMemoryTest extends ZanataTestCase {
                 .clickUploadButtonAndAcknowledge();
 
         assertThat(tmMemoryPage.getNumberOfEntries(clearTMId))
-                .isEqualTo("1")
-                .as("The TM has one item");
+                .as("The TM has one item")
+                .isEqualTo("1");
 
         tmMemoryPage = tmMemoryPage.clickOptions(clearTMId)
                 .clickClearTMAndCancel(clearTMId);
 
         assertThat(tmMemoryPage.getNumberOfEntries(clearTMId))
-                .isEqualTo("1")
-                .as("The translation memory entries count is the same");
+                .as("The translation memory entries count is the same")
+                .isEqualTo("1");
     }
 
     @Trace(summary = "The administrator must clear a translation memory " +
@@ -261,11 +261,11 @@ public class EditTranslationMemoryTest extends ZanataTestCase {
                 .clickUploadButtonAndAcknowledge();
 
         assertThat(tmMemoryPage.getNumberOfEntries(forceClear))
-                .isEqualTo("1")
-                .as("The TM has one item");
+                .as("The TM has one item")
+                .isEqualTo("1");
         assertThat(tmMemoryPage.clickOptions(forceClear).canDelete(forceClear))
-                .isFalse()
-                .as("The item cannot yet be deleted");
+                .as("The item cannot yet be deleted")
+                .isFalse();
 
         tmMemoryPage = tmMemoryPage.clickClearTMAndAccept(forceClear);
 
@@ -274,14 +274,14 @@ public class EditTranslationMemoryTest extends ZanataTestCase {
         tmMemoryPage.expectNumberOfEntries(0, forceClear);
 
         assertThat(tmMemoryPage.clickOptions(forceClear).canDelete(forceClear))
-                .isTrue()
-                .as("The item can be deleted");
+                .as("The item can be deleted")
+                .isTrue();
 
         tmMemoryPage = tmMemoryPage.clickDeleteTmAndAccept(forceClear);
 
         assertThat(tmMemoryPage.getListedTranslationMemorys())
-                .doesNotContain(forceClear)
-                .as("The item is deleted");
+                .as("The item is deleted")
+                .doesNotContain(forceClear);
     }
 
 }

--- a/server/functional-test/src/test/java/org/zanata/feature/administration/ManageSearchTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/administration/ManageSearchTest.java
@@ -42,8 +42,8 @@ public class ManageSearchTest extends ZanataTestCase {
     @Before
     public void before() {
         assertThat(new LoginWorkFlow().signIn("admin", "admin").loggedInAs())
-                .isEqualTo("admin")
-                .as("Admin is logged in");
+                .as("Admin is logged in")
+                .isEqualTo("admin");
         dashboardPage = new BasicWorkFlow().goToDashboard();
     }
 

--- a/server/functional-test/src/test/java/org/zanata/feature/administration/ManageUsersTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/administration/ManageUsersTest.java
@@ -67,8 +67,8 @@ public class ManageUsersTest extends ZanataTestCase {
         dashboardPage = new LoginWorkFlow().signIn("translator", "newpassword");
 
         assertThat(dashboardPage.loggedInAs())
-                .isEqualTo("translator")
-                .as("User logged in with new password");
+                .as("User logged in with new password")
+                .isEqualTo("translator");
     }
 
     @Trace(summary = "The administrator must enter the new user password " +
@@ -83,8 +83,8 @@ public class ManageUsersTest extends ZanataTestCase {
                 .saveUserExpectFailure();
 
         assertThat(manageUserAccountPage.getErrors())
-                .contains(ManageUserAccountPage.PASSWORD_ERROR)
-                .as("The password failure error is displayed");
+                .as("The password failure error is displayed")
+                .contains(ManageUserAccountPage.PASSWORD_ERROR);
     }
 
     @Trace(summary = "The administrator can disable an account")
@@ -104,8 +104,8 @@ public class ManageUsersTest extends ZanataTestCase {
                 .enterPassword("translator")
                 .clickSignInExpectError();
         assertThat(signInPage.getErrors())
-                .contains(SignInPage.LOGIN_FAILED_ERROR)
-                .as("The user's account cannot be logged in");
+                .as("The user's account cannot be logged in")
+                .contains(SignInPage.LOGIN_FAILED_ERROR);
     }
 
     @Trace(summary = "The administrator can change a user account's roles")
@@ -122,8 +122,8 @@ public class ManageUsersTest extends ZanataTestCase {
                 .signIn("translator", "translator");
 
         assertThat(dashboardBasePage.goToAdministration().getTitle())
-                .isEqualTo("Zanata: Administration")
-                .as("The user can access the administration panel");
+                .as("The user can access the administration panel")
+                .isEqualTo("Zanata: Administration");
     }
 
     @Trace(summary = "The administrator can change a user account's name")

--- a/server/functional-test/src/test/java/org/zanata/feature/administration/ServerSettingsTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/administration/ServerSettingsTest.java
@@ -55,8 +55,9 @@ public class ServerSettingsTest extends ZanataTestCase {
                 .send(HomePage.class);
         String emailContent =
                 HasEmailRule.getEmailContent(hasEmailRule.getMessages().get(0));
-        assertThat(emailContent).contains("http://myserver.com/zanata")
-                .as("The email indicates the expected server url");
+        assertThat(emailContent)
+                .as("The email indicates the expected server url")
+                .contains("http://myserver.com/zanata");
     }
 
     @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)
@@ -91,7 +92,8 @@ public class ServerSettingsTest extends ZanataTestCase {
                 .send(HomePage.class);
 
         assertThat(hasEmailRule.getMessages().get(0).getEnvelopeReceiver())
-                .contains("lara@example.com").as("The recipient admin was set");
+                .as("The recipient admin was set")
+                .contains("lara@example.com");
     }
 
     @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)
@@ -114,8 +116,8 @@ public class ServerSettingsTest extends ZanataTestCase {
                 "test1@test.com");
 
         assertThat(hasEmailRule.getMessages().get(0).getEnvelopeSender())
-                .contains("lara@example.com")
-                .as("The server email sender was set");
+                .as("The server email sender was set")
+                .contains("lara@example.com");
     }
 
     @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)
@@ -127,8 +129,9 @@ public class ServerSettingsTest extends ZanataTestCase {
                 .save()
                 .gotoMorePage();
 
-        assertThat(morePage.getHelpURL()).isEqualTo("http://www.test.com/")
-                .as("The help URL was set correctly");
+        assertThat(morePage.getHelpURL())
+                .as("The help URL was set correctly")
+                .isEqualTo("http://www.test.com/");
     }
 
     @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)
@@ -144,8 +147,9 @@ public class ServerSettingsTest extends ZanataTestCase {
                 .logout()
                 .goToRegistration();
 
-        assertThat(registerPage.termsOfUseUrlVisible()).isFalse()
-                .as("The Terms of Use URL is not visible");
+        assertThat(registerPage.termsOfUseUrlVisible())
+                .as("The Terms of Use URL is not visible")
+                .isFalse();
     }
 
     @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)
@@ -158,8 +162,9 @@ public class ServerSettingsTest extends ZanataTestCase {
                 .logout()
                 .goToRegistration();
 
-        assertThat(registerPage.getTermsUrl()).isEqualTo("http://www.test.com/")
-                .as("The Terms of Use URL was set correctly");
+        assertThat(registerPage.getTermsUrl())
+                .as("The Terms of Use URL was set correctly")
+                .isEqualTo("http://www.test.com/");
     }
 
     @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)
@@ -175,9 +180,11 @@ public class ServerSettingsTest extends ZanataTestCase {
                 .goToServerConfigPage();
 
         assertThat(serverConfigurationPage.selectedLoggingLevel())
-                .isEqualTo("Error").as("Level is correct");
+                .as("Level is correct")
+                .isEqualTo("Error");
         assertThat(serverConfigurationPage.getLogEmailTarget())
-                .isEqualTo("lara@example.com").as("Recipient is correct");
+                .as("Recipient is correct")
+                .isEqualTo("lara@example.com");
     }
 
     @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)
@@ -192,9 +199,10 @@ public class ServerSettingsTest extends ZanataTestCase {
                 .goToServerConfigPage();
 
         assertThat(serverConfigurationPage.getPiwikUrl())
-                .isEqualTo("http://example.com/piwik")
-                .as("Piwik url is correct is correct");
-        assertThat(serverConfigurationPage.getPiwikID()).isEqualTo("12345")
-                .as("Piwik ID is correct");
+                .as("Piwik url is correct is correct")
+                .isEqualTo("http://example.com/piwik");
+        assertThat(serverConfigurationPage.getPiwikID())
+                .as("Piwik ID is correct")
+                .isEqualTo("12345");
     }
 }

--- a/server/functional-test/src/test/java/org/zanata/feature/document/UploadTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/document/UploadTest.java
@@ -75,8 +75,9 @@ public class UploadTest extends ZanataTestCase {
                         .enterFilePath(cancelUploadFile.getAbsolutePath())
                         .cancelUpload();
         assertThat(versionDocumentsTab
-                .sourceDocumentsContains("cancelFileUpload.txt")).isFalse()
-                        .as("Document does not show in table");
+                .sourceDocumentsContains("cancelFileUpload.txt"))
+                .as("Document does not show in table")
+                .isFalse();
     }
 
     @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)
@@ -85,8 +86,9 @@ public class UploadTest extends ZanataTestCase {
                 new ProjectWorkFlow().goToProjectByName("uploadtest")
                         .gotoVersion("txt-upload").gotoSettingsTab()
                         .gotoSettingsDocumentsTab().pressUploadFileButton();
-        assertThat(versionDocumentsTab.canSubmitDocument()).isFalse()
-                .as("The upload button is not available");
+        assertThat(versionDocumentsTab.canSubmitDocument())
+                .as("The upload button is not available")
+                .isFalse();
     }
 
     @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)
@@ -103,8 +105,9 @@ public class UploadTest extends ZanataTestCase {
         VersionDocumentsPage versionDocumentsPage = versionDocumentsTab
                 .gotoDocumentTab().expectSourceDocsContains(longFile.getName());
         assertThat(versionDocumentsPage
-                .sourceDocumentsContains(longFile.getName())).isTrue()
-                        .as("Document shows in table");
+                .sourceDocumentsContains(longFile.getName()))
+                .as("Document shows in table")
+                .isTrue();
     }
 
     @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)
@@ -118,14 +121,16 @@ public class UploadTest extends ZanataTestCase {
                         .gotoSettingsDocumentsTab().pressUploadFileButton()
                         .enterFilePath(emptyFile.getAbsolutePath())
                         .submitUpload().clickUploadDone();
-        assertThat(emptyFile.exists()).isTrue()
-                .as("Data file emptyFile.txt still exists");
+        assertThat(emptyFile.exists())
+                .as("Data file emptyFile.txt still exists")
+                .isTrue();
         VersionDocumentsPage versionDocumentsPage =
                 versionDocumentsTab.gotoDocumentTab()
                         .expectSourceDocsContains(emptyFile.getName());
         assertThat(versionDocumentsPage
-                .sourceDocumentsContains(emptyFile.getName())).isTrue()
-                        .as("Document shows in table");
+                .sourceDocumentsContains(emptyFile.getName()))
+                .as("Document shows in table")
+                .isTrue();
     }
 
     @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)
@@ -138,7 +143,7 @@ public class UploadTest extends ZanataTestCase {
                         .gotoSettingsDocumentsTab().pressUploadFileButton()
                         .enterFilePath(unsupportedFile.getAbsolutePath());
         assertThat(versionDocumentsTab.getUploadError())
-                .contains(VersionDocumentsTab.UNSUPPORTED_FILETYPE)
-                .as("Unsupported file type error is shown");
+                .as("Unsupported file type error is shown")
+                .contains(VersionDocumentsTab.UNSUPPORTED_FILETYPE);
     }
 }

--- a/server/functional-test/src/test/java/org/zanata/feature/editor/TranslateTextTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/editor/TranslateTextTest.java
@@ -74,7 +74,8 @@ public class TranslateTextTest extends ZanataTestCase {
         File testfile = testFileGenerator.generateTestFileWithContent(
                 "basictext", ".txt",
                 "Line One\nLine Two\nLine Three");
-        zanataRestCaller.createProjectAndVersion("txt-translate", "txt", "file");
+        zanataRestCaller
+                .createProjectAndVersion("txt-translate", "txt", "file");
         EditorPage editorPage = new ProjectWorkFlow()
                 .goToProjectByName("txt-translate")
                 .gotoVersion("txt")
@@ -88,14 +89,14 @@ public class TranslateTextTest extends ZanataTestCase {
                 .translate("fr", testfile.getName());
 
         assertThat(editorPage.getMessageSourceAtRowIndex(0))
-                .isEqualTo("Line One")
-                .as("Item 1 shows Line One");
+                .as("Item 1 shows Line One")
+                .isEqualTo("Line One");
         assertThat(editorPage.getMessageSourceAtRowIndex(1))
-                .isEqualTo("Line Two")
-                .as("Item 2 shows Line Two");
+                .as("Item 2 shows Line Two")
+                .isEqualTo("Line Two");
         assertThat(editorPage.getMessageSourceAtRowIndex(2))
-                .isEqualTo("Line Three")
-                .as("Item 3 shows Line Three");
+                .as("Item 3 shows Line Three")
+                .isEqualTo("Line Three");
 
         editorPage = editorPage.translateTargetAtRowIndex(0, "Une Ligne")
                 .approveTranslationAtRow(0)
@@ -114,13 +115,13 @@ public class TranslateTextTest extends ZanataTestCase {
 
     private void assertTranslations(EditorPage editorPage) {
         assertThat(editorPage.getBasicTranslationTargetAtRowIndex(0))
-                .isEqualTo("Une Ligne")
-                .as("Item 1 shows a translation of Line One");
+                .as("Item 1 shows a translation of Line One")
+                .isEqualTo("Une Ligne");
         assertThat(editorPage.getBasicTranslationTargetAtRowIndex(1))
-                .isEqualTo("Deux Ligne")
-                .as("Item 2 shows a translation of Line Two");
+                .as("Item 2 shows a translation of Line Two")
+                .isEqualTo("Deux Ligne");
         assertThat(editorPage.getBasicTranslationTargetAtRowIndex(2))
-                .isEqualTo("Ligne Trois")
-                .as("Item 3 shows a translation of Line Three");
+                .as("Item 3 shows a translation of Line Three")
+                .isEqualTo("Ligne Trois");
     }
 }

--- a/server/functional-test/src/test/java/org/zanata/feature/editor/TranslationHistoryTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/editor/TranslationHistoryTest.java
@@ -54,11 +54,11 @@ public class TranslationHistoryTest extends ZanataTestCase {
                 .clickShowHistoryForRow(0);
 
         assertThat(editorPage.getHistoryEntryAuthor(0))
-                .startsWith("admin")
-                .as("The user is displayed");
+                .as("The user is displayed")
+                .startsWith("admin");
         assertThat(editorPage.getHistoryEntryContent(0))
-                .contains("historytest")
-                .as("The content change is displayed");
+                .as("The content change is displayed")
+                .contains("historytest");
     }
 
     @Test
@@ -79,19 +79,19 @@ public class TranslationHistoryTest extends ZanataTestCase {
                 .clickCompareOn(1);
 
         assertThat(editorPage.getTranslationHistoryCompareTabtext())
-                .isEqualTo("Compare ver. 2 and 1")
-                .as("The tab displays compared versions");
+                .as("The tab displays compared versions")
+                .isEqualTo("Compare ver. 2 and 1");
 
         editorPage = editorPage.clickCompareVersionsTab();
 
         assertThat(editorPage.getComparisonTextInRow(0))
-                .isEqualTo("historytest2")
-                .as("The new text is displayed");
+                .as("The new text is displayed")
+                .isEqualTo("historytest2");
         assertThat(editorPage.getComparisonTextInRow(1))
-                .isEqualTo("historytest2")
-                .as("The old text is also displayed");
+                .as("The old text is also displayed")
+                .isEqualTo("historytest2");
         assertThat(editorPage.getComparisonTextDiff())
-                .contains("--2")
-                .as("The diff is displayed");
+                .as("The diff is displayed")
+                .contains("--2");
     }
 }

--- a/server/functional-test/src/test/java/org/zanata/feature/endtoend/UserEndToEndTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/endtoend/UserEndToEndTest.java
@@ -204,8 +204,8 @@ public class UserEndToEndTest extends ZanataTestCase {
                 .register();
 
         assertThat(signInPage.getNotificationMessage())
-                .isEqualTo(HomePage.SIGNUP_SUCCESS_MESSAGE)
-                .as("Sign up is successful");
+                .as("Sign up is successful")
+                .isEqualTo(HomePage.SIGNUP_SUCCESS_MESSAGE);
 
         return signInPage;
     }

--- a/server/functional-test/src/test/java/org/zanata/feature/language/AddLanguageTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/language/AddLanguageTest.java
@@ -48,8 +48,8 @@ public class AddLanguageTest extends ZanataTestCase {
     public void before() {
         new BasicWorkFlow().goToHome().deleteCookiesAndRefresh();
         assertThat(new LoginWorkFlow().signIn("admin", "admin").loggedInAs())
-                .isEqualTo("admin")
-                .as("Admin is logged in");
+                .as("Admin is logged in")
+                .isEqualTo("admin");
     }
 
     @Trace(summary = "The administrator can add a language to Zanata")
@@ -106,8 +106,8 @@ public class AddLanguageTest extends ZanataTestCase {
                 .goToLanguages();
 
         assertThat(languagesPage.getLanguageLocales())
-                .doesNotContain(language)
-                .as("The language is not listed");
+                .as("The language is not listed")
+                .doesNotContain(language);
 
         languagesPage = languagesPage
                 .clickAddNewLanguage()
@@ -120,11 +120,11 @@ public class AddLanguageTest extends ZanataTestCase {
                 .saveLanguage();
 
         assertThat(languagesPage.getLanguageLocales())
-                .contains(language)
-                .as("The language is listed");
+                .as("The language is listed")
+                .contains(language);
         assertThat(languagesPage.languageIsEnabledByDefault(language))
-                .isFalse()
-                .as("The language is disabled by default");
+                .as("The language is disabled by default")
+                .isFalse();
 
         languagesPage.closeNotification();
 
@@ -133,11 +133,12 @@ public class AddLanguageTest extends ZanataTestCase {
                 .searchAndGotoProjectByName("about fedora")
                 .gotoSettingsTab()
                 .gotoSettingsLanguagesTab();
-        List<String> enabledLocaleList = projectLanguagesTab.getEnabledLocaleList();
+        List<String> enabledLocaleList =
+                projectLanguagesTab.getEnabledLocaleList();
 
         assertThat(enabledLocaleList)
-                .doesNotContain(language)
-                .as("The language is disabled by default");
+                .as("The language is disabled by default")
+                .doesNotContain(language);
     }
 
     @Trace(summary = "The administrator can add a known language to Zanata")
@@ -149,8 +150,8 @@ public class AddLanguageTest extends ZanataTestCase {
                 .goToLanguages();
 
         assertThat(languagesPage.getLanguageLocales())
-                .doesNotContain(language)
-                .as("The language is not listed");
+                .as("The language is not listed")
+                .doesNotContain(language);
 
         AddLanguagePage addLanguagePage = languagesPage
                 .clickAddNewLanguage()
@@ -158,14 +159,14 @@ public class AddLanguageTest extends ZanataTestCase {
                 .selectSearchLanguage(language);
 
         assertThat(addLanguagePage.getNewLanguageName())
-                .isEqualTo("Russian (Russia)")
-                .as("The name is correct");
+                .as("The name is correct")
+                .isEqualTo("Russian (Russia)");
         assertThat(addLanguagePage.getNewLanguageNativeName())
-                .isEqualTo("русский (Россия)")
-                .as("The native name is correct");
+                .as("The native name is correct")
+                .isEqualTo("русский (Россия)");
         assertThat(addLanguagePage.getNewLanguageCode())
-                .isEqualTo(language)
-                .as("The language is correct");
+                .as("The language is correct")
+                .isEqualTo(language);
     }
 
 }

--- a/server/functional-test/src/test/java/org/zanata/feature/language/JoinLanguageTeamTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/language/JoinLanguageTeamTest.java
@@ -59,8 +59,8 @@ public class JoinLanguageTeamTest extends ZanataTestCase {
                         LanguagePage.TeamPermission.Reviewer);
 
         assertThat(languagePage.getMemberUsernames())
-                .contains("translator")
-                .as("Translator is a listed member of the pl team");
+                .as("Translator is a listed member of the pl team")
+                .contains("translator");
         assertThat(hasEmailRule.emailsArrivedWithinTimeout(1, 30,
                 TimeUnit.SECONDS))
                 .as("The email arrived within thirty seconds")

--- a/server/functional-test/src/test/java/org/zanata/feature/language/comp/LanguageCTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/language/comp/LanguageCTest.java
@@ -52,9 +52,10 @@ public class LanguageCTest extends ZanataTestCase {
     @Before
     public void before() {
         new BasicWorkFlow().goToHome().deleteCookiesAndRefresh();
-        assertThat(new LoginWorkFlow().signIn("translator", "translator").loggedInAs())
-                .isEqualTo("translator")
-                .as("translator is logged in");
+        assertThat(new LoginWorkFlow().signIn("translator", "translator")
+                .loggedInAs())
+                .as("translator is logged in")
+                .isEqualTo("translator");
     }
 
     @Trace(summary = "Translator can search for language",
@@ -67,8 +68,8 @@ public class LanguageCTest extends ZanataTestCase {
                 .goToLanguages();
 
         assertThat(languagesPage.getLanguageLocales())
-                .contains(language)
-                .as("The language is listed");
+                .as("The language is listed")
+                .contains(language);
 
     }
 
@@ -88,25 +89,26 @@ public class LanguageCTest extends ZanataTestCase {
         List<WiserMessage> messages = emailRule.getMessages();
 
         assertThat(messages.size())
-                .isGreaterThanOrEqualTo(1)
-                .as("One email was sent");
+                .as("One email was sent")
+                .isGreaterThanOrEqualTo(1);
 
         WiserMessage wiserMessage = messages.get(0);
 
         assertThat(wiserMessage.getEnvelopeReceiver())
-                .isEqualTo("admin@example.com")
-                .as("The email recipient is the Coordinator");
+                .as("The email recipient is the Coordinator")
+                .isEqualTo("admin@example.com");
 
         String content = HasEmailRule.getEmailContent(wiserMessage);
 
         assertThat(content)
                 .contains("Dear Language Team Coordinator")
-                .contains("Zanata user \"translator\" with id \"translator\" is requesting to join ")
+                .contains(
+                        "Zanata user \"translator\" with id \"translator\" is requesting to join ")
                 .as("The email is to the language team coordinator");
 
         assertThat(languagePage.getNotificationMessage())
-                .contains("Your message has been sent to the administrator")
-                .as("The user is informed the message was sent");
+                .as("The user is informed the message was sent")
+                .contains("Your message has been sent to the administrator");
 
     }
 
@@ -125,8 +127,8 @@ public class LanguageCTest extends ZanataTestCase {
                 .cancelRequest();
 
         assertThat(languagePage.getNotificationMessage())
-                .contains("Request cancelled by translator")
-                .as("Request to join language team is cancel");
+                .as("Request to join language team is cancel")
+                .contains("Request cancelled by translator");
     }
 
     @Trace(summary = "Translator can leave language team",
@@ -141,8 +143,8 @@ public class LanguageCTest extends ZanataTestCase {
                 .leaveTeam();
 
         assertThat(languagePage.getNotificationMessage())
-                .contains("You have left the français language team")
-                .as("Leaved language team " + language);
+                .as("Leaved language team " + language)
+                .contains("You have left the français language team");
     }
 
 }

--- a/server/functional-test/src/test/java/org/zanata/feature/misc/DatabaseDDLTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/misc/DatabaseDDLTest.java
@@ -106,14 +106,16 @@ public class DatabaseDDLTest {
                 getForeignKeysForDatabase("test", em2);
         log.debug("foreign keys from hibernate:{}", fkFromHibernate);
 
-        assertThat(fkFromLiquibase).isEqualTo(fkFromHibernate)
-                .as("Liquibase foreign keys should equate to hibernate mapping");
+        assertThat(fkFromLiquibase)
+                .as("Liquibase foreign keys should equate to hibernate mapping")
+                .isEqualTo(fkFromHibernate);
 
         List<UniqueKey> ukFromLiquibase = getUniqueKeysForDatabase(dbName, em1);
         List<UniqueKey> ukFromHibernate = getUniqueKeysForDatabase("test", em2);
 
-        assertThat(ukFromLiquibase).isEqualTo(ukFromHibernate)
-                .as("Liquibase unique keys should equate to hibernate mapping");
+        assertThat(ukFromLiquibase)
+                .as("Liquibase unique keys should equate to hibernate mapping")
+                .isEqualTo(ukFromHibernate);
     }
 
     private List<UniqueKey> getUniqueKeysForDatabase(String dbName,

--- a/server/functional-test/src/test/java/org/zanata/feature/misc/PageNotFoundTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/misc/PageNotFoundTest.java
@@ -37,14 +37,14 @@ public class PageNotFoundTest extends ZanataTestCase {
                 .goToPage("notAPage", Error404Page.class);
 
         assertThat(error404Page.isItA404())
-                .isTrue()
-                .as("Standard page shows a 404 error");
+                .as("Standard page shows a 404 error")
+                .isTrue();
 
         error404Page = new BasicWorkFlow()
                 .goToPage("projects/view/NotAProject", Error404Page.class);
 
         assertThat(error404Page.isItA404())
-                .isTrue()
-                .as("Seam 'entity not found' page shows a 404 error");
+                .as("Seam 'entity not found' page shows a 404 error")
+                .isTrue();
     }
 }

--- a/server/functional-test/src/test/java/org/zanata/feature/project/CreateProjectTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/project/CreateProjectTest.java
@@ -49,8 +49,8 @@ public class CreateProjectTest extends ZanataTestCase {
     public void before() {
         new BasicWorkFlow().goToHome().deleteCookiesAndRefresh();
         assertThat(new LoginWorkFlow().signIn("admin", "admin").loggedInAs())
-                .isEqualTo("admin")
-                .as("Admin is logged in");
+                .as("Admin is logged in")
+                .isEqualTo("admin");
     }
 
     @Trace(summary = "The user can create a project")
@@ -60,8 +60,8 @@ public class CreateProjectTest extends ZanataTestCase {
                 .createNewSimpleProject("basicproject", "basicproject");
 
         assertThat(projectVersionsPage.getProjectName().trim())
-                .isEqualTo("basicproject")
-                .as("The project name is correct");
+                .as("The project name is correct")
+                .isEqualTo("basicproject");
     }
 
     @Trace(summary = "The user can create a project with description")
@@ -76,12 +76,12 @@ public class CreateProjectTest extends ZanataTestCase {
                 new ProjectWorkFlow().createNewProject(projectSettings);
 
         assertThat(projectPage.getProjectName().trim())
-                .isEqualTo(projectSettings.get("Name"))
-                .as("The project name is correct");
+                .as("The project name is correct")
+                .isEqualTo(projectSettings.get("Name"));
 
         assertThat(projectPage.getContentAreaParagraphs())
-                .contains(projectSettings.get("Description"))
-                .as("The project content area shows the description");
+                .as("The project content area shows the description")
+                .contains(projectSettings.get("Description"));
     }
 
 }

--- a/server/functional-test/src/test/java/org/zanata/feature/project/EditPermissionsTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/project/EditPermissionsTest.java
@@ -62,15 +62,15 @@ public class EditPermissionsTest extends ZanataTestCase {
                 .gotoSettingsPermissionsTab();
 
         assertThat(projectPermissionsTab.getSettingsMaintainersList())
-                .contains("admin")
-                .as("The admin user is shown in the list");
+                .as("The admin user is shown in the list")
+                .contains("admin");
 
         ProjectPeoplePage projectPeoplePage = projectPermissionsTab
                 .gotoPeopleTab();
 
         assertThat(projectPeoplePage.getPeople())
-                .contains("Administrator @admin")
-                .as("The admin user is shown in the list");
+                .as("The admin user is shown in the list")
+                .contains("Administrator @admin");
     }
 
     @Trace(summary = "The administrator can add a maintainer to a project")
@@ -84,15 +84,15 @@ public class EditPermissionsTest extends ZanataTestCase {
                 .gotoSettingsPermissionsTab();
 
         assertThat(projectPermissionsTab.getSettingsMaintainersList())
-                .doesNotContain("translator")
-                .as("The translator user is not a maintainer");
+                .as("The translator user is not a maintainer")
+                .doesNotContain("translator");
 
         projectPermissionsTab = new ProjectWorkFlow()
                 .addMaintainer("about fedora", "translator");
 
         assertThat(projectPermissionsTab.getSettingsMaintainersList())
-                .contains("translator")
-                .as("The translator user is a maintainer");
+                .as("The translator user is a maintainer")
+                .contains("translator");
 
         /* Workaround for ZNTA-666 */
         projectPermissionsTab.reload();
@@ -101,8 +101,8 @@ public class EditPermissionsTest extends ZanataTestCase {
                 .gotoPeopleTab();
 
         assertThat(projectPeoplePage.getPeople())
-                .contains("translator|Maintainer;")
-                .as("The translator user is shown in the list");
+                .as("The translator user is shown in the list")
+                .contains("translator|Maintainer;");
 
         projectPeoplePage.logout();
 
@@ -111,8 +111,8 @@ public class EditPermissionsTest extends ZanataTestCase {
                 .gotoExplore()
                 .searchAndGotoProjectByName("about fedora")
                 .settingsTabIsDisplayed())
-                .isTrue()
-                .as("The settings tab is now available to the user");
+                .as("The settings tab is now available to the user")
+                .isTrue();
     }
 
     @Trace(summary = "The maintainer can add a maintainer to a project")
@@ -125,8 +125,8 @@ public class EditPermissionsTest extends ZanataTestCase {
         assertThat(new LoginWorkFlow()
                 .signIn("translator", "translator")
                 .loggedInAs())
-                .isEqualTo("translator")
-                .as("Translator has signed in");
+                .as("Translator has signed in")
+                .isEqualTo("translator");
 
         ProjectPermissionsTab projectPermissionsTab = new ProjectWorkFlow()
                 .goToProjectByName("addmaintainer")
@@ -138,8 +138,8 @@ public class EditPermissionsTest extends ZanataTestCase {
         projectPermissionsTab.expectMaintainersContains("glossarist");
 
         assertThat(projectPermissionsTab.getSettingsMaintainersList())
-                .contains("glossarist")
-                .as("The glossarist user was added as a maintainer");
+                .as("The glossarist user was added as a maintainer")
+                .contains("glossarist");
 
         /* Workaround for ZNTA-666 */
         projectPermissionsTab.reload();
@@ -148,8 +148,8 @@ public class EditPermissionsTest extends ZanataTestCase {
                 .gotoPeopleTab();
 
         assertThat(projectPeoplePage.getPeople())
-                .contains("glossarist|Maintainer;")
-                .as("The glossarist user is shown in the list");
+                .as("The glossarist user is shown in the list")
+                .contains("glossarist|Maintainer;");
 
         projectPeoplePage.logout();
 
@@ -159,8 +159,8 @@ public class EditPermissionsTest extends ZanataTestCase {
                 .searchAndGotoProjectByName("addmaintainer");
 
         assertThat(projectVersionsPage.settingsTabIsDisplayed())
-                .isTrue()
-                .as("The settings tab is now available to the glossarist");
+                .as("The settings tab is now available to the glossarist")
+                .isTrue();
     }
 
     @Trace(summary = "The maintainer can remove a maintainer from a project")
@@ -172,28 +172,28 @@ public class EditPermissionsTest extends ZanataTestCase {
         assertThat(new LoginWorkFlow()
                 .signIn("translator", "translator")
                 .loggedInAs())
-                .isEqualTo("translator")
-                .as("Translator has signed in");
+                .as("Translator has signed in")
+                .isEqualTo("translator");
 
         assertThat(new ProjectWorkFlow()
                 .addMaintainer("removemaintainer", "glossarist")
                 .getSettingsMaintainersList())
-                .contains("glossarist")
-                .as("Glossarist maintainer is added");
+                .as("Glossarist maintainer is added")
+                .contains("glossarist");
 
         ProjectPermissionsTab projectPermissionsTab = new ProjectWorkFlow()
                 .removeMaintainer("removemaintainer", "glossarist");
 
         assertThat(projectPermissionsTab.getSettingsMaintainersList())
-                .doesNotContain("glossarist")
-                .as("Glossarist maintainer is removed");
+                .as("Glossarist maintainer is removed")
+                .doesNotContain("glossarist");
 
         ProjectPeoplePage projectPeoplePage = projectPermissionsTab
                 .gotoPeopleTab();
 
         assertThat(projectPeoplePage.getPeople())
-                .doesNotContain("Glossarist|Maintainer;")
-                .as("The glossarist user is not in the list");
+                .as("The glossarist user is not in the list")
+                .doesNotContain("Glossarist|Maintainer;");
     }
 
     @Trace(summary = "The maintainer can remove themselves as maintainer " +
@@ -208,15 +208,15 @@ public class EditPermissionsTest extends ZanataTestCase {
         assertThat(new LoginWorkFlow()
                 .signIn("translator", "translator")
                 .loggedInAs())
-                .isEqualTo("translator")
-                .as("Translator has signed in");
+                .as("Translator has signed in")
+                .isEqualTo("translator");
 
         ProjectPermissionsTab projectPermissionsTab = new ProjectWorkFlow()
                 .addMaintainer("removemaintainer", "admin");
 
         assertThat(projectPermissionsTab.getSettingsMaintainersList())
-                .contains("admin")
-                .as("admin maintainer is added");
+                .as("admin maintainer is added")
+                .contains("admin");
 
         projectPermissionsTab.slightPause();
         ProjectBasePage projectBasePage = projectPermissionsTab
@@ -231,8 +231,8 @@ public class EditPermissionsTest extends ZanataTestCase {
 
 
         assertThat(projectVersionsPage.settingsTabIsDisplayed())
-                .isFalse()
-                .as("The translator user is no longer a maintainer");
+                .as("The translator user is no longer a maintainer")
+                .isFalse();
     }
 
 }

--- a/server/functional-test/src/test/java/org/zanata/feature/project/EditProjectAboutTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/project/EditProjectAboutTest.java
@@ -52,8 +52,8 @@ public class EditProjectAboutTest extends ZanataTestCase {
         assertThat(new LoginWorkFlow()
                 .signIn("admin", "admin")
                 .loggedInAs())
-                .isEqualTo("admin")
-                .as("Admin is logged in");
+                .as("Admin is logged in")
+                .isEqualTo("admin");
 
         ProjectAboutTab projectAboutTab = new ProjectWorkFlow()
                 .goToProjectByName("aboutpagetest")
@@ -73,7 +73,7 @@ public class EditProjectAboutTest extends ZanataTestCase {
         ProjectAboutPage projectAboutPage = projectAboutTab.gotoAboutTab();
 
         assertThat(projectAboutPage.getAboutText())
-                .isEqualTo(aboutText)
-                .as("The text in the About tab is correct");
+                .as("The text in the About tab is correct")
+                .isEqualTo(aboutText);
     }
 }

--- a/server/functional-test/src/test/java/org/zanata/feature/project/EditProjectGeneralTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/project/EditProjectGeneralTest.java
@@ -46,8 +46,8 @@ public class EditProjectGeneralTest extends ZanataTestCase {
     @Before
     public void before() {
         assertThat(new LoginWorkFlow().signIn("admin", "admin").loggedInAs())
-                .isEqualTo("admin")
-                .as("Admin is logged in");
+                .as("Admin is logged in")
+                .isEqualTo("admin");
     }
 
 
@@ -68,8 +68,8 @@ public class EditProjectGeneralTest extends ZanataTestCase {
                 .enterSearch("about fedora");
 
         assertThat(explorePage.getProjectSearchResults())
-            .doesNotContain("about fedora")
-                .as("The project is not displayed");
+                .as("The project is not displayed")
+                .doesNotContain("about fedora");
     }
 
     @Trace(summary = "The administrator can set a read-only project " +
@@ -98,8 +98,8 @@ public class EditProjectGeneralTest extends ZanataTestCase {
                 .expectProjectListContains("about fedora");
 
         assertThat(explorePage.getProjectSearchResults())
-                .contains("about fedora")
-                .as("The project is now displayed");
+                .as("The project is now displayed")
+                .contains("about fedora");
     }
 
     @Trace(summary = "The administrator can change a project's name")
@@ -116,8 +116,8 @@ public class EditProjectGeneralTest extends ZanataTestCase {
                 .searchAndGotoProjectByName(replacementText);
 
         assertThat(projectVersionsPage.getProjectName())
-                .isEqualTo(replacementText)
-                .as("The project name has changed");
+                .as("The project name has changed")
+                .isEqualTo(replacementText);
     }
 
     @Trace(summary = "The administrator can change a project's description")
@@ -128,8 +128,8 @@ public class EditProjectGeneralTest extends ZanataTestCase {
                 .goToProjectByName("about fedora");
 
         assertThat(projectVersionsPage.getContentAreaParagraphs())
-                .doesNotContain(replacementText)
-                .as("The description is default");
+                .as("The description is default")
+                .doesNotContain(replacementText);
 
         ProjectGeneralTab projectGeneralTab = projectVersionsPage
                 .gotoSettingsTab()
@@ -138,8 +138,8 @@ public class EditProjectGeneralTest extends ZanataTestCase {
                 .updateProject();
 
         assertThat(projectGeneralTab.getContentAreaParagraphs())
-                .contains(replacementText)
-                .as("The text has changed");
+                .as("The text has changed")
+                .contains(replacementText);
     }
 
     @Trace(summary = "The administrator can change a project's type")
@@ -158,8 +158,8 @@ public class EditProjectGeneralTest extends ZanataTestCase {
                 .gotoSettingsGeneral();
 
         assertThat(projectGeneralTab.getSelectedProjectType())
-                .isEqualTo("Properties")
-                .as("The project type is correct");
+                .as("The project type is correct")
+                .isEqualTo("Properties");
     }
 
     @Trace(summary = "The administrator can change a project's source urls")
@@ -176,12 +176,12 @@ public class EditProjectGeneralTest extends ZanataTestCase {
                 .searchAndGotoProjectByName("about fedora");
 
         assertThat(projectVersionsPage.getHomepage())
-                .isEqualTo("http://www.example.com")
-                .as("The homepage is correct");
+                .as("The homepage is correct")
+                .isEqualTo("http://www.example.com");
 
         assertThat(projectVersionsPage.getGitUrl())
-                .isEqualTo("http://git.example.com")
-                .as("The git url is correct");
+                .as("The git url is correct")
+                .isEqualTo("http://git.example.com");
     }
 
     @Trace(summary = "Project slug can be changed and page will redirect to new URL after the change")
@@ -201,8 +201,8 @@ public class EditProjectGeneralTest extends ZanataTestCase {
                 .gotoSettingsGeneral();
 
         assertThat(projectGeneralTab.getProjectId())
-                .isEqualTo("fedora-reborn")
-                .as("The project slug is correct");
+                .as("The project slug is correct")
+                .isEqualTo("fedora-reborn");
         // FIXME wait for async indexing to finish to avoid interfering with other tests
 
         // TODO test that search results work for new slug

--- a/server/functional-test/src/test/java/org/zanata/feature/project/EditProjectLanguagesTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/project/EditProjectLanguagesTest.java
@@ -46,8 +46,8 @@ public class EditProjectLanguagesTest extends ZanataTestCase {
     @Before
     public void before() {
         assertThat(new LoginWorkFlow().signIn("admin", "admin").loggedInAs())
-                .isEqualTo("admin")
-                .as("Admin is logged in");
+                .as("Admin is logged in")
+                .isEqualTo("admin");
     }
 
     @Trace(summary = "The administrator can edit the project languages")
@@ -63,13 +63,13 @@ public class EditProjectLanguagesTest extends ZanataTestCase {
                 .getEnabledLocaleList();
 
         assertThat(enabledLocaleList)
-                .contains("fr", "hi", "pl")
-                .as("The enabled list contains three languages");
+                .as("The enabled list contains three languages")
+                .contains("fr", "hi", "pl");
 
         assertThat(enabledLocaleList)
-                .doesNotContain("en-US")
                 .as("The enabled list does not contain " +
-                        "'English (United States)[en-US]'");
+                        "'English (United States)[en-US]'")
+                .doesNotContain("en-US");
 
         projectLanguagesTab = projectLanguagesTab
                 .gotoSettingsTab()
@@ -98,9 +98,9 @@ public class EditProjectLanguagesTest extends ZanataTestCase {
         enabledLocaleList = projectLanguagesTab
                 .getEnabledLocaleList();
 
-        Assertions.assertThat(enabledLocaleList)
-                .contains("en-US", "fr", "hi")
-                .as("The enabled language list contains en-US, fr and hi");
+        assertThat(enabledLocaleList)
+                .as("The enabled language list contains en-US, fr and hi")
+                .contains("en-US", "fr", "hi");
         projectLanguagesTab.filterEnabledLanguages("en-US")
                 .expectEnabledLocaleListCount(1);
     }
@@ -121,8 +121,8 @@ public class EditProjectLanguagesTest extends ZanataTestCase {
                 .saveLocaleAlias("pl");
 
         assertThat(projectLanguagesTab.getAlias("pl"))
-                .isEqualTo("pl-PL")
-                .as("The alias was set");
+                .as("The alias was set")
+                .isEqualTo("pl-PL");
     }
 
     @Trace(summary = "The administrator can remove an alias for a project " +
@@ -139,8 +139,8 @@ public class EditProjectLanguagesTest extends ZanataTestCase {
                 .saveLocaleAlias("pl");
 
         assertThat(projectLanguagesTab.getAlias("pl"))
-                .isEqualTo("pl-PL")
-                .as("The alias was set");
+                .as("The alias was set")
+                .isEqualTo("pl-PL");
 
         projectLanguagesTab = projectLanguagesTab
                 .clickLanguageActionsDropdown("pl")
@@ -165,8 +165,8 @@ public class EditProjectLanguagesTest extends ZanataTestCase {
                 .saveLocaleAlias(locale);
 
         assertThat(projectLanguagesTab.getAlias(locale))
-                .isEqualTo("pl-PL")
-                .as("The alias was set");
+                .as("The alias was set")
+                .isEqualTo("pl-PL");
 
         projectLanguagesTab = projectLanguagesTab
                 .clickLanguageActionsDropdown(locale)

--- a/server/functional-test/src/test/java/org/zanata/feature/project/EditProjectValidationsTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/project/EditProjectValidationsTest.java
@@ -42,8 +42,8 @@ public class EditProjectValidationsTest extends ZanataTestCase {
     @Before
     public void before() {
         assertThat(new LoginWorkFlow().signIn("admin", "admin").loggedInAs())
-                .isEqualTo("admin")
-                .as("Admin is logged in");
+                .as("Admin is logged in")
+                .isEqualTo("admin");
     }
 
     @Trace(summary = "The administrator can change the validation levels " +
@@ -58,8 +58,8 @@ public class EditProjectValidationsTest extends ZanataTestCase {
 
         assertThat(projectTranslationTab
                 .isValidationLevel("Tab characters (\\t)", "Warning"))
-                .isTrue()
-                .as("The level for tabs is currently Warning");
+                .as("The level for tabs is currently Warning")
+                .isTrue();
 
         projectTranslationTab = projectTranslationTab
                 .setValidationLevel("HTML/XML tags", "Error");
@@ -87,28 +87,28 @@ public class EditProjectValidationsTest extends ZanataTestCase {
 
         assertThat(projectTranslationTab
                 .isValidationLevel("HTML/XML tags", "Error"))
-                .isTrue()
-                .as("The validation changes were saved");
+                .as("The validation changes were saved")
+                .isTrue();
         assertThat(projectTranslationTab
                 .isValidationLevel("Java variables", "Error"))
-                .isTrue()
-                .as("The validation changes were saved");
+                .as("The validation changes were saved")
+                .isTrue();
         assertThat(projectTranslationTab
                 .isValidationLevel("Leading/trailing newline (\\n)", "Error"))
-                .isTrue()
-                .as("The validation changes were saved");
+                .as("The validation changes were saved")
+                .isTrue();
         assertThat(projectTranslationTab
                 .isValidationLevel("Printf variables", "Error"))
-                .isTrue()
-                .as("The validation changes were saved");
+                .as("The validation changes were saved")
+                .isTrue();
         assertThat(projectTranslationTab
                 .isValidationLevel("Tab characters (\\t)", "Error"))
-                .isTrue()
-                .as("The validation changes were saved");
+                .as("The validation changes were saved")
+                .isTrue();
         assertThat(projectTranslationTab
                 .isValidationLevel("XML entity reference", "Error"))
-                .isTrue()
-                .as("The validation changes were saved");
+                .as("The validation changes were saved")
+                .isTrue();
     }
 
     @Trace(summary = "The system will only allow one of the two Printf " +
@@ -127,14 +127,15 @@ public class EditProjectValidationsTest extends ZanataTestCase {
         //        "Positional printf (XSI extension) to Error.");
 
         assertThat(projectTranslationTab
-                .isValidationLevel("Positional printf (XSI extension)", "Error"))
-                .isTrue()
-                .as("The Positional printf level is Error");
+                .isValidationLevel("Positional printf (XSI extension)",
+                        "Error"))
+                .as("The Positional printf level is Error")
+                .isTrue();
 
         assertThat(projectTranslationTab
                 .isValidationLevel("Printf variables", "Off"))
-                .isTrue()
-                .as("The Printf level is Off");
+                .as("The Printf level is Off")
+                .isTrue();
 
         projectTranslationTab = projectTranslationTab
                 .setValidationLevel("Printf variables", "Error");
@@ -145,12 +146,12 @@ public class EditProjectValidationsTest extends ZanataTestCase {
 
         assertThat(projectTranslationTab
                 .isValidationLevel("Printf variables", "Error"))
-                .isTrue()
-                .as("The Printf level is Error");
+                .as("The Printf level is Error")
+                .isTrue();
 
         assertThat(projectTranslationTab
                 .isValidationLevel("Positional printf (XSI extension)", "Off"))
-                .isTrue()
-                .as("The Positional printf level is Off");
+                .as("The Positional printf level is Off")
+                .isTrue();
     }
 }

--- a/server/functional-test/src/test/java/org/zanata/feature/project/EditWebHooksTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/project/EditWebHooksTest.java
@@ -45,8 +45,8 @@ public class EditWebHooksTest extends ZanataTestCase {
     public void before() {
         new BasicWorkFlow().goToHome().deleteCookiesAndRefresh();
         assertThat(new LoginWorkFlow().signIn("admin", "admin").loggedInAs())
-                .isEqualTo("admin")
-                .as("Admin is logged in");
+                .as("Admin is logged in")
+                .isEqualTo("admin");
     }
 
     @Trace(summary = "The maintainer can add WebHooks for a project")

--- a/server/functional-test/src/test/java/org/zanata/feature/project/SetProjectVisibilityTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/project/SetProjectVisibilityTest.java
@@ -28,8 +28,8 @@ public class SetProjectVisibilityTest extends ZanataTestCase {
                 .gotoExplore();
 
         assertThat(explore.getProjectSearchResults())
-                .doesNotContain("about fedora")
-                .as("The project is not displayed");
+                .as("The project is not displayed")
+                .doesNotContain("about fedora");
     }
 
 }

--- a/server/functional-test/src/test/java/org/zanata/feature/projectversion/CreateProjectVersionTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/projectversion/CreateProjectVersionTest.java
@@ -48,8 +48,8 @@ public class CreateProjectVersionTest extends ZanataTestCase {
     @Before
     public void before() {
         assertThat(new LoginWorkFlow().signIn("admin", "admin").loggedInAs())
-                .isEqualTo("admin")
-                .as("Admin is logged in");
+                .as("Admin is logged in")
+                .isEqualTo("admin");
     }
 
     @Trace(summary = "The administrator can create a project version")
@@ -63,8 +63,8 @@ public class CreateProjectVersionTest extends ZanataTestCase {
                 .saveVersion();
 
         assertThat(versionLanguagesPage.getProjectVersionName())
-                .isEqualTo("my-aboutfedora-version")
-                .as("The version is created with correct ID");
+                .as("The version is created with correct ID")
+                .isEqualTo("my-aboutfedora-version");
     }
 
     @Trace(summary = "The user must enter an id to create a project version")
@@ -78,8 +78,8 @@ public class CreateProjectVersionTest extends ZanataTestCase {
 
         List<String> errors = createVersionPage.getErrors();
         assertThat(errors)
-                .contains("value is required")
-                .as("The empty value is rejected");
+                .as("The empty value is rejected")
+                .contains("value is required");
     }
 
     @Trace(summary = "The user must enter an id that starts and ends with " +
@@ -93,31 +93,31 @@ public class CreateProjectVersionTest extends ZanataTestCase {
         createVersionPage.defocus(createVersionPage.projectVersionID);
 
         assertThat(createVersionPage.getErrors())
-                .contains(CreateVersionPage.VALIDATION_ERROR)
-                .as("The input is rejected");
+                .as("The input is rejected")
+                .contains(CreateVersionPage.VALIDATION_ERROR);
 
         createVersionPage = createVersionPage.inputVersionId("B-");
         createVersionPage.defocus(createVersionPage.projectVersionID);
 
         assertThat(createVersionPage.getErrors())
-                .contains(CreateVersionPage.VALIDATION_ERROR)
-                .as("The input is rejected");
+                .as("The input is rejected")
+                .contains(CreateVersionPage.VALIDATION_ERROR);
 
         createVersionPage = createVersionPage.inputVersionId("_C_");
         createVersionPage.defocus(createVersionPage.projectVersionID);
         createVersionPage = createVersionPage.expectNumErrors(1);
 
         assertThat(createVersionPage.getErrors())
-                .contains(CreateVersionPage.VALIDATION_ERROR)
-                .as("The input is rejected");
+                .as("The input is rejected")
+                .contains(CreateVersionPage.VALIDATION_ERROR);
 
         createVersionPage = createVersionPage.inputVersionId("A-B_C");
         createVersionPage.defocus(createVersionPage.projectVersionID);
         createVersionPage = createVersionPage.expectNumErrors(0);
 
         assertThat(createVersionPage.getErrors())
-                .doesNotContain(CreateVersionPage.VALIDATION_ERROR)
-                .as("The input is acceptable");
+                .as("The input is acceptable")
+                .doesNotContain(CreateVersionPage.VALIDATION_ERROR);
     }
 
     @Trace(summary = "The system updates the project version counter " +
@@ -129,8 +129,8 @@ public class CreateProjectVersionTest extends ZanataTestCase {
         assertThat(new ProjectWorkFlow()
                 .createNewSimpleProject("version-nums", projectName)
                 .getProjectName())
-                .isEqualTo(projectName)
-                .as("The project is created");
+                .as("The project is created")
+                .isEqualTo(projectName);
 
         ProjectVersionsPage projectVersionsPage = new ProjectWorkFlow()
                 .createNewProjectVersion(projectName, "alpha")
@@ -138,8 +138,8 @@ public class CreateProjectVersionTest extends ZanataTestCase {
         projectVersionsPage.expectDisplayedVersions(1);
 
         assertThat(projectVersionsPage.getNumberOfDisplayedVersions())
-                .isEqualTo(1)
-                .as("The version count is 1");
+                .as("The version count is 1")
+                .isEqualTo(1);
 
         projectVersionsPage = new ProjectWorkFlow()
                 .createNewProjectVersion("version nums", "bravo")
@@ -147,7 +147,7 @@ public class CreateProjectVersionTest extends ZanataTestCase {
         projectVersionsPage.expectDisplayedVersions(2);
 
         assertThat(projectVersionsPage.getNumberOfDisplayedVersions())
-                .isEqualTo(2)
-                .as("The version count is 2");
+                .as("The version count is 2")
+                .isEqualTo(2);
     }
 }

--- a/server/functional-test/src/test/java/org/zanata/feature/projectversion/EditVersionLanguagesTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/projectversion/EditVersionLanguagesTest.java
@@ -59,8 +59,8 @@ public class EditVersionLanguagesTest extends ZanataTestCase {
         assertThat(new LoginWorkFlow()
                 .signIn("admin", "admin")
                 .loggedInAs())
-                .isEqualTo("admin")
-                .as("Admin user has logged in");
+                .as("Admin user has logged in")
+                .isEqualTo("admin");
 
         VersionLanguagesTab versionLanguagesTab = new ProjectWorkFlow()
                 .goToProjectByName("langoverride")
@@ -73,8 +73,8 @@ public class EditVersionLanguagesTest extends ZanataTestCase {
                 .getEnabledLocaleList();
 
         assertThat(enabledLocaleList)
-                .contains("fr", "hi", "pl")
-                .as("The enabled list contains no languages");
+                .as("The enabled list contains no languages")
+                .contains("fr", "hi", "pl");
 
         versionLanguagesTab = versionLanguagesTab
                 .gotoSettingsTab()
@@ -92,8 +92,8 @@ public class EditVersionLanguagesTest extends ZanataTestCase {
         enabledLocaleList = versionLanguagesTab.getEnabledLocaleList();
 
         assertThat(enabledLocaleList)
-                .contains("en-US", "fr", "hi", "pl")
-                .as("The languages are available to translate");
+                .as("The languages are available to translate")
+                .contains("en-US", "fr", "hi", "pl");
         versionLanguagesTab.filterEnabledLanguages("en-US")
                 .expectEnabledLocaleListCount(1);
     }

--- a/server/functional-test/src/test/java/org/zanata/feature/projectversion/EditVersionSlugTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/projectversion/EditVersionSlugTest.java
@@ -58,8 +58,8 @@ public class EditVersionSlugTest extends ZanataTestCase {
         assertThat(new LoginWorkFlow()
                 .signIn("admin", "admin")
                 .loggedInAs())
-                .isEqualTo("admin")
-                .as("Admin user has logged in");
+                .as("Admin user has logged in")
+                .isEqualTo("admin");
 
         VersionLanguagesPage versionLanguagesPage = new ProjectWorkFlow()
                 .goToProjectByName("change-version-slug")
@@ -76,7 +76,7 @@ public class EditVersionSlugTest extends ZanataTestCase {
                 .gotoSettingsTab()
                 .gotoSettingsGeneral();
         assertThat(versionGeneralTab.getVersionID())
-                .isEqualTo("newSlug")
-                .as("The version slug has been changed");
+                .as("The version slug has been changed")
+                .isEqualTo("newSlug");
     }
 }

--- a/server/functional-test/src/test/java/org/zanata/feature/projectversion/EditVersionValidationsTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/projectversion/EditVersionValidationsTest.java
@@ -131,14 +131,14 @@ public class EditVersionValidationsTest extends ZanataTestCase {
                 .openValidationOptions();
 
         assertThat(editorPage.isValidationOptionSelected(
-                        EditorPage.Validations.TABS))
-                .isTrue()
-                .as("The option is selected");
+                EditorPage.Validations.TABS))
+                .as("The option is selected")
+                .isTrue();
 
         assertThat(editorPage.isValidationOptionAvailable(
-                        EditorPage.Validations.TABS))
-                .isFalse()
-                .as("The option is unavailable");
+                EditorPage.Validations.TABS))
+                .as("The option is unavailable")
+                .isFalse();
     }
 
     @Trace(summary = "The user cannot select both printf formats for " +
@@ -158,13 +158,14 @@ public class EditVersionValidationsTest extends ZanataTestCase {
         //        "Updated validation Positional printf (XSI extension) to Error.");
 
         assertThat(versionTranslationTab
-                .isValidationLevel("Positional printf (XSI extension)", "Error"))
-                .isTrue()
-                .as("The Positional printf level is Error");
+                .isValidationLevel("Positional printf (XSI extension)",
+                        "Error"))
+                .as("The Positional printf level is Error")
+                .isTrue();
         assertThat(versionTranslationTab
                 .isValidationLevel("Printf variables", "Off"))
-                .isTrue()
-                .as("The Printf level is Off");
+                .as("The Printf level is Off")
+                .isTrue();
 
         versionTranslationTab.setValidationLevel("Printf variables", "Error");
 
@@ -174,12 +175,12 @@ public class EditVersionValidationsTest extends ZanataTestCase {
 
         assertThat(versionTranslationTab
                 .isValidationLevel("Printf variables", "Error"))
-                .isTrue()
-                .as("The Printf level is Error");
+                .as("The Printf level is Error")
+                .isTrue();
         assertThat(versionTranslationTab
                 .isValidationLevel("Positional printf (XSI extension)", "Off"))
-                .isTrue()
-                .as("The Positional printf level is Off");
+                .as("The Positional printf level is Off")
+                .isTrue();
     }
 
     @Trace(summary = "The user can turn on a disabled validation option")

--- a/server/functional-test/src/test/java/org/zanata/feature/projectversion/VersionFilteringTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/projectversion/VersionFilteringTest.java
@@ -59,33 +59,35 @@ public class VersionFilteringTest extends ZanataTestCase {
         assertThat(new LoginWorkFlow()
                 .signIn("translator", "translator")
                 .loggedInAs())
-                .isEqualTo("translator")
-                .as("Login as translator");
+                .as("Login as translator")
+                .isEqualTo("translator");
 
         ProjectVersionsPage projectVersionsPage = new ProjectWorkFlow()
                 .goToProjectByName(projectName)
                 .expectDisplayedVersions(2);
 
-        assertVersions(projectVersionsPage, 2, new String[]{"bravo", "alpha"});
+        assertVersions(projectVersionsPage, 2,
+                new String[]{ "bravo", "alpha" });
 
         projectVersionsPage = projectVersionsPage
                 .clickSearchIcon()
                 .enterVersionSearch("alpha")
                 .expectDisplayedVersions(1);
 
-        assertVersions(projectVersionsPage, 1, new String[]{"alpha"});
+        assertVersions(projectVersionsPage, 1, new String[]{ "alpha" });
 
         projectVersionsPage = projectVersionsPage
                 .clearVersionSearch()
                 .expectDisplayedVersions(2);
 
-        assertVersions(projectVersionsPage, 2, new String[]{"bravo", "alpha"});
+        assertVersions(projectVersionsPage, 2,
+                new String[]{ "bravo", "alpha" });
 
         projectVersionsPage = projectVersionsPage
                 .enterVersionSearch("bravo")
                 .expectDisplayedVersions(1);
 
-        assertVersions(projectVersionsPage, 1, new String[]{"bravo"});
+        assertVersions(projectVersionsPage, 1, new String[]{ "bravo" });
 
         projectVersionsPage.waitForPageSilence();
         projectVersionsPage = projectVersionsPage
@@ -100,18 +102,19 @@ public class VersionFilteringTest extends ZanataTestCase {
                 .clearVersionSearch()
                 .expectDisplayedVersions(2);
 
-        assertVersions(projectVersionsPage, 2, new String[]{"bravo", "alpha"});
+        assertVersions(projectVersionsPage, 2,
+                new String[]{ "bravo", "alpha" });
     }
 
     private void assertVersions(ProjectVersionsPage page,
                                 int versionsCount,
                                 String[] versionNames) {
         assertThat(page.getNumberOfDisplayedVersions())
-                .isEqualTo(versionsCount)
-                .as("The version count is " + versionsCount);
+                .as("The version count is " + versionsCount)
+                .isEqualTo(versionsCount);
 
         assertThat(page.getVersions())
-                .contains(versionNames)
-                .as("The versions are correct");
+                .as("The versions are correct")
+                .contains(versionNames);
     }
 }

--- a/server/functional-test/src/test/java/org/zanata/feature/search/PersonSearchTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/search/PersonSearchTest.java
@@ -50,10 +50,11 @@ public class PersonSearchTest extends ZanataTestCase {
                 .expectPersonListContains("translator");
 
         assertThat(explorePage.getUserSearchResults())
-                .contains("translator")
-                .as("Normal user can see the person listed");
+                .as("Normal user can see the person listed")
+                .contains("translator");
 
-        ProfilePage profilePage = explorePage.clickUserSearchEntry("translator");
+        ProfilePage profilePage =
+                explorePage.clickUserSearchEntry("translator");
 
         assertThat(profilePage.getUsername().trim())
                 .isEqualTo("translator");
@@ -71,8 +72,8 @@ public class PersonSearchTest extends ZanataTestCase {
                 .enterSearch("snart");
 
         assertThat(explorePage.getUserSearchResults().isEmpty())
-                .isTrue()
-                .as("The user is not displayed");
+                .as("The user is not displayed")
+                .isTrue();
     }
 
     @Trace(summary = "The user can access another user's profile via the URL")
@@ -100,7 +101,7 @@ public class PersonSearchTest extends ZanataTestCase {
                 .clickUserSearchEntry("translator");
 
         assertThat(profilePage.expectContributionsMatrixVisible())
-                .isTrue()
-                .as("A logged in user can see the user's contributions");
+                .as("A logged in user can see the user's contributions")
+                .isTrue();
     }
 }

--- a/server/functional-test/src/test/java/org/zanata/feature/search/ProjectSearchTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/search/ProjectSearchTest.java
@@ -50,15 +50,15 @@ public class ProjectSearchTest extends ZanataTestCase {
                 .expectProjectListContains("about fedora");
 
         assertThat(explorePage.getProjectSearchResults())
-                .contains("about fedora")
-                .as("Normal user can see the project");
+                .as("Normal user can see the project")
+                .contains("about fedora");
 
         ProjectBasePage projectPage =
-            explorePage.clickProjectEntry("about fedora");
+                explorePage.clickProjectEntry("about fedora");
 
         assertThat(projectPage.getProjectName().trim())
-                .isEqualTo("about fedora")
-                .as("The project page is the correct one");
+                .as("The project page is the correct one")
+                .isEqualTo("about fedora");
     }
 
     @Trace(summary = "The system will provide no results on an " +
@@ -71,8 +71,8 @@ public class ProjectSearchTest extends ZanataTestCase {
                 .enterSearch("arodef");
 
         assertThat(explorePage.getProjectSearchResults().isEmpty())
-                .isTrue()
-                .as("No projects are displayed");
+                .as("No projects are displayed")
+                .isTrue();
     }
 
     @Trace(summary = "The user cannot search for Deleted projects")
@@ -94,8 +94,8 @@ public class ProjectSearchTest extends ZanataTestCase {
                 .enterSearch("about");
 
         assertThat(explorePage.getProjectSearchResults().isEmpty())
-            .isTrue()
-            .as("No projects are displayed");
+                .as("No projects are displayed")
+                .isTrue();
     }
 
 }

--- a/server/functional-test/src/test/java/org/zanata/feature/search/comp/ExploreCTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/search/comp/ExploreCTest.java
@@ -45,8 +45,8 @@ public class ExploreCTest extends ZanataTestCase {
                 .gotoExplore()
                 .enterSearch("abcde");
         assertThat(explorePage.isCancelButtonEnabled())
-                .isTrue()
-                .as("Cancel button is enabled after search");
+                .as("Cancel button is enabled after search")
+                .isTrue();
     }
 
     @Test(timeout = MAX_SHORT_TEST_DURATION)
@@ -57,7 +57,7 @@ public class ExploreCTest extends ZanataTestCase {
                 .enterSearch("abcde")
                 .clearSearch();
         assertThat(explorePage.isSearchFieldCleared())
-                .isTrue()
-                .as("Able clear the search field");
+                .as("Able clear the search field")
+                .isTrue();
     }
 }

--- a/server/functional-test/src/test/java/org/zanata/feature/search/comp/GroupSearchCTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/search/comp/GroupSearchCTest.java
@@ -44,8 +44,8 @@ public class GroupSearchCTest extends ZanataTestCase {
         String groupID = "basic-group";
         String groupName = "A Basic Group";
         assertThat(new LoginWorkFlow().signIn("admin", "admin").loggedInAs())
-                .isEqualTo("admin")
-                .as("Admin is logged in");
+                .as("Admin is logged in")
+                .isEqualTo("admin");
 
         new BasicWorkFlow().goToHome()
                 .goToMyDashboard()
@@ -63,10 +63,11 @@ public class GroupSearchCTest extends ZanataTestCase {
                 .expectGroupListContains(groupName);
 
         assertThat(explorePage.getGroupSearchResults())
-                .contains(groupName)
-                .as("Normal user can see the group listed");
+                .as("Normal user can see the group listed")
+                .contains(groupName);
 
-        VersionGroupPage versionGroupPage = explorePage.clickGroupSearchEntry(groupName);
+        VersionGroupPage versionGroupPage =
+                explorePage.clickGroupSearchEntry(groupName);
 
         assertThat(versionGroupPage.getGroupName().trim())
                 .isEqualTo(groupName);
@@ -80,7 +81,7 @@ public class GroupSearchCTest extends ZanataTestCase {
                 .enterSearch("groop");
 
         assertThat(explorePage.getGroupSearchResults().isEmpty())
-                .isTrue()
-                .as("The group is not displayed");
+                .as("The group is not displayed")
+                .isTrue();
     }
 }

--- a/server/functional-test/src/test/java/org/zanata/feature/search/comp/LanguageSearchCTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/search/comp/LanguageSearchCTest.java
@@ -46,8 +46,8 @@ public class LanguageSearchCTest extends ZanataTestCase {
                 .expectLanguageTeamListContains("English (United States)");
 
         assertThat(explorePage.getLanguageSearchResults())
-                .contains("English (United States)")
-                .as("Normal user can see the languages listed");
+                .as("Normal user can see the languages listed")
+                .contains("English (United States)");
     }
 
     @Test(timeout = MAX_SHORT_TEST_DURATION)
@@ -58,7 +58,7 @@ public class LanguageSearchCTest extends ZanataTestCase {
                 .enterSearch("abc");
 
         assertThat(explorePage.getLanguageSearchResults().isEmpty())
-                .isTrue()
-                .as("The Language is not displayed");
+                .as("The Language is not displayed")
+                .isTrue();
     }
 }

--- a/server/functional-test/src/test/java/org/zanata/feature/security/SecurityTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/security/SecurityTest.java
@@ -60,8 +60,8 @@ public class SecurityTest extends ZanataTestCase {
         assertThat(new LoginWorkFlow()
                 .signIn("admin", "admin")
                 .loggedInAs())
-                .isEqualTo("admin")
-                .as("User can log in");
+                .as("User can log in")
+                .isEqualTo("admin");
     }
 
     @Trace(summary = "The user must enter a correct username and " +
@@ -72,8 +72,8 @@ public class SecurityTest extends ZanataTestCase {
         assertThat(new LoginWorkFlow()
                 .signInFailure("nosuchuser", "password")
                 .expectError("Login failed"))
-                .contains("Login failed")
-                .as("Log in error message is shown");
+                .as("Log in error message is shown")
+                .contains("Login failed");
     }
 
     @Trace(summary = "The user may reset their password via email",
@@ -131,9 +131,9 @@ public class SecurityTest extends ZanataTestCase {
                 .resetFailure();
 
         assertThat(resetPasswordPage.getNotificationMessage(By
-                        .id("passwordResetRequestForm:messages")))
-                .isEqualTo("No account found.")
-                .as("A no such account message is displayed");
+                .id("passwordResetRequestForm:messages")))
+                .as("A no such account message is displayed")
+                .isEqualTo("No account found.");
     }
 
     @Trace(summary = "Username or email field must not empty")
@@ -147,8 +147,8 @@ public class SecurityTest extends ZanataTestCase {
                 .resetFailure();
 
         assertThat(resetPasswordPage.getErrors())
-                .contains("value is required")
-                .as("value is required error is displayed");
+                .as("value is required error is displayed")
+                .contains("value is required");
     }
 
 }

--- a/server/functional-test/src/test/java/org/zanata/feature/versionGroup/VersionGroupTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/versionGroup/VersionGroupTest.java
@@ -47,10 +47,11 @@ public class VersionGroupTest extends ZanataTestCase {
     @Before
     public void before() {
         assertThat(new LoginWorkFlow().signIn("admin", "admin").loggedInAs())
-                .isEqualTo("admin")
-                .as("Admin is logged in");
+                .as("Admin is logged in")
+                .isEqualTo("admin");
         dashboardGroupsTab =
-            new BasicWorkFlow().goToHome().goToMyDashboard().gotoGroupsTab();
+                new BasicWorkFlow().goToHome().goToMyDashboard()
+                        .gotoGroupsTab();
     }
 
     @Trace(summary = "The administrator can create a basic group")
@@ -59,15 +60,15 @@ public class VersionGroupTest extends ZanataTestCase {
         String groupID = "basic-group";
         String groupName = "A Basic Group";
         VersionGroupPage versionGroupPage = dashboardGroupsTab
-            .createNewGroup()
-            .inputGroupId(groupID)
-            .inputGroupName(groupName)
-            .inputGroupDescription("A basic group can be saved")
-            .saveGroup();
+                .createNewGroup()
+                .inputGroupId(groupID)
+                .inputGroupName(groupName)
+                .inputGroupDescription("A basic group can be saved")
+                .saveGroup();
 
         assertThat(versionGroupPage.getGroupName().trim())
-            .isEqualTo(groupName)
-            .as("The group name is correct");
+                .as("The group name is correct")
+                .isEqualTo(groupName);
     }
 
     @Trace(summary = "The administrator must fill in the required fields " +
@@ -83,24 +84,24 @@ public class VersionGroupTest extends ZanataTestCase {
                 .saveGroupFailure();
 
         assertThat(groupPage.getErrors())
-                .contains(errorMsg, errorMsg)
-                .as("The two errors are value is required");
+                .as("The two errors are value is required")
+                .contains(errorMsg, errorMsg);
 
         groupPage = groupPage.clearFields()
                 .inputGroupName(groupName)
                 .saveGroupFailure();
 
         assertThat(groupPage.getErrors())
-                .contains(errorMsg)
-                .as("The value required error shown");
+                .as("The value required error shown")
+                .contains(errorMsg);
 
         groupPage = groupPage.clearFields()
                 .inputGroupId(groupID)
                 .saveGroupFailure();
 
         assertThat(groupPage.getErrors())
-                .contains(errorMsg)
-                .as("The value required error shown");
+                .as("The value required error shown")
+                .contains(errorMsg);
     }
 
     @Trace(summary = "The administrator must enter valid data into the " +
@@ -123,20 +124,20 @@ public class VersionGroupTest extends ZanataTestCase {
                 .saveGroupFailure();
 
         assertThat(groupPage.getErrors())
-                .contains(CreateVersionGroupPage.LENGTH_ERROR)
-                .as("Invalid length error is shown");
+                .as("Invalid length error is shown")
+                .contains(CreateVersionGroupPage.LENGTH_ERROR);
 
         groupDescription = groupDescription.substring(0, 100);
         VersionGroupPage versionGroupPage = groupPage
-            .clearFields()
-            .inputGroupId("verifyDescriptionFieldSizeID")
-            .inputGroupName(groupName)
-            .inputGroupDescription(groupDescription)
-            .saveGroup();
+                .clearFields()
+                .inputGroupId("verifyDescriptionFieldSizeID")
+                .inputGroupName(groupName)
+                .inputGroupDescription(groupDescription)
+                .saveGroup();
 
         assertThat(versionGroupPage.getGroupName().trim())
-            .isEqualTo(groupName)
-            .as("A group description of 100 chars is valid");
+                .as("A group description of 100 chars is valid")
+                .isEqualTo(groupName);
     }
 
     @Trace(summary = "The administrator can add a project version to " +
@@ -157,8 +158,8 @@ public class VersionGroupTest extends ZanataTestCase {
                 .clickProjectsTab();
 
         assertThat(versionGroupPage.getProjectVersionsInGroup())
-                .contains("about fedora\nmaster")
-                .as("The version group shows in the list");
+                .as("The version group shows in the list")
+                .contains("about fedora\nmaster");
     }
 
     @Trace(summary = "The administrator can use numbers, letters, periods, " +
@@ -174,8 +175,8 @@ public class VersionGroupTest extends ZanataTestCase {
                 .saveGroup();
 
         assertThat(versionGroupPage.getGroupName())
-                .isEqualTo(groupName)
-                .as("The group was created");
+                .as("The group was created")
+                .isEqualTo(groupName);
     }
 
     @Trace(summary = "The administrator must use numbers, letters, periods, "
@@ -191,8 +192,8 @@ public class VersionGroupTest extends ZanataTestCase {
         groupPage.saveGroupFailure();
 
         assertThat(groupPage.getErrors())
-                .contains(CreateVersionGroupPage.VALIDATION_ERROR)
-                .as("Validation error is displayed for " + inputText);
+                .as("Validation error is displayed for " + inputText)
+                .contains(CreateVersionGroupPage.VALIDATION_ERROR);
     }
 
     @Test

--- a/server/functional-test/src/test/java/org/zanata/feature/versionGroup/VersionGroupUrlTest.java
+++ b/server/functional-test/src/test/java/org/zanata/feature/versionGroup/VersionGroupUrlTest.java
@@ -49,10 +49,9 @@ public class VersionGroupUrlTest extends ZanataTestCase {
 
     @Before
     public void before() {
-        assertThat(
-                new LoginWorkFlow().signIn("admin", "admin").loggedInAs())
-                .isEqualTo("admin")
-                .as("Admin is logged in");
+        assertThat(new LoginWorkFlow().signIn("admin", "admin").loggedInAs())
+                .as("Admin is logged in")
+                .isEqualTo("admin");
     }
 
     @Test(timeout = ZanataTestCase.MAX_SHORT_TEST_DURATION)

--- a/server/gwt-editor/src/test/java/org/zanata/webtrans/client/history/HistoryTokenTest.java
+++ b/server/gwt-editor/src/test/java/org/zanata/webtrans/client/history/HistoryTokenTest.java
@@ -24,16 +24,18 @@ public class HistoryTokenTest {
     public void constructionSetsDefaults() {
         token = new HistoryToken();
 
-        assertThat(MainView.Documents).isEqualTo(token.getView())
-                .as("default view should be document list");
+        assertThat(MainView.Documents)
+                .as("default view should be document list")
+                .isEqualTo(token.getView());
         assertThat(token.getDocumentPath())
                 .as("default document path should be an empty string")
                 .isEqualTo("");
         assertThat(token.getDocFilterText())
                 .as("default document filter text should be an empty string")
                 .isEqualTo("");
-        assertThat(token.getDocFilterExact()).isFalse()
-                .as("default document filter exact match flag should be false");
+        assertThat(token.getDocFilterExact())
+                .as("default document filter exact match flag should be false")
+                .isFalse();
         assertThat(token.getEditorTextSearch())
                 .as("default search text should be null").isNull();
         assertThat(token.getProjectSearchText())
@@ -42,8 +44,9 @@ public class HistoryTokenTest {
         assertThat(token.getProjectSearchReplacement())
                 .as("default project-wide search replacement text should be an empty string")
                 .isEqualTo("");
-        assertThat(token.getProjectSearchCaseSensitive()).isFalse()
-                .as("default project-wide search case sensitive flag should be false");
+        assertThat(token.getProjectSearchCaseSensitive())
+                .as("default project-wide search case sensitive flag should be false")
+                .isFalse();
         assertThat(token.getTextFlowId()).isNull();
         assertThat(token.isFilterTranslated()).isFalse();
         assertThat(token.isFilterUntranslated()).isFalse();
@@ -57,21 +60,29 @@ public class HistoryTokenTest {
     public void fromEmptyStringSetsDefaults() {
         token = HistoryToken.fromTokenString("");
 
-        assertThat(token.getView()).isEqualTo(MainView.Documents)
-                .as("default view should be document list");
-        assertThat(token.getDocumentPath()).isEqualTo("")
-                .as("default document path should be an empty string");
-        assertThat(token.getDocFilterText()).isEqualTo("")
-                .as("default document filter text should be an empty string");
-        assertThat(token.getDocFilterExact()).isFalse()
-                .as("default document filter exact match flag should be false");
-        assertThat(token.getEditorTextSearch()).as("default search text should be null").isNull();
-        assertThat(token.getProjectSearchText()).isEqualTo("").as(
-                "default project-wide search text should be an empty string");
-        assertThat(token.getProjectSearchReplacement()).isEqualTo("")
-                .as("default project-wide search replacement text should be an empty string");
-        assertThat(token.getProjectSearchCaseSensitive()).isFalse()
-                .as("default project-wide search case sensitive flag should be false");
+        assertThat(token.getView())
+                .as("default view should be document list")
+                .isEqualTo(MainView.Documents);
+        assertThat(token.getDocumentPath())
+                .as("default document path should be an empty string")
+                .isEqualTo("");
+        assertThat(token.getDocFilterText())
+                .as("default document filter text should be an empty string")
+                .isEqualTo("");
+        assertThat(token.getDocFilterExact())
+                .as("default document filter exact match flag should be false")
+                .isFalse();
+        assertThat(token.getEditorTextSearch())
+                .as("default search text should be null").isNull();
+        assertThat(token.getProjectSearchText())
+                .as("default project-wide search text should be an empty string")
+                .isEqualTo("");
+        assertThat(token.getProjectSearchReplacement())
+                .as("default project-wide search replacement text should be an empty string")
+                .isEqualTo("");
+        assertThat(token.getProjectSearchCaseSensitive())
+                .as("default project-wide search case sensitive flag should be false")
+                .isFalse();
         assertThat(token.getTextFlowId()).isNull();
         assertThat(token.isFilterTranslated()).isFalse();
         assertThat(token.isFilterUntranslated()).isFalse();
@@ -85,22 +96,29 @@ public class HistoryTokenTest {
     public void fromNullStringSetsDefaults() {
         token = HistoryToken.fromTokenString(null);
 
-        assertThat(token.getView()).isEqualTo(MainView.Documents)
-                .as("default view should be document list");
-        assertThat(token.getDocumentPath()).isEqualTo("")
-                .as("default document path should be an empty string");
-        assertThat(token.getDocFilterText()).isEqualTo("")
-                .as("default document filter text should be an empty string");
-        assertThat(token.getDocFilterExact()).isFalse()
-                .as("default document filter exact match flag should be false");
+        assertThat(token.getView())
+                .as("default view should be document list")
+                .isEqualTo(MainView.Documents);
+        assertThat(token.getDocumentPath())
+                .as("default document path should be an empty string")
+                .isEqualTo("");
+        assertThat(token.getDocFilterText())
+                .as("default document filter text should be an empty string")
+                .isEqualTo("");
+        assertThat(token.getDocFilterExact())
+                .as("default document filter exact match flag should be false")
+                .isFalse();
         assertThat(token.getEditorTextSearch())
                 .as("default search text should be null").isNull();
-        assertThat(token.getProjectSearchText()).isEqualTo("")
-                .as("default project-wide search text should be an empty string");
-        assertThat(token.getProjectSearchReplacement()).isEqualTo("")
-                .as("default project-wide search replacement text should be an empty string");
-        assertThat(token.getProjectSearchCaseSensitive()).isFalse()
-                .as("default project-wide search case sensitive flag should be false");
+        assertThat(token.getProjectSearchText())
+                .as("default project-wide search text should be an empty string")
+                .isEqualTo("");
+        assertThat(token.getProjectSearchReplacement())
+                .as("default project-wide search replacement text should be an empty string")
+                .isEqualTo("");
+        assertThat(token.getProjectSearchCaseSensitive())
+                .as("default project-wide search case sensitive flag should be false")
+                .isFalse();
         assertThat(token.getTextFlowId()).isNull();
         assertThat(token.isFilterTranslated()).isFalse();
         assertThat(token.isFilterUntranslated()).isFalse();
@@ -117,14 +135,18 @@ public class HistoryTokenTest {
 
         token = HistoryToken.fromTokenString(tokenString);
 
-        assertThat(token.getView()).isEqualTo(MainView.Editor)
-                .as("view should be set from token string");
-        assertThat(token.getDocumentPath()).isEqualTo("some/document")
-                .as("document path should be set from token string");
-        assertThat(token.getDocFilterText()).isEqualTo("myfilter")
-                .as("document filter text should be set from token string");
-        assertThat(token.getDocFilterExact()).isTrue()
-                .as("document filter exact match flag should be set from token string");
+        assertThat(token.getView())
+                .as("view should be set from token string")
+                .isEqualTo(MainView.Editor);
+        assertThat(token.getDocumentPath())
+                .as("document path should be set from token string")
+                .isEqualTo("some/document");
+        assertThat(token.getDocFilterText())
+                .as("document filter text should be set from token string")
+                .isEqualTo("myfilter");
+        assertThat(token.getDocFilterExact())
+                .as("document filter exact match flag should be set from token string")
+                .isTrue();
     }
 
     @Test
@@ -134,14 +156,18 @@ public class HistoryTokenTest {
 
         token = HistoryToken.fromTokenString(tokenString);
 
-        assertThat(token.getEditorTextSearch()).isEqualTo("searchtext")
-                .as("search text should be set from token string");
-        assertThat(token.getProjectSearchText()).isEqualTo("projectsearchtext")
-                .as("project-wide search text should be set from token string");
-        assertThat(token.getProjectSearchReplacement()).isEqualTo("replacementtext")
-                .as("project-wide search replacement text should be set from token string");
-        assertThat(token.getProjectSearchCaseSensitive()).isTrue()
-                .as("project-wide search case sensitivity should be set from token string");
+        assertThat(token.getEditorTextSearch())
+                .as("search text should be set from token string")
+                .isEqualTo("searchtext");
+        assertThat(token.getProjectSearchText())
+                .as("project-wide search text should be set from token string")
+                .isEqualTo("projectsearchtext");
+        assertThat(token.getProjectSearchReplacement())
+                .as("project-wide search replacement text should be set from token string")
+                .isEqualTo("replacementtext");
+        assertThat(token.getProjectSearchCaseSensitive())
+                .as("project-wide search case sensitivity should be set from token string")
+                .isTrue();
     }
 
     @Test
@@ -151,14 +177,18 @@ public class HistoryTokenTest {
 
         token = HistoryToken.fromTokenString(differentOrderTokenString);
 
-        assertThat(token.getView()).isEqualTo(MainView.Editor)
-                .as("view should be set from any position in token string");
-        assertThat(token.getDocumentPath()).isEqualTo("some/document")
-                .as("document path should be set from any position in token string");
-        assertThat(token.getDocFilterText()).isEqualTo("myfilter")
-                .as("document filter text should be set from any position in token string");
-        assertThat(token.getDocFilterExact()).isTrue()
-                .as("document filter exact match flag should be set from any position in token string");
+        assertThat(token.getView())
+                .as("view should be set from any position in token string")
+                .isEqualTo(MainView.Editor);
+        assertThat(token.getDocumentPath())
+                .as("document path should be set from any position in token string")
+                .isEqualTo("some/document");
+        assertThat(token.getDocFilterText())
+                .as("document filter text should be set from any position in token string")
+                .isEqualTo("myfilter");
+        assertThat(token.getDocFilterExact())
+                .as("document filter exact match flag should be set from any position in token string")
+                .isTrue();
     }
 
     @Test
@@ -168,15 +198,18 @@ public class HistoryTokenTest {
 
         token = HistoryToken.fromTokenString(differentOrderTokenString);
 
-        assertThat(token.getEditorTextSearch()).isEqualTo("searchtext")
-                .as("search text should be set from any position in token string");
-        assertThat(token.getProjectSearchText()).isEqualTo("projectsearchtext")
-                .as("project-wide search text should be set from any position in token string");
+        assertThat(token.getEditorTextSearch())
+                .as("search text should be set from any position in token string")
+                .isEqualTo("searchtext");
+        assertThat(token.getProjectSearchText())
+                .as("project-wide search text should be set from any position in token string")
+                .isEqualTo("projectsearchtext");
         assertThat(token.getProjectSearchReplacement())
-                .isEqualTo("replacementtext")
-                .as("project-wide search replacement text should be set from any position in token string");
-        assertThat(token.getProjectSearchCaseSensitive()).isTrue().as(
-                "project-wide search case sensitivity should be set from any position in token string");
+                .as("project-wide search replacement text should be set from any position in token string")
+                .isEqualTo("replacementtext");
+        assertThat(token.getProjectSearchCaseSensitive())
+                .as("project-wide search case sensitivity should be set from any position in token string")
+                .isTrue();
     }
 
     @Test
@@ -205,22 +238,29 @@ public class HistoryTokenTest {
         token = HistoryToken.fromTokenString(unknownTokensString);
 
         // should be using defaults as there are no known keys
-        assertThat(token.getView()).isEqualTo(MainView.Documents)
-                .as("unknown keys should be ignored");
-        assertThat(token.getDocumentPath()).isEqualTo("")
-                .as("unknown keys should be ignored");
-        assertThat(token.getDocFilterText()).isEqualTo("")
-                .as("unknown keys should be ignored");
-        assertThat(token.getDocFilterExact()).isFalse()
-                .as("unknown keys should be ignored");
+        assertThat(token.getView())
+                .as("unknown keys should be ignored")
+                .isEqualTo(MainView.Documents);
+        assertThat(token.getDocumentPath())
+                .as("unknown keys should be ignored")
+                .isEqualTo("");
+        assertThat(token.getDocFilterText())
+                .as("unknown keys should be ignored")
+                .isEqualTo("");
+        assertThat(token.getDocFilterExact())
+                .as("unknown keys should be ignored")
+                .isFalse();
         assertThat(token.getEditorTextSearch())
                 .as("unknown keys should be ignored").isNull();
-        assertThat(token.getProjectSearchText()).isEqualTo("")
-                .as("unknown keys should be ignored");
-        assertThat(token.getProjectSearchReplacement()).isEqualTo("")
-                .as("unknown keys should be ignored");
-        assertThat(token.getProjectSearchCaseSensitive()).isFalse()
-                .as("unknown keys should be ignored");
+        assertThat(token.getProjectSearchText())
+                .as("unknown keys should be ignored")
+                .isEqualTo("");
+        assertThat(token.getProjectSearchReplacement())
+                .as("unknown keys should be ignored")
+                .isEqualTo("");
+        assertThat(token.getProjectSearchCaseSensitive())
+                .as("unknown keys should be ignored")
+                .isFalse();
     }
 
     @Test
@@ -234,8 +274,9 @@ public class HistoryTokenTest {
 
         token.setView(MainView.Editor);
         token.setView(null);
-        assertThat(token.getView()).isEqualTo(MainView.Documents)
-                .as("view should reset to default if set to null value");
+        assertThat(token.getView())
+                .as("view should reset to default if set to null value")
+                .isEqualTo(MainView.Documents);
     }
 
     @Test
@@ -246,28 +287,34 @@ public class HistoryTokenTest {
         assertThat(token.getDocumentPath()).isEqualTo("new/document/path");
 
         token.setDocumentPath(null);
-        assertThat(token.getDocumentPath()).isEqualTo("")
-                .as("document path should be set to empty string if null is given");
+        assertThat(token.getDocumentPath())
+                .as("document path should be set to empty string if null is given")
+                .isEqualTo("");
 
         token.setDocumentPath("random/path");
         token.setDocumentPath("");
-        assertThat(token.getDocumentPath()).isEqualTo("")
-                .as("document path can be set to empty string");
+        assertThat(token.getDocumentPath())
+                .as("document path can be set to empty string")
+                .isEqualTo("");
     }
 
     @Test
     public void getSetFilterText() {
         token = new HistoryToken();
         token.setDocFilterText("filter/text, more/filter/text, foo");
-        assertThat(token.getDocFilterText()).isEqualTo("filter/text, more/filter/text, foo");
+        assertThat(token.getDocFilterText())
+                .isEqualTo("filter/text, more/filter/text, foo");
 
         token.setDocFilterText(null);
-        assertThat(token.getDocFilterText()).isEqualTo("").as(
-                "filter text should be returned as empty string after setting to null");
+        assertThat(token.getDocFilterText())
+                .as("filter text should be returned as empty string after setting to null")
+                .isEqualTo("");
 
         token.setDocFilterText("some filter text");
         token.setDocFilterText("");
-        assertThat(token.getDocFilterText()).isEqualTo("").as("filter text can be set to empty string");
+        assertThat(token.getDocFilterText())
+                .as("filter text can be set to empty string")
+                .isEqualTo("");
     }
 
     @Test
@@ -299,16 +346,19 @@ public class HistoryTokenTest {
     public void getSetProjectSearchText() {
         token = new HistoryToken();
         token.setProjectSearchText("some project search text");
-        assertThat(token.getProjectSearchText()).isEqualTo("some project search text");
+        assertThat(token.getProjectSearchText())
+                .isEqualTo("some project search text");
 
         token.setProjectSearchText(null);
-        assertThat(token.getProjectSearchText()).isEqualTo("").as(
-                "project search text should be returned as empty string after setting to null");
+        assertThat(token.getProjectSearchText())
+                .as("project search text should be returned as empty string after setting to null")
+                .isEqualTo("");
 
         token.setProjectSearchText("text to be discarded");
         token.setProjectSearchText("");
-        assertThat(token.getProjectSearchText()).isEqualTo("")
-                .as("project search text can be set to empty string");
+        assertThat(token.getProjectSearchText())
+                .as("project search text can be set to empty string")
+                .isEqualTo("");
     }
 
     @Test
@@ -342,16 +392,18 @@ public class HistoryTokenTest {
     public void encodesColon() {
         token = new HistoryToken();
         token.setProjectSearchText("test:test");
-        assertThat(token.toTokenString()).isEqualTo("projectsearch:test!ctest")
-                .as("Colons should be replaced with \"!c\" in the token string");
+        assertThat(token.toTokenString())
+                .as("Colons should be replaced with \"!c\" in the token string")
+                .isEqualTo("projectsearch:test!ctest");
     }
 
     @Test
     public void encodesSemicolon() {
         token = new HistoryToken();
         token.setProjectSearchText("test;test");
-        assertThat(token.toTokenString()).isEqualTo("projectsearch:test!stest")
-                .as("Semicolons should be replaced with \"!s\" in the token string");
+        assertThat(token.toTokenString())
+                .as("Semicolons should be replaced with \"!s\" in the token string")
+                .isEqualTo("projectsearch:test!stest");
     }
 
     @Test
@@ -360,8 +412,9 @@ public class HistoryTokenTest {
 
         String tokenString = token.toTokenString();
 
-        assertThat(tokenString.length()).isEqualTo(0)
-                .as("output token string should not contain default values");
+        assertThat(tokenString.length())
+                .as("output token string should not contain default values")
+                .isEqualTo(0);
     }
 
     @Test
@@ -408,23 +461,30 @@ public class HistoryTokenTest {
         token = null;
         token = HistoryToken.fromTokenString(tokenString);
 
-        assertThat(token.getView()).isEqualTo(MainView.Editor)
-                .as("view should survive a round-trip to and from token string");
-        assertThat(token.getDocumentPath()).isEqualTo("some/document")
-                .as("document path should survive a round-trip to and from token string");
-        assertThat(token.getDocFilterText()).isEqualTo("myfilter")
-                .as("document filter text should survive a round-trip to and from token string");
-        assertThat(token.getDocFilterExact()).isTrue()
-                .as("document filter exact match flag should survive a round-trip to and from token string");
-        assertThat(token.getEditorTextSearch()).isEqualTo("searchtext")
-                .as("search text should survive a round-trip to and from token string");
-        assertThat(token.getProjectSearchText()).isEqualTo("projectsearchtext")
-                .as("project-wide search text should survive a round-trip to and from token string");
+        assertThat(token.getView())
+                .as("view should survive a round-trip to and from token string")
+                .isEqualTo(MainView.Editor);
+        assertThat(token.getDocumentPath())
+                .as("document path should survive a round-trip to and from token string")
+                .isEqualTo("some/document");
+        assertThat(token.getDocFilterText())
+                .as("document filter text should survive a round-trip to and from token string")
+                .isEqualTo("myfilter");
+        assertThat(token.getDocFilterExact())
+                .as("document filter exact match flag should survive a round-trip to and from token string")
+                .isTrue();
+        assertThat(token.getEditorTextSearch())
+                .as("search text should survive a round-trip to and from token string")
+                .isEqualTo("searchtext");
+        assertThat(token.getProjectSearchText())
+                .as("project-wide search text should survive a round-trip to and from token string")
+                .isEqualTo("projectsearchtext");
         assertThat(token.getProjectSearchReplacement())
-                .isEqualTo("replacementtext")
-                .as("project-wide search replacement text should survive a round-trip to and from token string");
-        assertThat(token.getProjectSearchCaseSensitive()).isTrue().as(
-                "project-wide search case sensitivity should survive a round-trip to and from token string");
+                .as("project-wide search replacement text should survive a round-trip to and from token string")
+                .isEqualTo("replacementtext");
+        assertThat(token.getProjectSearchCaseSensitive())
+                .as("project-wide search case sensitivity should survive a round-trip to and from token string")
+                .isTrue();
     }
 
     @Test
@@ -442,19 +502,21 @@ public class HistoryTokenTest {
         token = HistoryToken.fromTokenString(tokenString);
 
         assertThat(token.getDocumentPath())
-                .isEqualTo("some:document;with!encodedchars")
-                .as("encodable characters in document path should survive a round-trip to and from token string");
+                .as("encodable characters in document path should survive a round-trip to and from token string")
+                .isEqualTo("some:document;with!encodedchars");
 
-        assertThat(token.getDocFilterText()).isEqualTo("my!fil:ter;")
-                .as("encodable characters in document filter text should survive a round-trip to and from token string");
-        assertThat(token.getEditorTextSearch()).isEqualTo(":search!text;")
-                .as("encodable characters in search text should survive a round-trip to and from token string");
+        assertThat(token.getDocFilterText())
+                .as("encodable characters in document filter text should survive a round-trip to and from token string")
+                .isEqualTo("my!fil:ter;");
+        assertThat(token.getEditorTextSearch())
+                .as("encodable characters in search text should survive a round-trip to and from token string")
+                .isEqualTo(":search!text;");
         assertThat(token.getProjectSearchText())
-                .isEqualTo("project:search;text!")
-                .as("encodable characters in project-wide search text should survive a round-trip to and from token string");
+                .as("encodable characters in project-wide search text should survive a round-trip to and from token string")
+                .isEqualTo("project:search;text!");
         assertThat(token.getProjectSearchReplacement())
-                .isEqualTo("re!place;ment:text")
-                .as("encodable characters in project-wide search replacement text should survive a round-trip to and from token string");
+                .as("encodable characters in project-wide search replacement text should survive a round-trip to and from token string")
+                .isEqualTo("re!place;ment:text");
     }
 
     @Test

--- a/server/gwt-editor/src/test/java/org/zanata/webtrans/client/presenter/AppPresenterTest.java
+++ b/server/gwt-editor/src/test/java/org/zanata/webtrans/client/presenter/AppPresenterTest.java
@@ -556,19 +556,23 @@ public class AppPresenterTest {
     public void onProjectStatsUpdated() {
         projectStats = new ContainerTranslationStatistics();
         projectStats.addStats(new TranslationStatistics(new TransUnitCount(0,
-            0, 0), userWorkspace.getWorkspaceContext().getWorkspaceId().getLocaleId().getId()));
+                0, 0), userWorkspace.getWorkspaceContext().getWorkspaceId()
+                .getLocaleId().getId()));
         projectStats.addStats(new TranslationStatistics(new TransUnitWords(0,
-            0, 0), userWorkspace.getWorkspaceContext().getWorkspaceId().getLocaleId().getId()));
+                0, 0), userWorkspace.getWorkspaceContext().getWorkspaceId()
+                .getLocaleId().getId()));
 
         presenter.setStatesForTest(projectStats, selectedDocumentStats, null,
                 null);
         presenter.showView(MainView.Documents);
 
-        RefreshProjectStatsEvent event = new RefreshProjectStatsEvent(buildSampleDocumentArray());
+        RefreshProjectStatsEvent event =
+                new RefreshProjectStatsEvent(buildSampleDocumentArray());
         presenter.onProjectStatsUpdated(event);
 
-        assertThat(projectStats.getStats().size()).isEqualTo(2)
-                .as("project stats should contain stats in the event");
+        assertThat(projectStats.getStats().size())
+                .as("project stats should contain stats in the event")
+                .isEqualTo(2);
 
         verify(display, times(2)).setStats(projectStats, true);
     }

--- a/server/gwt-editor/src/test/java/org/zanata/webtrans/client/presenter/DocumentListPresenterTest.java
+++ b/server/gwt-editor/src/test/java/org/zanata/webtrans/client/presenter/DocumentListPresenterTest.java
@@ -166,21 +166,23 @@ public class DocumentListPresenterTest {
         documentListPresenter.setDocuments(buildSampleDocumentArray());
 
         // right amount of docs
-        assertThat(documentListPresenter.getFilteredNodes()).hasSize(3)
-                .as("the data provider should have the same sized document list returned from the server");
+        assertThat(documentListPresenter.getFilteredNodes())
+                .as("the data provider should have the same sized document list returned from the server")
+                .hasSize(3);
 
         ArrayList<DocumentInfo> expectedDocs = buildSampleDocumentArray();
 
         ArrayList<DocumentInfo> actualDocInfos = new ArrayList<DocumentInfo>();
         for (DocumentNode node : documentListPresenter.getFilteredNodes()) {
-            assertThat(node.getDocInfo()).isIn(expectedDocs)
-                    .as("the data provider should have only documents that were returned from the server");
+            assertThat(node.getDocInfo())
+                    .as("the data provider should have only documents that were returned from the server")
+                    .isIn(expectedDocs);
             actualDocInfos.add(node.getDocInfo());
         }
         assertThat(actualDocInfos)
+                .as("the data provider should have all documents returned from the server")
                 .contains(expectedDocs.get(0), expectedDocs.get(1),
-                        expectedDocs.get(2))
-                .as("the data provider should have all documents returned from the server");
+                        expectedDocs.get(2));
     }
 
     @Test
@@ -224,43 +226,46 @@ public class DocumentListPresenterTest {
                 extractFromEvents(capturedEventBusEvent.getAllValues(),
                         DocumentStatsUpdatedEvent.class);
 
-        assertThat(docStatsEvent).isNotNull()
-                .as("a document stats event should be fired when a TU update event occurs, not found");
+        assertThat(docStatsEvent)
+                .as("a document stats event should be fired when a TU update event occurs, not found")
+                .isNotNull();
 
         // document stats
         assertThat(docStatsEvent.getDocId())
-                .isEqualTo(new DocumentId(2222L, ""))
-                .as("document id in document stats event shoudl match updated TU document id");
+                .as("document id in document stats event shoudl match updated TU document id")
+                .isEqualTo(new DocumentId(2222L, ""));
 
         // check actual counts (approved/fuzzy/untranslated)
         // default TUs: 1/2/3
         // approving 1 fuzzy, expect 2/1/3
         assertThat(docStatsEvent.getNewStats()
                 .getStats(LocaleId.ES.toString(), StatUnit.MESSAGE)
-                .getApproved()).isEqualTo(new Long(2))
-                .as("document Approved TU count should increase by 1 when a TU is updated from NeedsReview to Approved");
+                .getApproved())
+                .as("document Approved TU count should increase by 1 when a TU is updated from NeedsReview to Approved")
+                .isEqualTo(new Long(2));
         assertThat(docStatsEvent.getNewStats()
                 .getStats(LocaleId.ES.toString(), StatUnit.MESSAGE).getDraft())
                 .isEqualTo(new Long(1));
         assertThat(docStatsEvent.getNewStats()
                 .getStats(LocaleId.ES.toString(), StatUnit.MESSAGE)
-                .getUntranslated()).isEqualTo(new Long(3))
-                .as("document Untranslated TU count should remain the same when a TU is updated from NeedsReview to Approved");
+                .getUntranslated())
+                .as("document Untranslated TU count should remain the same when a TU is updated from NeedsReview to Approved")
+                .isEqualTo(new Long(3));
 
         // default words: 4/5/6
         // approving 3 fuzzy so expect 7/2/6
         assertThat(docStatsEvent.getNewStats()
                 .getStats(LocaleId.ES.toString(), StatUnit.WORD).getApproved())
-                .isEqualTo(new Long(7))
-                .as("document Approved words should increase when TU changes to Approved");
+                .as("document Approved words should increase when TU changes to Approved")
+                .isEqualTo(new Long(7));
         assertThat(docStatsEvent.getNewStats()
                 .getStats(LocaleId.ES.toString(), StatUnit.WORD).getDraft())
-                .isEqualTo(new Long(2))
-                .as("document NeedsReview words should decrease when a TU changes from NeedsReview");
+                .as("document NeedsReview words should decrease when a TU changes from NeedsReview")
+                .isEqualTo(new Long(2));
         assertThat(docStatsEvent.getNewStats()
                 .getStats(LocaleId.ES.toString(), StatUnit.WORD).getDraft())
-                .isEqualTo(new Long(2))
-                .as("document Untranslated words should not change when TU changes between NeedsReview and Approved");
+                .as("document Untranslated words should not change when TU changes between NeedsReview and Approved")
+                .isEqualTo(new Long(2));
     }
 
     @Test
@@ -278,10 +283,11 @@ public class DocumentListPresenterTest {
                 HistoryToken.fromTokenString(capturedHistoryTokenString
                         .getValue());
         assertThat(capturedHistoryToken.getDocFilterText())
-                .isEqualTo(filterText)
-                .as("generated history token filter text should match the filter textbox");
-        assertThat(capturedHistoryToken.getDocFilterExact()).isFalse()
-                .as("generated history token filter exact flag should match the exact match checkbox");
+                .as("generated history token filter text should match the filter textbox")
+                .isEqualTo(filterText);
+        assertThat(capturedHistoryToken.getDocFilterExact())
+                .as("generated history token filter exact flag should match the exact match checkbox")
+                .isFalse();
     }
 
     @Test
@@ -296,8 +302,8 @@ public class DocumentListPresenterTest {
         HistoryToken exactSearchToken = new HistoryToken();
         exactSearchToken.setDocFilterExact(true);
         assertThat(capturedHistoryTokenString.getValue())
-                .isEqualTo(exactSearchToken.toTokenString())
-                .as("checking the 'exact search' checkbox should be reflected in a new history token");
+                .as("checking the 'exact search' checkbox should be reflected in a new history token")
+                .isEqualTo(exactSearchToken.toTokenString());
     }
 
     @Test
@@ -317,8 +323,8 @@ public class DocumentListPresenterTest {
         HistoryToken inexactSearchToken = new HistoryToken();
         inexactSearchToken.setDocFilterExact(false);
         assertThat(capturedHistoryTokenString.getValue())
-                .isEqualTo(inexactSearchToken.toTokenString())
-                .as("unchecking the 'exact search' checkbox should be reflected in a new history token");
+                .as("unchecking the 'exact search' checkbox should be reflected in a new history token")
+                .isEqualTo(inexactSearchToken.toTokenString());
     }
 
     // TODO tests for check and uncheck case sensitive check
@@ -336,19 +342,21 @@ public class DocumentListPresenterTest {
                 new DocumentInfo(new DocumentId(2222L, ""), "doc122",
                         "second/path/", LocaleId.EN_US,
                         new ContainerTranslationStatistics(), new AuditInfo(
-                                new Date(), "Translator"),
+                        new Date(), "Translator"),
                         new HashMap<String, String>(), new AuditInfo(
-                                new Date(), "last translator"));
+                        new Date(), "last translator"));
         documentListPresenter.fireDocumentSelection(docInfo);
 
         verify(mockHistory).newItem(capturedHistoryToken.capture());
         verify(mockUserWorkspaceContext).setSelectedDoc(docInfo);
 
         HistoryToken newToken = capturedHistoryToken.getValue();
-        assertThat(newToken.getDocumentPath()).isEqualTo("second/path/doc122")
-                .as("path of selected document should be set in history token");
-        assertThat(newToken.getView()).isEqualTo(MainView.Editor)
-                .as("view in history token should change to individual document view when a new document is selected");
+        assertThat(newToken.getDocumentPath())
+                .as("path of selected document should be set in history token")
+                .isEqualTo("second/path/doc122");
+        assertThat(newToken.getView())
+                .as("view in history token should change to individual document view when a new document is selected")
+                .isEqualTo(MainView.Editor);
     }
 
     @Test
@@ -374,14 +382,17 @@ public class DocumentListPresenterTest {
         expectedDocs.remove(0);
         ArrayList<DocumentInfo> actualDocInfos = new ArrayList<DocumentInfo>();
         for (DocumentNode node : documentListPresenter.getFilteredNodes()) {
-            assertThat(node.getDocInfo()).isIn(expectedDocs)
-                    .as("the data provider should have only documents that exactly match the current filter");
+            assertThat(node.getDocInfo())
+                    .as("the data provider should have only documents that exactly match the current filter")
+                    .isIn(expectedDocs);
             actualDocInfos.add(node.getDocInfo());
         }
-        assertThat(actualDocInfos).contains(expectedDocs.get(0))
-                .as("the data provider should have all documents that exactly match the filter");
-        assertThat(documentListPresenter.getFilteredNodes()).hasSize(1)
-                .as("the data provider list should contain exactly the number of documents matching the filter");
+        assertThat(actualDocInfos)
+                .as("the data provider should have all documents that exactly match the filter")
+                .contains(expectedDocs.get(0));
+        assertThat(documentListPresenter.getFilteredNodes())
+                .as("the data provider list should contain exactly the number of documents matching the filter")
+                .hasSize(1);
     }
 
     // TODO test case sensitivity option
@@ -408,15 +419,17 @@ public class DocumentListPresenterTest {
         ArrayList<DocumentInfo> actualDocInfos = new ArrayList<DocumentInfo>();
         expectedDocs.remove(1);
         for (DocumentNode node : documentListPresenter.getFilteredNodes()) {
-            assertThat(node.getDocInfo()).isIn(expectedDocs)
-                    .as("the data provider should have only documents that match the current filter");
+            assertThat(node.getDocInfo())
+                    .as("the data provider should have only documents that match the current filter")
+                    .isIn(expectedDocs);
             actualDocInfos.add(node.getDocInfo());
         }
         assertThat(actualDocInfos)
-                .contains(expectedDocs.get(0), expectedDocs.get(1))
-                .as("the data provider should have all documents that match the filter");
-        assertThat(documentListPresenter.getFilteredNodes()).hasSize(2)
-                .as("the data provider list should contain exactly the number of documents matching the filter");
+                .as("the data provider should have all documents that match the filter")
+                .contains(expectedDocs.get(0), expectedDocs.get(1));
+        assertThat(documentListPresenter.getFilteredNodes())
+                .as("the data provider list should contain exactly the number of documents matching the filter")
+                .hasSize(2);
     }
 
     // TODO test case sensitive check updated from history

--- a/server/gwt-editor/src/test/java/org/zanata/webtrans/client/presenter/KeyShortcutPresenterTest.java
+++ b/server/gwt-editor/src/test/java/org/zanata/webtrans/client/presenter/KeyShortcutPresenterTest.java
@@ -132,38 +132,51 @@ public class KeyShortcutPresenterTest {
         keyShortcutPresenter.showShortcuts();
 
         // Shortcut list should contain Alt+Y and Esc shortcuts
-        assertThat(shortcutList.size()).isEqualTo(3)
-                .as("KeyShortcutPresenter should register 2 global shortcuts");
+        assertThat(shortcutList.size())
+                .as("KeyShortcutPresenter should register 2 global shortcuts")
+                .isEqualTo(3);
 
         // esc should be first as it has no modifiers
         Set<Keys> firstShortcutKeys = shortcutList.get(0).getAllKeys();
         String firstShortcut = "first shortcut should be Esc with no modifiers";
-        assertThat(firstShortcutKeys.size()).isEqualTo(1).as(firstShortcut);
+        assertThat(firstShortcutKeys.size())
+                .as(firstShortcut)
+                .isEqualTo(1);
         Keys firstShortcutFirstKeys = firstShortcutKeys.iterator().next();
-        assertThat(firstShortcutFirstKeys.getModifiers()).isEqualTo(0)
-                .as(firstShortcut);
+        assertThat(firstShortcutFirstKeys.getModifiers())
+                .as(firstShortcut)
+                .isEqualTo(0);
         assertThat(firstShortcutFirstKeys.getKeyCode())
-                .isEqualTo(KeyCodes.KEY_ESCAPE).as(firstShortcut);
+                .as(firstShortcut)
+                .isEqualTo(KeyCodes.KEY_ESCAPE);
 
         // Alt+X should be next
         Set<Keys> secondShortcutKeys = shortcutList.get(1).getAllKeys();
         String secondShortcut = "second shortcut should be Alt+X";
-        assertThat(secondShortcutKeys.size()).isEqualTo(1).as(secondShortcut);
+        assertThat(secondShortcutKeys.size())
+                .as(secondShortcut)
+                .isEqualTo(1);
         Keys secondShortcutFirstKeys = secondShortcutKeys.iterator().next();
         assertThat(secondShortcutFirstKeys.getModifiers())
-                .isEqualTo(Keys.ALT_KEY).as(secondShortcut);
-        assertThat(secondShortcutFirstKeys.getKeyCode()).isEqualTo((int) 'X')
-                .as(secondShortcut);
+                .as(secondShortcut)
+                .isEqualTo(Keys.ALT_KEY);
+        assertThat(secondShortcutFirstKeys.getKeyCode())
+                .as(secondShortcut)
+                .isEqualTo((int) 'X');
 
         // Alt+Y should be last
         Set<Keys> thirdShortcutKeys = shortcutList.get(2).getAllKeys();
         String thirdShortcut = "third shortcut should be Alt+Y";
-        assertThat(thirdShortcutKeys.size()).isEqualTo(1).as(thirdShortcut);
+        assertThat(thirdShortcutKeys.size())
+                .as(thirdShortcut)
+                .isEqualTo(1);
         Keys thirdShortcutFirstKeys = thirdShortcutKeys.iterator().next();
         assertThat(thirdShortcutFirstKeys.getModifiers())
-                .isEqualTo(Keys.ALT_KEY).as(thirdShortcut);
-        assertThat(thirdShortcutFirstKeys.getKeyCode()).isEqualTo((int) 'Y')
-                .as(thirdShortcut);
+                .as(thirdShortcut)
+                .isEqualTo(Keys.ALT_KEY);
+        assertThat(thirdShortcutFirstKeys.getKeyCode())
+                .as(thirdShortcut)
+                .isEqualTo((int) 'Y');
     }
 
     @Test

--- a/server/gwt-editor/src/test/java/org/zanata/webtrans/client/presenter/SearchResultsPresenterTest.java
+++ b/server/gwt-editor/src/test/java/org/zanata/webtrans/client/presenter/SearchResultsPresenterTest.java
@@ -322,17 +322,17 @@ public class SearchResultsPresenterTest {
 
         HistoryToken newToken = capturedHistoryToken.getValue();
         assertThat(newToken.getProjectSearchText())
-                .isEqualTo(TEST_SEARCH_PHRASE)
-                .as("new history token should be updated with current search phrase in search text box");
+                .as("new history token should be updated with current search phrase in search text box")
+                .isEqualTo(TEST_SEARCH_PHRASE);
         assertThat(newToken.getProjectSearchCaseSensitive())
-                .isEqualTo(caseSensitiveFalseValue)
-                .as("new history token project search case sensitivity should match checkbox value");
+                .as("new history token project search case sensitivity should match checkbox value")
+                .isEqualTo(caseSensitiveFalseValue);
         assertThat(newToken.isProjectSearchInTarget())
-                .isTrue()
-                .as("new history token should reflect search in target when selected search field is target");
+                .as("new history token should reflect search in target when selected search field is target")
+                .isTrue();
         assertThat(newToken.isProjectSearchInSource())
-                .isFalse()
-                .as("new history token should reflect not to search in source when selected search field is target");
+                .as("new history token should reflect not to search in source when selected search field is target")
+                .isFalse();
     }
 
     @Test
@@ -351,9 +351,9 @@ public class SearchResultsPresenterTest {
 
         verify(mockHistory).newItem(capturedHistoryToken.capture());
         HistoryToken newToken = capturedHistoryToken.getValue();
-        assertThat(newToken.getProjectSearchCaseSensitive()).
-                isEqualTo(caseSensitiveTrueValue)
-                .as("new history token project search case sensitivity should match checkbox value");
+        assertThat(newToken.getProjectSearchCaseSensitive())
+                .as("new history token project search case sensitivity should match checkbox value")
+                .isEqualTo(caseSensitiveTrueValue);
     }
 
     @Test
@@ -369,10 +369,12 @@ public class SearchResultsPresenterTest {
         verify(mockHistory).newItem(capturedHistoryToken.capture());
 
         HistoryToken newToken = capturedHistoryToken.getValue();
-        assertThat(newToken.isProjectSearchInSource()).isTrue()
-                .as("new history token should reflect search in source when selected search field is source");
-        assertThat(newToken.isProjectSearchInTarget()).isFalse()
-                .as("new history token should reflect not to search in target when selected search field is source");
+        assertThat(newToken.isProjectSearchInSource())
+                .as("new history token should reflect search in source when selected search field is source")
+                .isTrue();
+        assertThat(newToken.isProjectSearchInTarget())
+                .as("new history token should reflect not to search in target when selected search field is source")
+                .isFalse();
     }
 
     @Test
@@ -389,10 +391,12 @@ public class SearchResultsPresenterTest {
         verify(mockHistory).newItem(capturedHistoryToken.capture());
 
         HistoryToken newToken = capturedHistoryToken.getValue();
-        assertThat(newToken.isProjectSearchInSource()).isTrue()
-                .as("new history token should reflect search in source when selected search field is both");
-        assertThat(newToken.isProjectSearchInTarget()).isTrue()
-                .as("new history token should reflect search in target when selected search field is both");
+        assertThat(newToken.isProjectSearchInSource())
+                .as("new history token should reflect search in source when selected search field is both")
+                .isTrue();
+        assertThat(newToken.isProjectSearchInTarget())
+                .as("new history token should reflect search in target when selected search field is both")
+                .isTrue();
     }
 
     @Test
@@ -411,8 +415,9 @@ public class SearchResultsPresenterTest {
         verify(mockHistory).newItem(capturedHistoryToken.capture());
 
         HistoryToken newToken = capturedHistoryToken.getValue();
-        assertThat(newToken.getProjectSearchReplacement()).isEqualTo(TEST_REPLACE_PHRASE)
-                .as("new history token should be updated with current replacement phrase");
+        assertThat(newToken.getProjectSearchReplacement())
+                .as("new history token should be updated with current replacement phrase")
+                .isEqualTo(TEST_REPLACE_PHRASE);
     }
 
     @Ignore
@@ -444,8 +449,9 @@ public class SearchResultsPresenterTest {
         searchResultsPresenter.bind();
         simulateSearch();
 
-        assertThat(dataProviderDoc1List.size()).isEqualTo(1)
-                .as("text flows for document should be added to data provider");
+        assertThat(dataProviderDoc1List.size())
+                .as("text flows for document should be added to data provider")
+                .isEqualTo(1);
     }
 
     // TODO use 4 results in 2 documents

--- a/server/services/src/test/java/org/zanata/adapter/OpenOfficeAdapterTest.java
+++ b/server/services/src/test/java/org/zanata/adapter/OpenOfficeAdapterTest.java
@@ -75,16 +75,20 @@ public class OpenOfficeAdapterTest extends AbstractAdapterTest<OpenOfficeAdapter
         // TODO test IDs
 
         assertThat(resource.getTextFlows().get(0).getContents().get(0))
-                .isEqualTo("TestODS")
-                .as("Item 1 shows TestODS (the sheet name)");
+                .as("Item 1 shows TestODS (the sheet name)")
+                .isEqualTo("TestODS");
         assertThat(resource.getTextFlows().get(1).getContents().get(0))
-                .isEqualTo("First").as("Item 2 shows First (the page name)");
+                .as("Item 2 shows First (the page name)")
+                .isEqualTo("First");
         assertThat(resource.getTextFlows().get(2).getContents().get(0))
-                .isEqualTo("Line One").as("Item 3 shows Line One");
+                .as("Item 3 shows Line One")
+                .isEqualTo("Line One");
         assertThat(resource.getTextFlows().get(3).getContents().get(0))
-                .isEqualTo("Line Two").as("Item 4 shows Line Two");
+                .as("Item 4 shows Line Two")
+                .isEqualTo("Line Two");
         assertThat(resource.getTextFlows().get(4).getContents().get(0))
-                .isEqualTo("Line Three").as("Item 5 shows Line Three");
+                .as("Item 5 shows Line Three")
+                .isEqualTo("Line Three");
     }
 
     private void check3TextFlows(Resource resource, boolean checkSize) {
@@ -92,11 +96,14 @@ public class OpenOfficeAdapterTest extends AbstractAdapterTest<OpenOfficeAdapter
         // TODO test IDs
 
         assertThat(resource.getTextFlows().get(0).getContents().get(0))
-                .isEqualTo("Line One").as("Item 0 shows Line One");
+                .as("Item 0 shows Line One")
+                .isEqualTo("Line One");
         assertThat(resource.getTextFlows().get(1).getContents().get(0))
-                .isEqualTo("Line Two").as("Item 1 shows Line Two");
+                .as("Item 1 shows Line Two")
+                .isEqualTo("Line Two");
         assertThat(resource.getTextFlows().get(2).getContents().get(0))
-                .isEqualTo("Line Three").as("Item 2 shows Line Three");
+                .as("Item 2 shows Line Three")
+                .isEqualTo("Line Three");
     }
 
 }

--- a/server/services/src/test/java/org/zanata/dao/DocumentDAOTest.java
+++ b/server/services/src/test/java/org/zanata/dao/DocumentDAOTest.java
@@ -93,8 +93,9 @@ public class DocumentDAOTest extends ZanataDbunitJpaTest {
             String unchangedHash =
                     documentDAO.getTranslatedDocumentStateHash(PROJECT_SLUG,
                             ITERATION_SLUG, DOC_ID, as);
-            assertThat(unchangedHash).isEqualTo(docHash)
-                    .as("Translated Document state hash function not repeatable");
+            assertThat(unchangedHash)
+                    .as("Translated Document state hash function not repeatable")
+                    .isEqualTo(docHash);
         }
     }
 
@@ -117,11 +118,13 @@ public class DocumentDAOTest extends ZanataDbunitJpaTest {
                 documentDAO.getTranslatedDocumentStateHash(PROJECT_SLUG,
                         ITERATION_SLUG, DOC_ID, as);
         if (expectHashChange) {
-            assertThat(changedDocHash).isNotEqualTo(docHash)
-                    .as("Translated document hash must change when something is changed");
+            assertThat(changedDocHash)
+                    .as("Translated document hash must change when something is changed")
+                    .isNotEqualTo(docHash);
         } else {
-            assertThat(changedDocHash).isEqualTo(docHash)
-                    .as("Translated document hash must not change when nothing is changed");
+            assertThat(changedDocHash)
+                    .as("Translated document hash must not change when nothing is changed")
+                    .isEqualTo(docHash);
         }
     }
 

--- a/server/services/src/test/java/org/zanata/dao/LocaleDAOTest.java
+++ b/server/services/src/test/java/org/zanata/dao/LocaleDAOTest.java
@@ -57,8 +57,12 @@ public class LocaleDAOTest extends ZanataDbunitJpaTest {
         dao.clear();
         HLocale loadedLocale = dao.findById(id);
         assertThat(loadedLocale.getLocaleId().getId()).isEqualTo("en-ENABLED");
-        assertThat(loadedLocale.isActive()).isTrue().as("still active");
-        assertThat(loadedLocale.isEnabledByDefault()).isTrue().as("still enabled by default");
+        assertThat(loadedLocale.isActive())
+                .as("still active")
+                .isTrue();
+        assertThat(loadedLocale.isEnabledByDefault())
+                .as("still enabled by default")
+                .isTrue();
     }
 
     @Test

--- a/server/services/src/test/java/org/zanata/dao/ProjectDAOJPATest.java
+++ b/server/services/src/test/java/org/zanata/dao/ProjectDAOJPATest.java
@@ -77,8 +77,9 @@ public class ProjectDAOJPATest extends ZanataJpaTest {
         assertThat(searchProjects("proj"))
                 .as("wildcard search is only applied to full slug")
                 .isEmpty();
-        assertThat(searchProjects("example project")).containsExactly(expected)
-                .as("search by description");
+        assertThat(searchProjects("example project"))
+                .as("search by description")
+                .containsExactly(expected);
     }
 
     private List<HProject> searchProjects(String sam) throws ParseException {

--- a/server/services/src/test/java/org/zanata/model/DocumentJPATest.java
+++ b/server/services/src/test/java/org/zanata/model/DocumentJPATest.java
@@ -66,8 +66,9 @@ public class DocumentJPATest extends ZanataDbunitJpaTest {
         assertThat(project).isNotNull();
 
         List<HProjectIteration> projectTargets = project.getProjectIterations();
-        assertThat(projectTargets.size()).isEqualTo(3)
-                .as("Project should have 3 targets");
+        assertThat(projectTargets.size())
+                .as("Project should have 3 targets")
+                .isEqualTo(3);
 
         List<Long> iterationIds = Lists.transform(projectTargets,
                 input -> input.getId());

--- a/server/services/src/test/java/org/zanata/model/HTextFlowHistoryJPATest.java
+++ b/server/services/src/test/java/org/zanata/model/HTextFlowHistoryJPATest.java
@@ -52,8 +52,9 @@ public class HTextFlowHistoryJPATest extends ZanataDbunitJpaTest {
 
         List<HTextFlowHistory> historyElems = getHistory(tf);
 
-        assertThat(historyElems.size()).isEqualTo(0)
-                .as("Incorrect History size on persist");
+        assertThat(historyElems.size())
+                .as("Incorrect History size on persist")
+                .isEqualTo(0);
 
         d.incrementRevision();
         tf.setContents("hello world again");
@@ -62,8 +63,9 @@ public class HTextFlowHistoryJPATest extends ZanataDbunitJpaTest {
 
         historyElems = getHistory(tf);
 
-        assertThat(historyElems.size()).isEqualTo(1)
-                .as("Incorrect History size on first update");
+        assertThat(historyElems.size())
+                .as("Incorrect History size on first update")
+                .isEqualTo(1);
         assertThat(historyElems.get(0).getContents())
                 .isEqualTo(Arrays.asList("hello world"));
 
@@ -74,8 +76,9 @@ public class HTextFlowHistoryJPATest extends ZanataDbunitJpaTest {
 
         historyElems = getHistory(tf);
 
-        assertThat(historyElems.size()).isEqualTo(2)
-                .as("Incorrect History size on second update");
+        assertThat(historyElems.size())
+                .as("Incorrect History size on second update")
+                .isEqualTo(2);
         assertThat(historyElems.get(1).getContents())
                 .isEqualTo(Arrays.asList("hello world again"));
     }
@@ -98,8 +101,9 @@ public class HTextFlowHistoryJPATest extends ZanataDbunitJpaTest {
 
         List<HTextFlowHistory> historyElems = getHistory(tf);
 
-        assertThat(historyElems.size()).isEqualTo(0)
-                .as("Incorrect History size on persist");
+        assertThat(historyElems.size())
+                .as("Incorrect History size on persist")
+                .isEqualTo(0);
 
         d.incrementRevision();
         tf.setPlural(true);
@@ -109,8 +113,9 @@ public class HTextFlowHistoryJPATest extends ZanataDbunitJpaTest {
 
         historyElems = getHistory(tf);
 
-        assertThat(historyElems.size()).isEqualTo(1)
-                .as("Incorrect History size on first update");
+        assertThat(historyElems.size())
+                .as("Incorrect History size on first update")
+                .isEqualTo(1);
         assertThat(historyElems.get(0).getContents())
                 .isEqualTo(Arrays.asList("hello world"));
 
@@ -121,8 +126,9 @@ public class HTextFlowHistoryJPATest extends ZanataDbunitJpaTest {
 
         historyElems = getHistory(tf);
 
-        assertThat(historyElems.size()).isEqualTo(2)
-                .as("Incorrect History size on second update");
+        assertThat(historyElems.size())
+                .as("Incorrect History size on second update")
+                .isEqualTo(2);
         assertThat(historyElems.get(1).getContents())
                 .isEqualTo(Arrays.asList("hello world 1", "hello world 2"));
     }

--- a/server/services/src/test/java/org/zanata/model/HTextFlowJPATest.java
+++ b/server/services/src/test/java/org/zanata/model/HTextFlowJPATest.java
@@ -77,9 +77,10 @@ public class HTextFlowJPATest extends ZanataDbunitJpaTest {
     public void textFlowWithSingleContent() {
         HDocument hdoc =
                 new HDocument("fullpath", ContentType.TextPlain, en_US);
-        hdoc.setProjectIteration(projectIterationDAO.findById(1L, false)); // Taken
-                                                                           // from
-                                                                           // ProjectsData.dbunit.xml
+        hdoc.setProjectIteration(
+                projectIterationDAO.findById(1L, false)); // Taken
+        // from
+        // ProjectsData.dbunit.xml
 
         HTextFlow tf = new HTextFlow(hdoc, "hello world res id", "hello world");
 
@@ -91,22 +92,25 @@ public class HTextFlowJPATest extends ZanataDbunitJpaTest {
         // reload the doc
         em.refresh(hdoc);
 
-        assertThat(hdoc.getTextFlows().size()).isGreaterThan(0)
-                .as("Expected document to contain at least one text flow");
-        assertThat(hdoc.getTextFlows().get(0).getContents().size()).isEqualTo(1)
-                .as("Expected Text flow to contain single content");
+        assertThat(hdoc.getTextFlows().size())
+                .as("Expected document to contain at least one text flow")
+                .isGreaterThan(0);
+        assertThat(hdoc.getTextFlows().get(0).getContents().size())
+                .as("Expected Text flow to contain single content")
+                .isEqualTo(1);
         assertThat(hdoc.getTextFlows().get(0).getContents().get(0))
-                .isEqualTo("hello world")
-                .as("Expected deprecated method to still work");
+                .as("Expected deprecated method to still work")
+                .isEqualTo("hello world");
     }
 
     @Test
     public void textFlowWithPlurals() {
         HDocument hdoc =
                 new HDocument("fullpath", ContentType.TextPlain, en_US);
-        hdoc.setProjectIteration(projectIterationDAO.findById(1L, false)); // Taken
-                                                                           // from
-                                                                           // ProjectsData.dbunit.xml
+        hdoc.setProjectIteration(
+                projectIterationDAO.findById(1L, false)); // Taken
+        // from
+        // ProjectsData.dbunit.xml
 
         HTextFlow tf =
                 new HTextFlow(hdoc, "hello world res id 1", "hello world");
@@ -124,26 +128,29 @@ public class HTextFlowJPATest extends ZanataDbunitJpaTest {
         // reload the doc
         em.refresh(hdoc);
 
-        assertThat(hdoc.getTextFlows().size()).isGreaterThan(0)
-                .as("Expected document to contain at least one text flow");
-        assertThat(hdoc.getTextFlows().get(0).getContents().size()).isEqualTo(3)
-                .as("Expected Text flow to contain 3 content strings");
+        assertThat(hdoc.getTextFlows().size())
+                .as("Expected document to contain at least one text flow")
+                .isGreaterThan(0);
+        assertThat(hdoc.getTextFlows().get(0).getContents().size())
+                .as("Expected Text flow to contain 3 content strings")
+                .isEqualTo(3);
         assertThat(hdoc.getTextFlows().get(0).getContents())
+                .as("Expected contents to be preserved")
                 .isEqualTo(Arrays.asList("hello world",
-                        "hello worlds", "hellos worlds"))
-                .as("Expected contents to be preserved");
+                        "hello worlds", "hellos worlds"));
         assertThat(hdoc.getTextFlows().get(0).getContents().get(0))
-                .isEqualTo("hello world")
-                .as("Expected deprecated method to still work");
+                .as("Expected deprecated method to still work")
+                .isEqualTo("hello world");
     }
 
     @Test
     public void textFlowWithPluralsAndSomeEmptyContents() {
         HDocument hdoc =
                 new HDocument("fullpath", ContentType.TextPlain, en_US);
-        hdoc.setProjectIteration(projectIterationDAO.findById(1L, false)); // Taken
-                                                                           // from
-                                                                           // ProjectsData.dbunit.xml
+        hdoc.setProjectIteration(
+                projectIterationDAO.findById(1L, false)); // Taken
+        // from
+        // ProjectsData.dbunit.xml
 
         HTextFlow tf =
                 new HTextFlow(hdoc, "hello world res id 1", "hello world");
@@ -157,14 +164,16 @@ public class HTextFlowJPATest extends ZanataDbunitJpaTest {
         // reload the doc
         em.refresh(hdoc);
 
-        assertThat(hdoc.getTextFlows().size()).isGreaterThan(0)
-                .as("Expected document to contain at least one text flow");
-        assertThat(hdoc.getTextFlows().get(0).getContents().size()).isEqualTo(4)
-                .as("Expected Text flow to contain 4 content strings");
+        assertThat(hdoc.getTextFlows().size())
+                .as("Expected document to contain at least one text flow")
+                .isGreaterThan(0);
+        assertThat(hdoc.getTextFlows().get(0).getContents().size())
+                .as("Expected Text flow to contain 4 content strings")
+                .isEqualTo(4);
         assertThat(hdoc.getTextFlows().get(0).getContents())
+                .as("Expected contents to be preserved")
                 .isEqualTo(Arrays.asList("hello world 1",
-                        "hello world 2", null, "hello world 4"))
-                .as("Expected contents to be preserved");
+                        "hello world 2", null, "hello world 4"));
         assertThat(hdoc.getTextFlows().get(0).getContents().get(0))
                 .isEqualTo("hello world 1");
     }

--- a/server/services/src/test/java/org/zanata/model/HTextFlowTargetHistoryJPATest.java
+++ b/server/services/src/test/java/org/zanata/model/HTextFlowTargetHistoryJPATest.java
@@ -66,24 +66,27 @@ public class HTextFlowTargetHistoryJPATest extends ZanataDbunitJpaTest {
         session.flush();
 
         List<HTextFlowTargetHistory> historyElems = getHistory(target);
-        assertThat(historyElems.size()).isEqualTo(0)
-                .as("Incorrect History size on persist");
+        assertThat(historyElems.size())
+                .as("Incorrect History size on persist")
+                .isEqualTo(0);
 
         target.setContents("blah!");
         session.flush();
 
         historyElems = getHistory(target);
 
-        assertThat(historyElems.size()).isEqualTo(1)
-                .as("Incorrect History size on first update");
+        assertThat(historyElems.size())
+                .as("Incorrect History size on first update")
+                .isEqualTo(1);
 
         target.setContents("hola mundo!");
         session.flush();
 
         historyElems = getHistory(target);
 
-        assertThat(historyElems.size()).isEqualTo(2)
-                .as("Incorrect History size on second update");
+        assertThat(historyElems.size())
+                .as("Incorrect History size on second update")
+                .isEqualTo(2);
         assertThat(historyElems.size()).isEqualTo(2);
         HTextFlowTargetHistory hist = historyElems.get(0);
         assertThat(hist.getContents()).isEqualTo(Arrays.asList("helleu world"));

--- a/server/services/src/test/java/org/zanata/rest/service/ResourceUtilsParamTest.java
+++ b/server/services/src/test/java/org/zanata/rest/service/ResourceUtilsParamTest.java
@@ -54,13 +54,15 @@ public class ResourceUtilsParamTest extends ZanataTest {
 
     @Test
     public void decodeDocIds() {
-        assertThat(resourceUtils.decodeDocId(encoded)).isEqualTo(decoded)
-                .as("Decoding " + encoded);
+        assertThat(resourceUtils.decodeDocId(encoded))
+                .as("Decoding " + encoded)
+                .isEqualTo(decoded);
     }
 
     @Test
     public void encodeDocIds() {
-        assertThat(resourceUtils.encodeDocId(decoded)).isEqualTo(encoded)
-                .as("Encoding " + decoded);
+        assertThat(resourceUtils.encodeDocId(decoded))
+                .as("Encoding " + decoded)
+                .isEqualTo(encoded);
     }
 }

--- a/server/services/src/test/java/org/zanata/rest/service/ResourceUtilsTest.java
+++ b/server/services/src/test/java/org/zanata/rest/service/ResourceUtilsTest.java
@@ -148,7 +148,8 @@ public class ResourceUtilsTest extends ZanataTest {
 
         // set up a textflow with the same id and different content
         TextFlow changedTF =
-                new TextFlow(originalTF.getResId(), LocaleId.EN, "changed text");
+                new TextFlow(originalTF.getResId(), LocaleId.EN,
+                        "changed text");
         List<TextFlow> from = new ArrayList<TextFlow>();
         from.add(changedTF);
 
@@ -168,15 +169,19 @@ public class ResourceUtilsTest extends ZanataTest {
         fuzzyTarg = targets.get(fuzzyLocId);
         assertThat(fuzzyTarg.getState()).isEqualTo(ContentState.NeedReview);
         assertThat(fuzzyTarg.getVersionNum()).isEqualTo(fuzzyTargVersionBefore);
-        assertThat(fuzzyTarg.getTextFlowRevision()).isEqualTo(originalTFRevision);
+        assertThat(fuzzyTarg.getTextFlowRevision())
+                .isEqualTo(originalTFRevision);
 
         apprTarg = targets.get(apprLocId);
-        assertThat(apprTarg.getState()).isEqualTo(ContentState.NeedReview)
-                .as("approved targets should be set to fuzzy when source content changes");
-        assertThat(apprTarg.getVersionNum()).isEqualTo(apprTargVersionBefore + 1);
+        assertThat(apprTarg.getState())
+                .as("approved targets should be set to fuzzy when source content changes")
+                .isEqualTo(ContentState.NeedReview);
+        assertThat(apprTarg.getVersionNum())
+                .isEqualTo(apprTargVersionBefore + 1);
         // Note: TFTRevision should be updated when target content or state is
         // changed in editor, not here.
-        assertThat(apprTarg.getTextFlowRevision()).isEqualTo(originalTFRevision);
+        assertThat(apprTarg.getTextFlowRevision())
+                .isEqualTo(originalTFRevision);
 
         assertThat(changed).isTrue();
     }

--- a/server/services/src/test/java/org/zanata/security/ZanataIdentityTest.java
+++ b/server/services/src/test/java/org/zanata/security/ZanataIdentityTest.java
@@ -130,10 +130,12 @@ public class ZanataIdentityTest extends ZanataJpaTest {
 
     @Test
     public void canAddRole() {
-        assertThat(identity.addRole("admin")).isFalse()
-                .as("before login addRole will not be successful");
-        assertThat(identity.hasRole("admin")).isFalse()
-                .as("before login hasRole is always false");
+        assertThat(identity.addRole("admin"))
+                .as("before login addRole will not be successful")
+                .isFalse();
+        assertThat(identity.hasRole("admin"))
+                .as("before login hasRole is always false")
+                .isFalse();
 
         identity.getCredentials().setUsername(username);
         identity.getCredentials().setPassword(validPassword);
@@ -141,8 +143,9 @@ public class ZanataIdentityTest extends ZanataJpaTest {
 
         assertThat(identity.hasRole("admin")).isFalse();
 
-        assertThat(identity.addRole("admin")).isTrue()
-                .as("after login addRole can be done");
+        assertThat(identity.addRole("admin"))
+                .as("after login addRole can be done")
+                .isTrue();
 
         assertThat(identity.hasRole("admin")).isTrue();
         identity.checkRole("admin"); // checkRole will not cause an exception
@@ -197,8 +200,9 @@ public class ZanataIdentityTest extends ZanataJpaTest {
     public void canTestPermission() {
         HAccountRole target = new HAccountRole();
         target.setName("user");
-        assertThat(identity.hasPermission(target, "seam.insert")).isFalse()
-                .as("only admin can create role");
+        assertThat(identity.hasPermission(target, "seam.insert"))
+                .as("only admin can create role")
+                .isFalse();
 
         identity.getCredentials().setUsername(username);
         identity.getCredentials().setPassword(validPassword);
@@ -207,8 +211,9 @@ public class ZanataIdentityTest extends ZanataJpaTest {
         boolean addedUser = identity.addRole("user");
         assert addedUser;
 
-        assertThat(identity.hasPermission(target, "seam.insert")).isFalse()
-                .as("ordinary user do not have permission to create role");
+        assertThat(identity.hasPermission(target, "seam.insert"))
+                .as("ordinary user do not have permission to create role")
+                .isFalse();
 
         boolean addedAdmin = identity.addRole("admin");
         assert addedAdmin;

--- a/server/services/src/test/java/org/zanata/validator/UsernameValidationTest.java
+++ b/server/services/src/test/java/org/zanata/validator/UsernameValidationTest.java
@@ -133,8 +133,8 @@ public class UsernameValidationTest {
                 validator.validateProperty(registerAction, "username");
 
         assertThat(constraintViolations.size())
-                .isGreaterThanOrEqualTo(1) // May cause multiple violations
-                .as("The username failed validation");
+                .as("The username failed validation")
+                .isGreaterThanOrEqualTo(1);
     }
 
     @Test
@@ -151,8 +151,8 @@ public class UsernameValidationTest {
                 validator.validateProperty(registerAction, "username");
 
         assertThat(constraintViolations.size())
-                .isEqualTo(0)
-                .as("The username passed validation");
+                .as("The username passed validation")
+                .isEqualTo(0);
     }
 
 }

--- a/server/services/src/test/java/org/zanata/validator/UsernameValidationTest.java
+++ b/server/services/src/test/java/org/zanata/validator/UsernameValidationTest.java
@@ -132,6 +132,7 @@ public class UsernameValidationTest {
         Set<ConstraintViolation<RegisterAction>> constraintViolations =
                 validator.validateProperty(registerAction, "username");
 
+        // May cause multiple violations
         assertThat(constraintViolations.size())
                 .as("The username failed validation")
                 .isGreaterThanOrEqualTo(1);

--- a/server/zanata-model/src/test/java/org/zanata/model/validator/SlugValidatorTest.java
+++ b/server/zanata-model/src/test/java/org/zanata/model/validator/SlugValidatorTest.java
@@ -98,7 +98,7 @@ public class SlugValidatorTest {
     @Test
     public void validateSlug() throws Exception {
         assertThat(slugValidator.isValid(slug, context))
-                .isEqualTo(isAcceptable)
-                .as("Slug is validated correctly");
+                .as("Slug is validated correctly")
+                .isEqualTo(isAcceptable);
     }
 }

--- a/server/zanata-war/src/test/java/org/zanata/rest/compat/StatisticsCompatibilityITCase.java
+++ b/server/zanata-war/src/test/java/org/zanata/rest/compat/StatisticsCompatibilityITCase.java
@@ -94,28 +94,33 @@ public class StatisticsCompatibilityITCase extends CompatibilityBase {
                             + langStats.getDraft()
                             + langStats.getTranslatedAndApproved());
             assertThat(langStats.getTotal())
-                    .isEqualTo(langStats.getUntranslated() + langStats.getDraft()
-                            + langStats.getTranslatedAndApproved());
+                    .isEqualTo(
+                            langStats.getUntranslated() + langStats.getDraft()
+                                    + langStats.getTranslatedAndApproved());
             assertThat(
                     langStats.getTotal())
-                    .isEqualTo(langStats.getUntranslated() + langStats.getFuzzy()
-                            + langStats.getRejected()
-                            + langStats.getTranslatedOnly()
-                            + langStats.getApproved());
+                    .isEqualTo(
+                            langStats.getUntranslated() + langStats.getFuzzy()
+                                    + langStats.getRejected()
+                                    + langStats.getTranslatedOnly()
+                                    + langStats.getApproved());
             // MatcherAssert.assertThat( 100,
             // Matchers.equalTo( asStats.getPercentNeedReview() +
             // asStats.getPercentUntranslated() + asStats.getPercentTranslated()
             // ));
             wordStatCount +=
-                    (langStats.getUnit() == TranslationStatistics.StatUnit.WORD ? 1
+                    (langStats.getUnit() ==
+                            TranslationStatistics.StatUnit.WORD ? 1
                             : 0);
             mssgStatCount +=
-                    (langStats.getUnit() == TranslationStatistics.StatUnit.MESSAGE ? 1
+                    (langStats.getUnit() ==
+                            TranslationStatistics.StatUnit.MESSAGE ? 1
                             : 0);
         }
 
-        assertThat(wordStatCount).isEqualTo(mssgStatCount)
-                .as("Word and Message level stat count should match");
+        assertThat(wordStatCount)
+                .as("Word and Message level stat count should match")
+                .isEqualTo(mssgStatCount);
     }
 
     @Test
@@ -136,28 +141,33 @@ public class StatisticsCompatibilityITCase extends CompatibilityBase {
                             + langStats.getDraft()
                             + langStats.getTranslatedAndApproved());
             assertThat(langStats.getTotal())
-                    .isEqualTo(langStats.getUntranslated() + langStats.getDraft()
-                            + langStats.getTranslatedAndApproved());
+                    .isEqualTo(
+                            langStats.getUntranslated() + langStats.getDraft()
+                                    + langStats.getTranslatedAndApproved());
             assertThat(
                     langStats.getTotal())
-                    .isEqualTo(langStats.getUntranslated() + langStats.getFuzzy()
-                            + langStats.getRejected()
-                            + langStats.getTranslatedOnly()
-                            + langStats.getApproved());
+                    .isEqualTo(
+                            langStats.getUntranslated() + langStats.getFuzzy()
+                                    + langStats.getRejected()
+                                    + langStats.getTranslatedOnly()
+                                    + langStats.getApproved());
             // MatcherAssert.assertThat( 100,
             // Matchers.equalTo( asStats.getPercentNeedReview() +
             // asStats.getPercentUntranslated() + asStats.getPercentTranslated()
             // ));
             wordStatCount +=
-                    (langStats.getUnit() == TranslationStatistics.StatUnit.WORD ? 1
+                    (langStats.getUnit() ==
+                            TranslationStatistics.StatUnit.WORD ? 1
                             : 0);
             mssgStatCount +=
-                    (langStats.getUnit() == TranslationStatistics.StatUnit.MESSAGE ? 1
+                    (langStats.getUnit() ==
+                            TranslationStatistics.StatUnit.MESSAGE ? 1
                             : 0);
         }
 
-        assertThat(wordStatCount).isEqualTo(mssgStatCount)
-                .as("Word and Message level stat count should match");
+        assertThat(wordStatCount)
+                .as("Word and Message level stat count should match")
+                .isEqualTo(mssgStatCount);
     }
 
     @Test

--- a/server/zanata-war/src/test/java/org/zanata/rest/service/raw/TranslationResourceRestITCase.java
+++ b/server/zanata-war/src/test/java/org/zanata/rest/service/raw/TranslationResourceRestITCase.java
@@ -257,12 +257,14 @@ public class TranslationResourceRestITCase extends SourceAndTranslationResourceR
                 false);
         TranslationsResource trans = createTargetDoc();
         getTransResource()
-                .putTranslationsWithDocId(nbLocale, trans, docName, null, "auto");
+                .putTranslationsWithDocId(nbLocale, trans, docName, null,
+                        "auto");
 
         {
             Response response =
                     getSourceDocResource().getResourceWithDocId(docName, null);
-            assertThat(response.getStatus()).isEqualTo(Status.OK.getStatusCode());
+            assertThat(response.getStatus())
+                    .isEqualTo(Status.OK.getStatusCode());
 
             Resource doc = getResourceFromResponse(response);
             assertThat(doc.getTextFlows().size()).isEqualTo(1);
@@ -275,18 +277,24 @@ public class TranslationResourceRestITCase extends SourceAndTranslationResourceR
                                 null);
         assertThat(response.getStatus()).isEqualTo(Status.OK.getStatusCode());
 
-        TranslationsResource doc = getTranslationsResourceFromResponse(response);
-        assertThat(doc.getTextFlowTargets().size()).isEqualTo(1)
-                .as("should have one textFlow");
+        TranslationsResource doc =
+                getTranslationsResourceFromResponse(response);
+        assertThat(doc.getTextFlowTargets().size())
+                .as("should have one textFlow")
+                .isEqualTo(1);
         TextFlowTarget tft = doc.getTextFlowTargets().get(0);
 
         assertThat(tft).isNotNull();
-        assertThat(tft.getResId()).isEqualTo("tf1")
-                .as("should have a textflow with this id");
+        assertThat(tft.getResId())
+                .as("should have a textflow with this id")
+                .isEqualTo("tf1");
 
-        assertThat(tft).isNotNull().as("expected de target");
-        assertThat(tft.getContents()).isEqualTo(asList("hei verden"))
-                .as("expected translation for de");
+        assertThat(tft)
+                .as("expected de target")
+                .isNotNull();
+        assertThat(tft.getContents())
+                .as("expected translation for de")
+                .isEqualTo(asList("hei verden"));
     }
 
     @Test
@@ -368,26 +376,34 @@ public class TranslationResourceRestITCase extends SourceAndTranslationResourceR
         Response response = getSourceDocResource()
                 .putResourceWithDocId(doc, docName, null, false);
 
-        assertThat(response.getStatus()).isEqualTo(Status.CREATED.getStatusCode());
+        assertThat(response.getStatus())
+                .isEqualTo(Status.CREATED.getStatusCode());
         assertThat(response.getMetadata().getFirst("Location").toString())
-                .endsWith(BASE_PATH + "?docId=" + UrlUtil.encodeString(docName));
+                .endsWith(
+                        BASE_PATH + "?docId=" + UrlUtil.encodeString(docName));
 
         Response documentResponse =
                 getSourceDocResource().getResourceWithDocId(docName, null);
 
-        assertThat(documentResponse.getStatus()).isEqualTo(Status.OK.getStatusCode());
+        assertThat(documentResponse.getStatus())
+                .isEqualTo(Status.OK.getStatusCode());
 
         doc = getResourceFromResponse(documentResponse);
 
         assertThat(doc.getRevision()).isEqualTo(1);
 
-        assertThat(doc.getTextFlows()).isNotNull().as("Should have textFlows");
-        assertThat(doc.getTextFlows().size()).isEqualTo(2)
-                .as("Should have 2 textFlows");
-        assertThat(doc.getTextFlows().get(0).getId()).isEqualTo("tf1")
-                .as("Should have tf1 textFlow");
-        assertThat(doc.getTextFlows().get(1).getId()).isEqualTo(tf3.getId())
-                .as("Container1 should have tf3 textFlow");
+        assertThat(doc.getTextFlows())
+                .as("Should have textFlows")
+                .isNotNull();
+        assertThat(doc.getTextFlows().size())
+                .as("Should have 2 textFlows")
+                .isEqualTo(2);
+        assertThat(doc.getTextFlows().get(0).getId())
+                .as("Should have tf1 textFlow")
+                .isEqualTo("tf1");
+        assertThat(doc.getTextFlows().get(1).getId())
+                .as("Container1 should have tf3 textFlow")
+                .isEqualTo(tf3.getId());
 
         textFlow = doc.getTextFlows().get(0);
         textFlow.setId("tf2");
@@ -400,16 +416,21 @@ public class TranslationResourceRestITCase extends SourceAndTranslationResourceR
 
         documentResponse = getSourceDocResource()
                 .getResourceWithDocId(docName, null);
-        assertThat(documentResponse.getStatus()).isEqualTo(Status.OK.getStatusCode());
+        assertThat(documentResponse.getStatus())
+                .isEqualTo(Status.OK.getStatusCode());
         doc = getResourceFromResponse(documentResponse);
 
         assertThat(doc.getRevision()).isEqualTo(2);
 
-        assertThat(doc.getTextFlows()).isNotNull().as("Should have textFlows");
-        assertThat(doc.getTextFlows().size()).isEqualTo(2)
-                .as("Should have two textFlows");
-        assertThat(doc.getTextFlows().get(0).getId()).isEqualTo("tf2")
-                .as("should have same id");
+        assertThat(doc.getTextFlows())
+                .as("Should have textFlows")
+                .isNotNull();
+        assertThat(doc.getTextFlows().size())
+                .as("Should have two textFlows")
+                .isEqualTo(2);
+        assertThat(doc.getTextFlows().get(0).getId())
+                .as("should have same id")
+                .isEqualTo("tf2");
     }
 
     @Test
@@ -656,8 +677,10 @@ public class TranslationResourceRestITCase extends SourceAndTranslationResourceR
                     headerFound = true;
                 }
             }
-            assertThat(headerFound).isTrue().as("PO Target Header '" + reqHeader
-                    + "' was not present when pulling translations.");
+            assertThat(headerFound)
+                    .as("PO Target Header '" + reqHeader
+                            + "' was not present when pulling translations.")
+                    .isTrue();
         }
 
         /**


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2555

Fixed using IntelliJ IDEA's structural search (396 replacements):

    assertThat($actual$)
        .$assertion$($assertArgs$)
        .$as$($description$);

with replacement:

    assertThat($actual$)
        .$as$($description$)
        .$assertion$($assertArgs$);

- the variable `$as$` is configured with the text regex: `(as|describedAs)` (just `as` would work too, and runs faster. We didn't misuse `describedAs` the same way.)
- `$assertion$` and `$assertArgs$` have occurences: 0 to infinity

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
