### PR TITLE
fix: concurrent modal type error

### DIFF
--- a/server/zanata-frontend/src/app/editor/containers/MainContent.js
+++ b/server/zanata-frontend/src/app/editor/containers/MainContent.js
@@ -112,7 +112,7 @@ class MainContent extends React.Component {
           closeConcurrentModal={this.props.toggleConcurrentModal}
           saveResolveConflictLatest={this.props.saveResolveConflictLatest}
           saveResolveConflictOriginal={this.props.saveResolveConflictOriginal}
-          conflictData={selectedPhrase.conflict}
+          conflictData={selectedPhraseRevision && selectedPhrase.conflict}
           show={this.props.showConflictModal}
         />
         <RejectTranslation


### PR DESCRIPTION
JIRA issue URL: *paste URL here*

Rendering the conflict modal in some circumstances (using the editor Filters, pagination) causes Maincontent.js to access `selectedPhrase.conflict` when `selectedPhrase` was undefined.

Reused the `isUndefined(selectedPhrase)` check to ensure selectedPhrase is not undefined before accessing.

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
