### PR TITLE
fix(ZNTA-2617) add spacing to delete entry buttons on language page

### DIFF
--- a/server/zanata-frontend/src/app/containers/Languages/DeleteEntry.js
+++ b/server/zanata-frontend/src/app/containers/Languages/DeleteEntry.js
@@ -22,11 +22,11 @@ class DeleteEntry extends Component {
     /* eslint-disable react/jsx-no-bind */
     const deleteLanguage = (
       <span>
-        <p>Are you sure you want to delete&nbsp;
+        <p className='tc'>Are you sure you want to delete&nbsp;
           <strong>{locale.displayName}</strong>?&nbsp;
         </p>
-        <span className='button-spacing'>
-          <Button className='btn-default btn-sm' aria-label='button'
+        <p className='button-spacing tc'>
+          <Button className='btn-default btn-sm mr3' aria-label='button'
             onClick={() => handleDeleteEntryDisplay(false)}>
             Cancel
           </Button>
@@ -38,7 +38,7 @@ class DeleteEntry extends Component {
             }}>
             Delete
           </Button>
-        </span>
+        </p>
       </span>
     )
 

--- a/server/zanata-frontend/src/app/containers/Languages/index.js
+++ b/server/zanata-frontend/src/app/containers/Languages/index.js
@@ -188,9 +188,8 @@ class Languages extends Component {
                   {noResults &&
                     <div className='loader-loadingContainer'>
                       <span className='u-textLoadingMuted'>
-                        <Icon type='global' />
+                        <Icon type='global' /> No results
                       </span>
-                      <p className='glossaryText-muted'>No results</p>
                     </div>
                   }
                   {!loading && !noResults &&


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2617

fix(ZNTA-2617) add spacing to delete entry buttons on language page & fix alignment of no languages statement when page is loading

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
