### PR TITLE
feat(ZNTA-2078): translation permalinks in alpha editor

### DIFF
--- a/server/zanata-frontend/src/app/editor/components/TransUnitSourceHeader.js
+++ b/server/zanata-frontend/src/app/editor/components/TransUnitSourceHeader.js
@@ -5,6 +5,7 @@ import 'antd/lib/button/style/css'
 import TransUnitLocaleHeading from './TransUnitLocaleHeading'
 import { hasTranslationChanged } from '../utils/phrase-util'
 import Tooltip from 'antd/lib/tooltip'
+import 'antd/lib/tooltip/style/css'
 
 /**
  * Header for the source of the selected phrase
@@ -49,13 +50,11 @@ class TransUnitSourceHeader extends React.Component {
         <Tooltip title="Cancel edit">
           <Button
             icon="close"
-
             onClick={this.props.cancelEdit}
             className={buttonClass} />
         </Tooltip>
       </li>
       )
-
     return (
       <div className="TransUnit-panelHeader TransUnit-panelHeader--source">
         <TransUnitLocaleHeading {...this.props.sourceLocale} />

--- a/server/zanata-frontend/src/app/editor/components/TransUnitTranslationHeader.js
+++ b/server/zanata-frontend/src/app/editor/components/TransUnitTranslationHeader.js
@@ -2,9 +2,13 @@ import React from 'react'
 import * as PropTypes from 'prop-types'
 import Button from 'antd/lib/button'
 import 'antd/lib/button/style/css'
+import Tooltip from 'antd/lib/tooltip'
+import 'antd/lib/tooltip/style/css'
+import Popover from 'antd/lib/popover'
+import 'antd/lib/popover/style/css'
 import TransUnitLocaleHeading from './TransUnitLocaleHeading'
 import { hasTranslationChanged } from '../utils/phrase-util'
-import Tooltip from 'antd/lib/tooltip'
+import { FormattedMessage } from 'react-intl'
 
 /**
  * Heading that displays locale name and ID
@@ -56,7 +60,28 @@ class TransUnitTranslationHeader extends React.Component {
     const button = displayUndo
       ? this.undoButtonElement()
       : this.closeButtonElement()
-
+    const phraseHref = window.location.origin + window.location.pathname +
+      '?lang=' + this.props.translationLocale.id +
+      '&textflow=' + this.props.phrase.id
+    // FIXME: Allow linking to text flows with no translation history
+    const phraseLink = this.props.phrase.revision > 0
+      ? <li className={'mr2'}>
+        <Popover
+          content={
+            <a href={phraseHref}>{phraseHref}</a>
+          }
+          title={
+            <FormattedMessage
+              id='TransUnitHeader.translationlink'
+              defaultMessage='Link to this Translation'
+            />
+          }>
+          <Button size="large" icon="link"
+            href={phraseHref}
+            className={this.buttonClass} />
+        </Popover>
+      </li>
+      : null
     return (
       <div
         className="TransUnit-panelHeader TransUnit-panelHeader--translation">
@@ -65,6 +90,7 @@ class TransUnitTranslationHeader extends React.Component {
           {...this.props.translationLocale} />
 
         <ul className="u-floatRight u-listHorizontal">
+          {phraseLink}
           {button}
         </ul>
       </div>

--- a/server/zanata-frontend/src/app/editor/components/TransUnitTranslationHeader.js
+++ b/server/zanata-frontend/src/app/editor/components/TransUnitTranslationHeader.js
@@ -55,14 +55,24 @@ class TransUnitTranslationHeader extends React.Component {
     )
   }
 
+  /**
+   * @param {string} localeId
+   * @param {string} phraseId
+   * @return {string}
+   */
+  buildPhraseHref = (localeId, phraseId) => {
+    return window.location.origin + window.location.pathname +
+      '?lang=' + localeId +
+      '&textflow=' + phraseId
+  }
+
   render () {
     const displayUndo = hasTranslationChanged(this.props.phrase)
     const button = displayUndo
       ? this.undoButtonElement()
       : this.closeButtonElement()
-    const phraseHref = window.location.origin + window.location.pathname +
-      '?lang=' + this.props.translationLocale.id +
-      '&textflow=' + this.props.phrase.id
+    const phraseHref = this.buildPhraseHref(
+      this.props.translationLocale.id, this.props.phrase.id)
     // FIXME: Allow linking to text flows with no translation history
     const phraseLink = this.props.phrase.revision > 0
       ? <li className={'mr2'}>

--- a/server/zanata-frontend/src/app/editor/middlewares/new-context-fetch.js
+++ b/server/zanata-frontend/src/app/editor/middlewares/new-context-fetch.js
@@ -6,6 +6,7 @@ import {
   selectDoc,
   selectLocale
 } from '../actions/header-actions'
+import { selectPhrase } from '../actions/phrases-actions'
 import { UPDATE_PAGE } from '../actions/controls-header-actions'
 import { every, isUndefined, max, negate } from 'lodash'
 
@@ -38,7 +39,6 @@ const fetchDocsMiddleware = stateChangeDispatchMiddleware(
   // FIXME replace with watcher
   (dispatch, oldState, newState) => {
     const { lang, docId } = newState.context
-
     const docChanged = oldState.context.docId !== docId
     const localeChanged = oldState.context.lang !== lang
 
@@ -71,6 +71,15 @@ const fetchDocsMiddleware = stateChangeDispatchMiddleware(
     if (!hasAllContextInfo(oldState) && hasAllContextInfo(newState)) {
       const { projectSlug, versionSlug, lang, docId } = newState.context
       dispatch(fetchHeaderInfo(projectSlug, versionSlug, docId, lang))
+    }
+
+    if (newState.context.textflow &&
+      newState.context.textflow !== oldState.context.textflow) {
+      const {
+        textflow, lang, projectSlug, versionSlug, docId
+      } = newState.context
+      dispatch(selectPhrase(
+        Number(textflow), lang, projectSlug, versionSlug, docId, true))
     }
   }
 )

--- a/server/zanata-frontend/src/messages/ja.json
+++ b/server/zanata-frontend/src/messages/ja.json
@@ -18,6 +18,7 @@
   "TranslatingIndicator.reviewing": "添削モード",
   "TranslatingIndicator.translating": "翻訳モード",
   "TranslatingIndicator.viewing": "表示専用モード",
+  "TransUnitHeader.translationlink": "この翻訳へのリンク",
   "Validator.header.warnings": "警告: {warningCount}",
   "Validator.header.errors": "エラー: {errorCount}",
   "ControlsHeader.suggestion.hide": "TM提案パネルを隠す",


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2078

Implement links to translations in alpha editor in the translation target panel:
![link](https://user-images.githubusercontent.com/7971187/42256339-02baad7e-7f94-11e8-9996-bf0299c1448c.png)
Use a route param '&textflow' to select a textflow when rendering the alpha editor, eg:
/project/translate/containers/v/ver1/containersblog.txt?lang=ja&textflow=156

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
