### PR TITLE
refactor(ZNTA-2584): EditorSearchInput to use Ant Collapse

### DIFF
--- a/server/zanata-frontend/src/app/editor/components/EditorSearchInput/EditorSearchInput.test.js
+++ b/server/zanata-frontend/src/app/editor/components/EditorSearchInput/EditorSearchInput.test.js
@@ -5,7 +5,11 @@ import React from 'react'
 import * as ReactDOMServer from 'react-dom/server'
 import * as TestUtils from 'react-dom/test-utils'
 import { EditorSearchInput } from '.'
-import { Panel, Button } from 'react-bootstrap'
+import Collapse from 'antd/lib/collapse'
+import 'antd/lib/collapse/style/css'
+import Button from 'antd/lib/button'
+import 'antd/lib/button/style/css'
+const Panel = Collapse.Panel
 
 const callback = () => {}
 
@@ -41,85 +45,95 @@ describe('EditorSearchInputTest', () => {
           <span className="EditorInputGroup-addon btn-xs btn-link n1"
             >Hide advanced</span>
         </div>
-        <Panel collapsible expanded>
-          <div title="exact Resource ID for a string"
-            className="u-sPB-1-2">
-            <label className="u-textSecondary u-sPB-1-4">Resource ID</label>
-            <input type="text"
-              onChange={callback}
-              placeholder="exact Resource ID for a string"
-              className="u-bgHighest u-sizeFull u-inputFlat u-sP-1-2 u-rounded u-sMH-1-4 u-sMV-1-8"
-              value="para-0001" />
-          </div>
-          <div title="username"
-            className="u-sPB-1-2">
-            <label className="u-textSecondary u-sPB-1-4">
-              Last modified by
-            </label>
-            <input type="text"
-              onChange={callback}
-              placeholder="username"
-              className="u-bgHighest u-sizeFull u-inputFlat u-sP-1-2 u-rounded u-sMH-1-4 u-sMV-1-8"
-              value="cdickens" />
-          </div>
-          <div title="date in format yyyy/mm/dd"
-            className="u-sPB-1-2">
-            <label className="u-textSecondary u-sPB-1-4">
-              Last modified before
-            </label>
-            <input type="text"
-              onChange={callback}
-              placeholder="date in format yyyy/mm/dd"
-              className="u-bgHighest u-sizeFull u-inputFlat u-sP-1-2 u-rounded u-sMH-1-4 u-sMV-1-8"
-              value="1859-12-31" />
-          </div>
-          <div title="date in format yyyy/mm/dd"
-            className="u-sPB-1-2">
-            <label className="u-textSecondary u-sPB-1-4">
-              Last modified after
-            </label>
-            <input type="text"
-              onChange={callback}
-              placeholder="date in format yyyy/mm/dd"
-              className="u-bgHighest u-sizeFull u-inputFlat u-sP-1-2 u-rounded u-sMH-1-4 u-sMV-1-8"
-              value="1859-01-01" />
-          </div>
-          <div title="source comment text"
-            className="u-sPB-1-2">
-            <label className="u-textSecondary u-sPB-1-4">Source comment</label>
-            <input type="text"
-              onChange={callback}
-              placeholder="source comment text"
-              className="u-bgHighest u-sizeFull u-inputFlat u-sP-1-2 u-rounded u-sMH-1-4 u-sMV-1-8"
-              value="England and France" />
-          </div>
-          <div title="translation comment text"
-            className="u-sPB-1-2">
-            <label className="u-textSecondary u-sPB-1-4">
-              Translation comment
-            </label>
-            <input type="text"
-              onChange={callback}
-              placeholder="translation comment text"
-              className="u-bgHighest u-sizeFull u-inputFlat u-sP-1-2 u-rounded u-sMH-1-4 u-sMV-1-8"
-              value="blurst of times?! You stupid monkey!" />
-          </div>
-          <div title="exact Message Context for a string"
-            className="u-sPB-1-2">
-            <label className="u-textSecondary u-sPB-1-4">
-              msgctxt (gettext)
-            </label>
-            <input type="text"
-              onChange={callback}
-              placeholder="exact Message Context for a string"
-              className="u-bgHighest u-sizeFull u-inputFlat u-sP-1-2 u-rounded u-sMH-1-4 u-sMV-1-8"
-              value="chapter01.txt" />
-          </div>
-          <Button bsStyle="link" bsSize="xsmall" className="AdvSearch-clear"
-            onClick={callback}>
-            Clear all
-          </Button>
-        </Panel>
+        <Collapse activeKey={'1'} onChange={callback}
+          style={{
+            zIndex: '1000',
+            position: 'absolute',
+            marginBottom: '0.5rem',
+            width: '100%'
+          }}>
+          <Panel key='1' header={undefined} showArrow={false}>
+            <span>
+              <div title="exact Resource ID for a string"
+                className="u-sPB-1-2">
+                <label className="u-textSecondary u-sPB-1-4">Resource ID</label>
+                <input type="text"
+                  onChange={callback}
+                  placeholder="exact Resource ID for a string"
+                  className="u-bgHighest u-sizeFull u-inputFlat u-sP-1-2 u-rounded u-sMH-1-4 u-sMV-1-8"
+                  value="para-0001" />
+              </div>
+              <div title="username"
+                className="u-sPB-1-2">
+                <label className="u-textSecondary u-sPB-1-4">
+                  Last modified by
+                </label>
+                <input type="text"
+                  onChange={callback}
+                  placeholder="username"
+                  className="u-bgHighest u-sizeFull u-inputFlat u-sP-1-2 u-rounded u-sMH-1-4 u-sMV-1-8"
+                  value="cdickens" />
+              </div>
+              <div title="date in format yyyy/mm/dd"
+                className="u-sPB-1-2">
+                <label className="u-textSecondary u-sPB-1-4">
+                  Last modified before
+                </label>
+                <input type="text"
+                  onChange={callback}
+                  placeholder="date in format yyyy/mm/dd"
+                  className="u-bgHighest u-sizeFull u-inputFlat u-sP-1-2 u-rounded u-sMH-1-4 u-sMV-1-8"
+                  value="1859-12-31" />
+              </div>
+              <div title="date in format yyyy/mm/dd"
+                className="u-sPB-1-2">
+                <label className="u-textSecondary u-sPB-1-4">
+                  Last modified after
+                </label>
+                <input type="text"
+                  onChange={callback}
+                  placeholder="date in format yyyy/mm/dd"
+                  className="u-bgHighest u-sizeFull u-inputFlat u-sP-1-2 u-rounded u-sMH-1-4 u-sMV-1-8"
+                  value="1859-01-01" />
+              </div>
+              <div title="source comment text"
+                className="u-sPB-1-2">
+                <label className="u-textSecondary u-sPB-1-4">Source comment</label>
+                <input type="text"
+                  onChange={callback}
+                  placeholder="source comment text"
+                  className="u-bgHighest u-sizeFull u-inputFlat u-sP-1-2 u-rounded u-sMH-1-4 u-sMV-1-8"
+                  value="England and France" />
+              </div>
+              <div title="translation comment text"
+                className="u-sPB-1-2">
+                <label className="u-textSecondary u-sPB-1-4">
+                  Translation comment
+                </label>
+                <input type="text"
+                  onChange={callback}
+                  placeholder="translation comment text"
+                  className="u-bgHighest u-sizeFull u-inputFlat u-sP-1-2 u-rounded u-sMH-1-4 u-sMV-1-8"
+                  value="blurst of times?! You stupid monkey!" />
+              </div>
+              <div title="exact Message Context for a string"
+                className="u-sPB-1-2">
+                <label className="u-textSecondary u-sPB-1-4">
+                  msgctxt (gettext)
+                </label>
+                <input type="text"
+                  onChange={callback}
+                  placeholder="exact Message Context for a string"
+                  className="u-bgHighest u-sizeFull u-inputFlat u-sP-1-2 u-rounded u-sMH-1-4 u-sMV-1-8"
+                  value="chapter01.txt" />
+              </div>
+              <Button size={'small'} aria-label='button' className="AdvSearch-clear"
+                onClick={callback}>
+                Clear all
+              </Button>
+            </span>
+          </Panel>
+        </Collapse>
       </div>
       /* eslint-enable max-len */
     )

--- a/server/zanata-frontend/src/app/editor/components/EditorSearchInput/index.css
+++ b/server/zanata-frontend/src/app/editor/components/EditorSearchInput/index.css
@@ -3,6 +3,8 @@
   --Input-color-mid: #20718A;
 }
 
+/* Set custom styles for ant-collapse */
+
 .InputEditorSearch {
   margin-left: 0.75rem;
   margin-right: 1rem;
@@ -11,12 +13,43 @@
   flex: 2 0 16rem;
 }
 
+/* Hide the ant collapse header and borders */
+.InputEditorSearch .ant-collapse-header {
+  display: none;
+}
+
+.InputEditorSearch .ant-collapse {
+  border: none;
+}
+
+.InputEditorSearch .ant-collapse .ant-collapse-item {
+  border: none;
+}
+.InputEditorSearch .ant-collapse-content {
+  border: none;
+}
+
+.InputEditorSearch .ant-collapse {
+  width: 100%;
+  margin-bottom: 0.5rem !important;
+  position: absolute;
+  z-index: 1000;
+}
+
 .InputEditorSearch .EditorInputGroup-addon.btn-xs {
   padding-left: 1rem;
 }
 
 .InputEditorSearch input {
   font-size: 0.875rem;
+}
+
+.InputEditorSearch .ant-collapse-content-box {
+  background-color: var(--u-bg-color-lighter);
+}
+
+.InputEditorSearch .ant-collapse-content-box input {
+  box-shadow: var(--default-box-shadow-inset)
 }
 
 .InputEditorSearch > div {
@@ -32,21 +65,6 @@
 /* advanced search panel */
 
 /* bootstrap classes used throughout */
-
-.InputEditorSearch .panel {
-  margin-bottom: 0.5rem !important;
-  position: absolute;
-  width: 100%;
-}
-
-.InputEditorSearch .panel-body {
-  /* bootstrap panel cannot use utility class u-bgHigher directly */
-  background-color: var(--u-bg-color-lighter);
-}
-
-.InputEditorSearch .panel-body input {
-  box-shadow: var(--default-box-shadow-inset)
-}
 
 .InputEditorSearch .icon-help button {
   vertical-align: sub;
@@ -85,21 +103,6 @@ li.InlineSearch-list span {
   width: 90%;
 }
 
-.InputEditorSearch .panel.panel-default {
-  z-index: 1000 !important;
-}
-
 .flex ul.u-listHorizontal {
   z-index: 999 !important;
 }
-
-.panel {
-  border: none !important;
-}
-
-button.AdvSearch-clear {
-  color: #03A6D7;
-  padding: 0;
-  padding-top: 0.75rem;
-}
-

--- a/server/zanata-frontend/src/app/editor/components/EditorSearchInput/index.js
+++ b/server/zanata-frontend/src/app/editor/components/EditorSearchInput/index.js
@@ -25,12 +25,16 @@ import { connect } from 'react-redux'
 import React from 'react'
 import { Component } from 'react'
 import * as PropTypes from 'prop-types'
-import { Panel, Button } from 'react-bootstrap'
 import { map } from 'lodash'
 import {
   toggleAdvanced,
   updatePhraseFilter
 } from '../../actions/phrases-filter-actions'
+import Collapse from 'antd/lib/collapse'
+import 'antd/lib/collapse/style/css'
+import Button from 'antd/lib/button'
+import 'antd/lib/button/style/css'
+const Panel = Collapse.Panel
 
 const fields = {
   resId: {
@@ -196,13 +200,23 @@ export class EditorSearchInput extends Component {
             onClick={this.toggleAdvanced}>
             {showAdvanced ? 'Hide advanced' : 'Advanced'}</span>
         </div>
-        <Panel collapsible expanded={showAdvanced}>
-          {advancedFields}
-          <Button bsStyle="link" bsSize="xsmall" className="AdvSearch-clear"
-            onClick={this.clearAllAdvancedFields}>
-            Clear all
-          </Button>
-        </Panel>
+        <Collapse activeKey={showAdvanced ? '1' : null} onChange={this.toggleAdvanced}
+          style={{
+            zIndex: '1000',
+            position: 'absolute',
+            marginBottom: '0.5rem',
+            width: '100%'
+          }}>
+          <Panel key='1' header={undefined} showArrow={false}>
+            <span>
+              {advancedFields}
+              <Button size={'small'} aria-label='button' className="AdvSearch-clear"
+                onClick={this.clearAllAdvancedFields}>
+                Clear all
+              </Button>
+            </span>
+          </Panel>
+        </Collapse>
       </div>
     )
   }


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2584

Found other components had the same issue with an unwanted collapse header, I could use the Ant Collapse with a controlled panel by hiding the header.
Updated the styles to match the new components elements:
![antcollapse](https://user-images.githubusercontent.com/7971187/40641699-e3141106-635d-11e8-8362-2aed863e66dd.png)

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
