### PR TITLE
fix(ZNTA-2591) remove extra width and height from languages page + minor styling fixes

### DIFF
--- a/server/zanata-frontend/src/app/containers/Languages/index.js
+++ b/server/zanata-frontend/src/app/containers/Languages/index.js
@@ -187,10 +187,9 @@ class Languages extends Component {
                   </div>)}
                   {noResults &&
                     <div className='loader-loadingContainer'>
-                      <span className='u-textLoadingMuted'>
-                        <Icon type='global' />
-                      </span>
-                      <p className='glossaryText-muted'>No results</p>
+                      <p className='glossaryText-muted'>
+                        <Icon type='global' />&bsp;No results
+                      </p>
                     </div>
                   }
                   {!loading && !noResults &&

--- a/server/zanata-frontend/src/app/containers/Languages/index.js
+++ b/server/zanata-frontend/src/app/containers/Languages/index.js
@@ -108,7 +108,7 @@ class Languages extends Component {
 
     /* eslint-disable max-len, react/jsx-no-bind */
     return (
-      <div className='wideView bstrapReact languages'>
+      <div className='bstrapReact languages'>
         <Layout>
           {notification &&
           (<Notification severity={notification.severity}

--- a/server/zanata-frontend/src/app/containers/Languages/index.less
+++ b/server/zanata-frontend/src/app/containers/Languages/index.less
@@ -55,7 +55,8 @@
 }
 
 .languages {
-
+  padding: 1rem;
+  
   span.languageCode {
     font-size: 0.9rem;
     color: #aaa;

--- a/server/zanata-frontend/src/app/styles/antd.less
+++ b/server/zanata-frontend/src/app/styles/antd.less
@@ -1,2 +1,6 @@
 @import "~antd/dist/antd.less";
 @import "./ant-theme-vars.less";
+
+input.react-autosuggest__input {
+  background-color: transparent;
+}

--- a/server/zanata-frontend/src/app/styles/style.less
+++ b/server/zanata-frontend/src/app/styles/style.less
@@ -65,10 +65,8 @@
     -webkit-align-items: center;
     /* Safari 7.0+ */
     overflow: hidden;
-    overflow-x: hidden;
     -webkit-overflow-scrolling: touch;
     max-width: 100%;
-    width: inherit;
     margin-left: 1rem;
     padding-left: @spacing-base;
     padding-right: @spacing-base;

--- a/server/zanata-frontend/src/app/styles/style.less
+++ b/server/zanata-frontend/src/app/styles/style.less
@@ -57,7 +57,6 @@
   .containerSidebar {
     margin-left: 4.5rem;
     background-color: #fff;
-    height: 100vh;
     padding-bottom: 3rem;
   }
   .wideView {
@@ -66,12 +65,12 @@
     /* Safari 7.0+ */
     overflow: hidden;
     -webkit-overflow-scrolling: touch;
-    max-width: 100%;
+    width: 99%;
     margin-left: 1rem;
     padding-left: @spacing-base;
     padding-right: @spacing-base;
   }
-  .wideView.languages, .wideView#glossary {
+  .wideView#glossary {
     padding-bottom: 3rem;
   }
   .gwtBase {
@@ -4067,7 +4066,7 @@
     }
     .containerSidebar {
       margin-left: 4.5rem;
-      width: 100%;
+      width: 95%;
       margin-bottom: 0;
     }
     #root {

--- a/server/zanata-frontend/src/app/styles/style.less
+++ b/server/zanata-frontend/src/app/styles/style.less
@@ -66,7 +66,6 @@
     overflow: hidden;
     -webkit-overflow-scrolling: touch;
     width: 99%;
-    margin-left: 1rem;
     padding-left: @spacing-base;
     padding-right: @spacing-base;
   }


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2591

remove extra vertical and horizontal scrolling from languages page by removing wideView container
also small styling fixes to page

- Fedora, Chrome.
- vertical scroll cannot be replicated on macOS

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
