### PR TITLE
refactor(ZNTA-2529) change colour of suggestions heading in editor

### DIFF
--- a/server/zanata-frontend/src/app/editor/containers/SuggestionsHeader.js
+++ b/server/zanata-frontend/src/app/editor/containers/SuggestionsHeader.js
@@ -97,7 +97,7 @@ class SuggestionsHeader extends React.Component {
 
     return (
       <nav className="Editor-suggestionsHeader u-bgHighest u-sPH-3-4">
-        <h2 className="Heading--panel u-textPrimary u-sPV-1-4 u-floatLeft u-sizeHeight-1_1-2">
+        <h2 className="Heading--panel u-textSecondary u-sPV-1-4 u-floatLeft u-sizeHeight-1_1-2">
           <span className="u-textMuted">
             <Icon name="suggestions" className="s0" />
           </span>


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2663

Suggestions title should be the same colour as the editor heading text

Before
![suggestions](https://user-images.githubusercontent.com/18179401/42796849-c3826714-89cf-11e8-925c-703695258648.png)

After
![after](https://user-images.githubusercontent.com/18179401/42796854-c7c09a12-89cf-11e8-91ba-c9bb3a52b9c8.png)

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
