### PR TITLE
fix(ZNTA-2517) add ellipsis to delete group modal

### DIFF
--- a/server/zanata-frontend/src/app/styles/frontend-jsf.less
+++ b/server/zanata-frontend/src/app/styles/frontend-jsf.less
@@ -17,6 +17,9 @@ body.bodyStyle {
   .bg--pop-highest {
     border: none;
   }
+  h2.modal__title.ellipsis {
+    padding-right: 3rem;
+  }
   /* Fixes for Add translation modal buttons */
   #uploadForm .rf-fu,
   #uploadForm .rf-fu-btns-lft,

--- a/server/zanata-war/src/main/webapp/WEB-INF/layout/version-group/delete_group_confirmation_modal.xhtml
+++ b/server/zanata-war/src/main/webapp/WEB-INF/layout/version-group/delete_group_confirmation_modal.xhtml
@@ -30,7 +30,9 @@
     role="dialog" >
     <div class="modal__dialog l--constrain-medium">
       <header class="modal__header">
-        <h2 class="modal__title">#{msgs.format('jsf.DeleteConfirmation', 'group', entityName)}</h2>
+        <h2 class="modal__title ellipsis">
+          #{msgs.format('jsf.DeleteConfirmation', 'group', entityName)}
+        </h2>
         <button class="modal__close button--link" data-dismiss="modal"><i
           class="i i--huge i--cancel"></i></button>
       </header>


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2517

fix(ZNTA-2517) add ellipsis to handle long group names in delete group modal

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
