### PR TITLE
fix(ZNTA-2608): reset new language form fields on close or submit

### DIFF
--- a/server/zanata-frontend/src/app/containers/Languages/NewLanguageModal.js
+++ b/server/zanata-frontend/src/app/containers/Languages/NewLanguageModal.js
@@ -56,6 +56,7 @@ class NewLanguageModal extends Component {
   }
 
   resetFields = () => {
+    this.props.form.resetFields()
     this.setState({
       details: {
         enabledByDefault: true,


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2608

When we are adding new languages after adding 1st language, once we again click on Add new language buttons it shows previously added language details.

Fixed by resetting the form fields when closing the modal or on new language submission.

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
