### PR TITLE
fix(ZNTA-821): alpha editor to use zanata language setting as lang attribute

### DIFF
--- a/server/zanata-frontend/src/app/editor/entrypoint/index.js
+++ b/server/zanata-frontend/src/app/editor/entrypoint/index.js
@@ -35,7 +35,13 @@ import '../index.css'
  */
 function runApp () {
   // Dynamically load the locale data of the selected appLocale
-  addLocaleData(require(`react-intl/locale-data/${appLocale}`))
+  try {
+    addLocaleData(require(`react-intl/locale-data/${appLocale}`))
+  } catch (e) {
+    console.error(`Locale module not found for locale: ${appLocale}
+    Defaulting to en`)
+    addLocaleData(require('react-intl/locale-data/en'))
+  }
 
   const history = browserHistory
   history.basename = appUrl

--- a/server/zanata-war/src/main/webapp/editor/index.xhtml
+++ b/server/zanata-war/src/main/webapp/editor/index.xhtml
@@ -25,7 +25,7 @@
   xmlns="http://www.w3.org/1999/xhtml"
   xmlns:f="http://java.sun.com/jsf/core">
 
-  <html lang="en">
+  <html lang="#{localeSelectorAction.getLocale()}">
   <head>
     <meta http-equiv="Content-Type" content="text/html; charset=UTF-8"/>
     <meta http-equiv="X-UA-Compatible" content="IE=edge,chrome=1"/>


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-821

In the Alpha (webapp) version, a global {{<html ... lang="en">}} attribute is present, making all the text being treated as English text in the browser. Since browsers (like Chrome) may choose fonts and sometimes OpenType features like {{locl}} by this attribute, many text end up being rendered oddly or even wrongly.

Updated the Alpha Editor index.xhtml to use the user selected language for Zanata in the html lang attribute
The selected language for Zanata also determines the localization of the alpha editor (if translations are available for the locale):
![htmllang](https://user-images.githubusercontent.com/7971187/40755698-cfb40808-64c2-11e8-9997-4ce2c84a9c69.png)

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
