### PR TITLE
fix: small ui changes

### DIFF
--- a/server/zanata-frontend/src/app/containers/Explore/index.less
+++ b/server/zanata-frontend/src/app/containers/Explore/index.less
@@ -40,7 +40,7 @@
   }
   .searchView .textInput {
     background-color: "";
-    border: @color-neutral solid 2px !important;
+    border: @color-neutral solid 2px;
     border-radius: @border-radius-text-input;
     font-family: inherit;
     font-weight: inherit;

--- a/server/zanata-frontend/src/app/containers/Glossary/EntryModal.js
+++ b/server/zanata-frontend/src/app/containers/Glossary/EntryModal.js
@@ -94,6 +94,7 @@ class EntryModal extends Component {
           <div className='modal-section'>
             <label className='text-bold'>Term</label>
             <EditableText
+              className='textInput'
               editable={false}
               editing={false}>
               {entry.srcTerm.content}
@@ -104,7 +105,7 @@ class EntryModal extends Component {
             <EditableText
               editable={!transSelected}
               editing
-              className='textState'
+              className='textState textInput'
               maxLength={255}
               placeholder='Add part of speech…'
               emptyReadOnlyText='No part of speech'
@@ -117,6 +118,7 @@ class EntryModal extends Component {
             <EditableText
               editable={!transSelected}
               editing
+              className='textInput'
               maxLength={500}
               placeholder='Add a description…'
               emptyReadOnlyText='No description'
@@ -129,6 +131,7 @@ class EntryModal extends Component {
               <label className='text-bold'>Translation</label>
               <EditableText
                 editable
+                className='textInput'
                 editing
                 maxLength={500}
                 placeholder='Add a translation…'
@@ -144,6 +147,7 @@ class EntryModal extends Component {
               <label className='text-bold'>Comment</label><br />
               <EditableText
                 maxLength={500}
+                className='textInput'
                 editable={enableComment}
                 editing={enableComment}
                 placeholder='Add a comment…'

--- a/server/zanata-frontend/src/app/containers/Glossary/NewEntryModal.js
+++ b/server/zanata-frontend/src/app/containers/Glossary/NewEntryModal.js
@@ -118,6 +118,7 @@ class NewEntryModal extends Component {
         <Form layout='vertical'>
           <Form.Item label={'Term'} title={'Term'}>
             <Input
+              className='textInput'
               maxLength={500}
               onChange={this.handleContentChanged.bind(this)}
               placeholder='The new term'
@@ -125,6 +126,7 @@ class NewEntryModal extends Component {
           </Form.Item>
           <Form.Item label={'Part of speech'} title={'Part of speech'}>
             <Input
+              className='textInput'
               maxLength={255}
               onChange={this.handlePosChanged.bind(this)}
               placeholder='Noun, Verb, etc'
@@ -132,6 +134,7 @@ class NewEntryModal extends Component {
           </Form.Item>
           <Form.Item label={'Description'} title={'Description'}>
             <Input
+              className='textInput'
               maxLength={500}
               onChange={this.handleDescChanged.bind(this)}
               placeholder='The definition of this term'

--- a/server/zanata-frontend/src/app/containers/Glossary/index.less
+++ b/server/zanata-frontend/src/app/containers/Glossary/index.less
@@ -48,6 +48,9 @@
     position: relative;
     width: 100%;
   }
+  .glossaryHeader-actions input.textInput {
+    border: solid 2px @color-neutral;
+  }
   .glossaryHeader .row .row {
     width: 5rem;
     padding-left: @spacing-rq;

--- a/server/zanata-frontend/src/app/containers/Languages/NewLanguageModal.js
+++ b/server/zanata-frontend/src/app/containers/Languages/NewLanguageModal.js
@@ -214,6 +214,7 @@ class NewLanguageModal extends Component {
               <Input
                 // id='displayName' set by getFieldDecorator
                 maxLength={100}
+                className='textInput'
                 onChange={(e) => this.updateField('displayName', e)}
                 placeholder='Display name' />
             )}
@@ -227,6 +228,7 @@ class NewLanguageModal extends Component {
               <Input
                 // id='nativeName' set by getFieldDecorator
                 maxLength={100}
+                className='textInput'
                 onChange={(e) => this.updateField('nativeName', e)}
                 placeholder='Native name' />
             )}
@@ -254,6 +256,7 @@ class NewLanguageModal extends Component {
               })(
                 <Input
                   maxLength={255}
+                  className='textInput'
                   onChange={(e) => this.updateField('pluralForms', e)}
                   placeholder='Plural forms' />
               )}

--- a/server/zanata-frontend/src/app/containers/Languages/index.js
+++ b/server/zanata-frontend/src/app/containers/Languages/index.js
@@ -147,6 +147,7 @@ class Languages extends Component {
                     <FormGroup className='searchBox'>
                       <InputGroup>
                         <FormControl type='text'
+                          className='textInput'
                           value={this.state.searchText}
                           onChange={this.onUpdateSearch} />
                         <InputGroup.Addon>

--- a/server/zanata-frontend/src/app/containers/ProjectVersion/TMMergeProjectSources.js
+++ b/server/zanata-frontend/src/app/containers/ProjectVersion/TMMergeProjectSources.js
@@ -102,7 +102,7 @@ class TMMergeProjectSources extends Component {
             </InputGroup.Addon>
             <FormControl type='text'
               value={mergeOptions.projectSearchTerm}
-              className='versionMergeSearch-input'
+              className='versionMergeSearch-input textInput'
               onChange={this.projectSearchTermChanged}
               onKeyDown={flushProjectSearch}
             />

--- a/server/zanata-frontend/src/app/styles/antd.less
+++ b/server/zanata-frontend/src/app/styles/antd.less
@@ -11,7 +11,7 @@
   color: @info-color;
 }
 
-.ant-form-item {
+.ant-form-item-;abel {
   color: @primary-color;
 }
 

--- a/server/zanata-frontend/src/app/styles/antd.less
+++ b/server/zanata-frontend/src/app/styles/antd.less
@@ -11,12 +11,21 @@
   color: @info-color;
 }
 
-.ant-form-item-;abel {
+.ant-form-item-label label {
   color: @primary-color;
 }
 
 input.react-autosuggest__input {
   background-color: transparent;
+  border-bottom: solid 1px @primary-color;
+}
+
+.ant-input.textInput {
+  border: solid 1px @primary-color;
+}
+
+.ant-input.textInput:focus, .ant-input.textInput:hover {
+  border: 2px solid @info-color;
 }
 
 // pagination alignment on Explore page

--- a/server/zanata-frontend/src/app/styles/antd.less
+++ b/server/zanata-frontend/src/app/styles/antd.less
@@ -7,6 +7,14 @@
   padding: initial !important;
 }
 
+.ant-modal-title {
+  color: @info-color;
+}
+
+.ant-form-item {
+  color: @primary-color;
+}
+
 input.react-autosuggest__input {
   background-color: transparent;
 }

--- a/server/zanata-frontend/src/app/styles/style.less
+++ b/server/zanata-frontend/src/app/styles/style.less
@@ -265,7 +265,7 @@
     -webkit-appearance: none;
     -moz-appearance: none;
     background-color: transparent;
-    border: 2px solid rgb(189, 212, 220);
+    border: 1px solid @color-dark;
     border-radius: @border-radius-text-input;
     color: @color-dark;
     font-family: inherit;
@@ -279,11 +279,8 @@
   .textInput .placeholder {
     color: hsl(195, 32%, 80%);
   }
-  .textInput:focus {
-    border-color: #1ba7d9;
-  }
-  input.textInput:focus {
-    border-color: @color-light;
+  .textInput:focus,   input.textInput:focus  {
+    border: 2px solid @color-light;
   }
   input.textInput::placeholder, textarea.textInput::placeholder {
     color: hsl(195, 32%, 80%);
@@ -1536,7 +1533,7 @@
     -o-transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
     transition: border-color ease-in-out 0.15s, box-shadow ease-in-out 0.15s;
     color: @color-dark;
-    border: 1px solid @color-neutral;
+    border: 1px solid @color-dark;
     border-radius: @border-radius-base;
     background: #fff none;
     -webkit-box-shadow: inset 0 1px 1px rgba(0, 0, 0, 0.075);
@@ -1544,7 +1541,7 @@
   }
   .form-control:focus {
     outline: 0;
-    border-color: #1ba7d9;
+    border: 2px solid @color-light;
   }
   .form-control::-moz-placeholder {
     opacity: 1;

--- a/server/zanata-frontend/src/app/styles/style.less
+++ b/server/zanata-frontend/src/app/styles/style.less
@@ -280,7 +280,7 @@
     color: hsl(195, 32%, 80%);
   }
   .textInput:focus,   input.textInput:focus  {
-    border: 2px solid @color-light;
+    border: 2px solid @color-light !important;
   }
   input.textInput::placeholder, textarea.textInput::placeholder {
     color: hsl(195, 32%, 80%);


### PR DESCRIPTION
allFuncTests

small ui fixes (input state colours) to frontend
- made hover and focus colours for react input elements use light blue, across antd and bootstrap to improve consistency

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
