### PR TITLE
refactor(ZNTA-2279): antd icons and select styling for glossary

### DIFF
--- a/server/zanata-frontend/src/app/containers/Glossary/ViewHeader.js
+++ b/server/zanata-frontend/src/app/containers/Glossary/ViewHeader.js
@@ -6,7 +6,8 @@ import {connect} from 'react-redux'
 import {debounce, isEmpty} from 'lodash'
 import {
   TextInput,
-  Link
+  Link,
+  Select
 } from '../../components'
 import Header from './Header'
 import {
@@ -30,10 +31,6 @@ import Icon from 'antd/lib/icon'
 import 'antd/lib/icon/style/css'
 import Row from 'antd/lib/row'
 import 'antd/lib/row/style/css'
-import Select from 'antd/lib/select'
-import 'antd/lib/select/style/css'
-
-const Option = Select.Option
 
 /**
  * Header for glossary page
@@ -136,7 +133,7 @@ class ViewHeader extends Component {
         permission.canUpdateEntry || permission.canDeleteEntry)
     const icon = isReadOnly && (
       <span title='read-only'>
-        <Icon name='locked' className='s1' parentClassName='iconLocked' />
+        <Icon type='lock' className='s1 iconLocked' />
       </span>)
     const showDeleteAll = permission.canDeleteEntry && !isEmptyTerms
 
@@ -245,22 +242,23 @@ class ViewHeader extends Component {
                 </td>
                 <td className='languageSelect td-3'>
                   <Select
+                    name='language-selection'
                     placeholder={statsLoading
                         ? 'Loading…' : 'Select a language…'}
                     className='inputFlex'
+                    isLoading={statsLoading}
                     value={selectedTransLocale}
-                    showSearch
-                    onChange={handleTranslationLocaleChange}>
-                    <Option value={transLocales}>{transLocales}</Option>
-                  </Select>
+                    options={transLocales}
+                    pageSize={20}
+                    optionRenderer={this.localeOptionsRenderer}
+                    onChange={handleTranslationLocaleChange}
+                  />
                   {selectedTransLocale &&
                   (<span className='hidden-xs'>
-                    <Row>
-                      <Icon name='translate' className='s1' parentClassName='iconTranslate-neutral' />
-                      <span className='u-textNeutral'>
+                    <Icon type='global' className='s1 iconTranslate-neutral' />
+                    <span className='u-textNeutral'>
                       {currentLocaleCount}
-                      </span>
-                    </Row>
+                    </span>
                   </span>
                   )}
                 </td>
@@ -270,10 +268,10 @@ class ViewHeader extends Component {
                     <Row>
                       {'part_of_speech' in sort
                           ? (sort.part_of_speech === true)
-                              ? <Icon name='chevron-down'
-                                className='s1' parentClassName='iconChevron' />
-                              : <Icon name='chevron-up'
-                                className='s1' parentClassName='iconChevron' />
+                              ? <Icon type='down'
+                                className='s1 iconChevron' />
+                              : <Icon type='up'
+                                className='s1 iconChevron' />
                           : ''}
                       <span className='u-marginL--rq'>
                       Part of Speech

--- a/server/zanata-frontend/src/app/containers/Glossary/ViewHeader.js
+++ b/server/zanata-frontend/src/app/containers/Glossary/ViewHeader.js
@@ -6,8 +6,7 @@ import {connect} from 'react-redux'
 import {debounce, isEmpty} from 'lodash'
 import {
   TextInput,
-  Link,
-  Select
+  Link
 } from '../../components'
 import Header from './Header'
 import {
@@ -31,6 +30,10 @@ import Icon from 'antd/lib/icon'
 import 'antd/lib/icon/style/css'
 import Row from 'antd/lib/row'
 import 'antd/lib/row/style/css'
+import Select from 'antd/lib/select'
+import 'antd/lib/select/style/css'
+
+const Option = Select.Option
 
 /**
  * Header for glossary page
@@ -242,17 +245,14 @@ class ViewHeader extends Component {
                 </td>
                 <td className='languageSelect td-3'>
                   <Select
-                    name='language-selection'
                     placeholder={statsLoading
                         ? 'Loading…' : 'Select a language…'}
                     className='inputFlex'
-                    isLoading={statsLoading}
                     value={selectedTransLocale}
-                    options={transLocales}
-                    pageSize={20}
-                    optionRenderer={this.localeOptionsRenderer}
-                    onChange={handleTranslationLocaleChange}
-                  />
+                    showSearch
+                    onChange={handleTranslationLocaleChange}>
+                    <Option value={transLocales}>{transLocales}</Option>
+                  </Select>
                   {selectedTransLocale &&
                   (<span className='hidden-xs'>
                     <Row>

--- a/server/zanata-frontend/src/app/containers/Glossary/index.less
+++ b/server/zanata-frontend/src/app/containers/Glossary/index.less
@@ -18,6 +18,12 @@
   .table>tbody>tr.highlight>td {
     border-top: none;
   }
+  td.languageSelect Select {
+    width: 80%;
+  }
+  td.languageSelect .hidden-xs {
+    width: 20%;
+  }
   td.languageSelect span.Select-value-label {
     line-height: 2.5rem;
   }

--- a/server/zanata-frontend/src/app/containers/Glossary/index.less
+++ b/server/zanata-frontend/src/app/containers/Glossary/index.less
@@ -18,18 +18,6 @@
   .table>tbody>tr.highlight>td {
     border-top: none;
   }
-  td.languageSelect Select {
-    width: 80%;
-  }
-  td.languageSelect .hidden-xs {
-    width: 20%;
-  }
-  td.languageSelect span.Select-value-label {
-    line-height: 2.5rem;
-  }
-  td.languageSelect .Selectmenu {
-    min-width: 12.25rem;
-  }
   td.languageSelect .Select-placeholder {
     position: absolute;
   }
@@ -199,8 +187,18 @@
     -webkit-flex: 1;
     margin-left: 0;
   }
+  td.languageSelect.td-3 {
+    display:inline-flex;
+    height: auto;
+    margin-top: 1rem;
+    width: 100%;
+  }
   td.languageSelect .Select {
     position: relative;
+    width: 80%;
+  }
+  td.languageSelect .hidden-xs {
+    width: 20%;
   }
   td.languageSelect .Select-input input {
     margin-top: 0.25rem;


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2279

* icons in the glossary view header refactored to antd (some incl. globe and arrows for part of speech were not showing)
* languageSelect count and icon now appears next to dropdown

Screenshot 

<img width="1358" alt="glossary-header" src="https://user-images.githubusercontent.com/18179401/41953753-b7b9b9f6-7a1a-11e8-898d-c26961211e78.png">

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
