### PR TITLE
fix(ZNTA-2613): hide activity commentbox when no translations to comment on

### DIFF
--- a/server/zanata-frontend/src/app/editor/containers/ActivityTab.tsx
+++ b/server/zanata-frontend/src/app/editor/containers/ActivityTab.tsx
@@ -180,6 +180,10 @@ const ActivityTab: React.SFC<ActivityTabProps> = ({
       pageCount={pageCount}
       countPerPage={COUNT_PER_PAGE}
     />
+  // Do not show the comment box if no translations to comment on
+  const commentBox = isEmpty(latest)
+    ? DO_NOT_RENDER
+    : <CommentBox postComment={postComment} maxLength={commentTextLimit} />
   return (
     <div>
       <div className="SidebarEditor-wrapper" id="SidebarEditorTabs-pane2">
@@ -187,7 +191,7 @@ const ActivityTab: React.SFC<ActivityTabProps> = ({
           selected={selectedActivites} />
       </div>
       <div className="SidebarActivity">
-        <CommentBox postComment={postComment} maxLength={commentTextLimit} />
+        {commentBox}
         {ActivityPager}
       </div>
     </div>


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2613

Hide the commentbox in the activity panel when there are no translations to comment on

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
