### PR TITLE
fix: add antd import to root css in editor

### DIFF
--- a/server/zanata-frontend/src/app/editor/containers/Root/index.css
+++ b/server/zanata-frontend/src/app/editor/containers/Root/index.css
@@ -1,4 +1,5 @@
 /** @define Editor; use strict */
+@import "../../../../node_modules/antd/dist/antd.min.css";
 
 :root {
   --Editor-rhythm: 1.5rem;

--- a/server/zanata-frontend/src/app/editor/entrypoint/index.js
+++ b/server/zanata-frontend/src/app/editor/entrypoint/index.js
@@ -20,8 +20,8 @@ import { fetchSettings } from '../actions/settings-actions'
 // This is needed to load intl-polyfill
 __webpack_public_path__ = serverUrl || '/' // eslint-disable-line
 
-import '../index.css'
 import 'tachyons/css/tachyons.min.css'
+import '../index.css'
 
 /**
  * Top level of the Zanata editor app.


### PR DESCRIPTION
JIRA issue URL: N/A

The antd tabs were not displaying in the editor due to a missing antd import.
This import was added to root/index.css and now the tabs are visible in production

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
