### PR TITLE
fix(ZNTA-2615): alpha editor translate button

### DIFF
--- a/server/zanata-frontend/src/app/editor/components/SplitDropdown/index.js
+++ b/server/zanata-frontend/src/app/editor/components/SplitDropdown/index.js
@@ -51,9 +51,9 @@ class SplitDropdown extends React.Component {
       /* eslint-disable max-len */
       <div className={className}>
         <ButtonGroup className="ButtonGroup--hz ButtonGroup--borderCollapse u-rounded">
-          <Button className="ButtonGroup-item">
+          <div className="ButtonGroup-item">
             {this.props.actionButton}
-          </Button>
+          </div>
           {toggleButtonItem}
         </ButtonGroup>
         {this.props.content}


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2615

Alpha Editor translate button was not responsive.
Selecting 'needs work' from the drop down worked as expected, as does navigating to another textflow.

Nested button in SplitDropdown component caused invalid html, breaking the translate button in Firefox browsers.

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
