### PR TITLE
fix(ZNTA-2614) increase contrast of concurrent editor username in gwt editor

### DIFF
--- a/server/gwt-editor/src/main/java/org/zanata/webtrans/client/ui/TranslatorListWidget.ui.xml
+++ b/server/gwt-editor/src/main/java/org/zanata/webtrans/client/ui/TranslatorListWidget.ui.xml
@@ -5,8 +5,8 @@
     .userLabel {
       text-overflow: ellipsis;
       overflow: hidden;
+      background-color: rgba(0,0,0,1) !important;
     }
-
   </ui:style>
 
   <g:HTMLPanel tag="ul" ui:field="container"


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2614

The GWT badges were applying a colour by default which I have overriden to be black (rgba(0,0,0,1)). **The opacity on this badge cannot be turned off,** have attempted everything css wise - looks like this is the best I can get it without increasing font size and messing with the whole translation panel layout

**Before**
![screenshot from 2018-06-07 11-19-57](https://user-images.githubusercontent.com/18179401/41138420-7df85574-6b24-11e8-86ca-f2849dccde27.png)


**After**
![gwtcontrast](https://user-images.githubusercontent.com/18179401/41138315-dd5d0754-6b23-11e8-9453-1733ec005f4d.png)


## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
