### PR TITLE
fix(ZNTA-2612) hide translation-comment search (can't show/edit)

### DIFF
--- a/server/gwt-editor/src/main/java/org/zanata/webtrans/client/ui/EditorSearchField.ui.xml
+++ b/server/gwt-editor/src/main/java/org/zanata/webtrans/client/ui/EditorSearchField.ui.xml
@@ -46,7 +46,10 @@
         <li class="js-suggest__result autocomplete__result" data-key="last-modified-before">last-modified-before: <span class="txt--understated">date in format yyyy-mm-dd</span></li>
         <li class="js-suggest__result autocomplete__result" data-key="last-modified-after">last-modified-after: <span class="txt--understated">date in format yyyy-mm-dd</span></li>
         <li class="js-suggest__result autocomplete__result" data-key="source-comment">source-comment: <span class="txt--understated">source comment text</span></li>
-        <li class="js-suggest__result autocomplete__result" data-key="translation-comment">translation-comment: <span class="txt--understated">translation comment text</span></li>
+        <!-- Disabled for now (ZNTA-2612) because it only searches for
+             translator comments (which Zanata can't show), not review comments. -->
+        <!-- Note that entity #45 is a dash (can't have two dashes in a comment) - IntelliJ can fix when uncommenting. -->
+        <!--<li class="js-suggest__result autocomplete__result" data-key="translation-comment">translation-comment: <span class="txt&#45;&#45;understated">translation comment text</span></li>-->
         <li class="js-suggest__result autocomplete__result" data-key="msgctxt">msgctxt: <span class="txt--understated">exact Message Context for a string</span></li>
       </ul>
     </g:HTMLPanel>


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2612

Zanata can't currently show or edit translator comments, so it's just confusing to have a feature which searches for them. It can't even show the matching comment.

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
