### PR TITLE
fix(ZNTA-2626): hide translation-comment search (can't show/edit)

### DIFF
--- a/server/zanata-frontend/src/app/editor/components/EditorSearchInput/EditorSearchInput.test.js
+++ b/server/zanata-frontend/src/app/editor/components/EditorSearchInput/EditorSearchInput.test.js
@@ -93,17 +93,6 @@ describe('EditorSearchInputTest', () => {
               className="u-bgHighest u-sizeFull u-inputFlat u-sP-1-2 u-rounded u-sMH-1-4 u-sMV-1-8"
               value="England and France" />
           </div>
-          <div title="translation comment text"
-            className="u-sPB-1-2">
-            <label className="u-textSecondary u-sPB-1-4">
-              Translation comment
-            </label>
-            <input type="text"
-              onChange={callback}
-              placeholder="translation comment text"
-              className="u-bgHighest u-sizeFull u-inputFlat u-sP-1-2 u-rounded u-sMH-1-4 u-sMV-1-8"
-              value="blurst of times?! You stupid monkey!" />
-          </div>
           <div title="exact Message Context for a string"
             className="u-sPB-1-2">
             <label className="u-textSecondary u-sPB-1-4">
@@ -123,6 +112,22 @@ describe('EditorSearchInputTest', () => {
       </div>
       /* eslint-enable max-len */
     )
+// When we uncomment transComment in EditorSearchInput/index.js, this
+// should go after the diff for "source comment text" above:
+/*
+          <div title="translation comment text"
+            className="u-sPB-1-2">
+            <label className="u-textSecondary u-sPB-1-4">
+              Translation comment
+            </label>
+            <input type="text"
+              onChange={callback}
+              placeholder="translation comment text"
+              className="u-bgHighest u-sizeFull u-inputFlat u-sP-1-2 u-rounded u-sMH-1-4 u-sMV-1-8"
+              value="blurst of times?! You stupid monkey!" />
+          </div>
+*/
+
     expect(actual).toEqual(expected)
   })
 

--- a/server/zanata-frontend/src/app/editor/components/EditorSearchInput/index.js
+++ b/server/zanata-frontend/src/app/editor/components/EditorSearchInput/index.js
@@ -53,10 +53,10 @@ const fields = {
     label: 'Source comment',
     description: 'source comment text'
   },
-  transComment: {
-    label: 'Translation comment',
-    description: 'translation comment text'
-  },
+  // transComment: {
+  //   label: 'Translation comment',
+  //   description: 'translation comment text'
+  // },
   msgContext: {
     label: 'msgctxt (gettext)',
     description: 'exact Message Context for a string'


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2626

Zanata can't currently show or edit translator comments, so it's just confusing to have a feature which searches for them. It can't even show the matching comment. PR #892 hid this feature in the GWT editor. This PR hides it in the React editor too.

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
