### PR TITLE
fix: ensure transaction for attribution

### DIFF
--- a/server/services/src/main/java/org/zanata/service/impl/MachineTranslationServiceImpl.java
+++ b/server/services/src/main/java/org/zanata/service/impl/MachineTranslationServiceImpl.java
@@ -237,8 +237,14 @@ public class MachineTranslationServiceImpl implements
                     projectSlug, versionSlug, options.getSaveState(),
                     options.getOverwriteFuzzy(), requestedBackend);
             if (backendId != null) {
-                attributionService.addAttribution(doc, targetLocale, backendId);
-                entityManager.merge(doc);
+                try {
+                    transactionUtil.run(() -> {
+                        attributionService.addAttribution(doc, targetLocale, backendId);
+                        entityManager.merge(doc);
+                    });
+                } catch (Exception e) {
+                    throw new RuntimeException("error adding attribution for machine translation", e);
+                }
             }
             taskHandle.increaseProgress(1);
         }


### PR DESCRIPTION
If any PO documents are changed during MT Merge, the request fails with this server-side error when trying to save the attribution:

```
06:50:29,431 ERROR [org.zanata.async.AsyncTaskManager] (pool-11-thread-2) Exception when executing an asynchronous task.: javax.persistence.PersistenceException: org.hibernate.TypeMismatchException: Provided id of the wrong type for class org.zanata.model.po.HPoTargetHeader. Expected: class java.lang.Long, got class org.hibernate.action.internal.DelayedPostInsertIdentifier
        at org.hibernate.jpa.spi.AbstractEntityManagerImpl.convert(AbstractEntityManagerImpl.java:1692)
        at org.hibernate.jpa.spi.AbstractEntityManagerImpl.convert(AbstractEntityManagerImpl.java:1602)
        at org.hibernate.jpa.spi.AbstractEntityManagerImpl.convert(AbstractEntityManagerImpl.java:1608)
        at org.hibernate.jpa.spi.AbstractEntityManagerImpl.merge(AbstractEntityManagerImpl.java:1171)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.jboss.weld.bean.proxy.AbstractBeanInstance.invoke(AbstractBeanInstance.java:38)
        at org.jboss.weld.bean.proxy.ProxyMethodHandler.invoke(ProxyMethodHandler.java:100)
        at org.jboss.weldx.persistence.EntityManager$2144150376$Proxy$_$$_WeldClientProxy.merge(Unknown Source)
        at org.zanata.service.impl.MachineTranslationServiceImpl.prefillProjectVersionWithMachineTranslation(MachineTranslationServiceImpl.java:240)
        at org.zanata.service.impl.MachineTranslationServiceImpl$Proxy$_$$_WeldSubclass.prefillProjectVersionWithMachineTranslation$$super(Unknown Source)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.jboss.weld.interceptor.proxy.TerminalAroundInvokeInvocationContext.proceedInternal(TerminalAroundInvokeInvocationContext.java:49)
        at org.jboss.weld.interceptor.proxy.AroundInvokeInvocationContext.proceed(AroundInvokeInvocationContext.java:77)
        at org.zanata.async.AsyncMethodInterceptor.aroundInvoke(AsyncMethodInterceptor.java:115)
        at sun.reflect.GeneratedMethodAccessor1425.invoke(Unknown Source)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.jboss.weld.interceptor.reader.SimpleInterceptorInvocation$SimpleMethodInvocation.invoke(SimpleInterceptorInvocation.java:74)
        at org.jboss.weld.interceptor.proxy.InterceptorMethodHandler.executeAroundInvoke(InterceptorMethodHandler.java:84)
        at org.jboss.weld.interceptor.proxy.InterceptorMethodHandler.executeInterception(InterceptorMethodHandler.java:72)
        at org.jboss.weld.interceptor.proxy.InterceptorMethodHandler.invoke(InterceptorMethodHandler.java:56)
        at org.jboss.weld.bean.proxy.CombinedInterceptorAndDecoratorStackMethodHandler.invoke(CombinedInterceptorAndDecoratorStackMethodHandler.java:79)
        at org.jboss.weld.bean.proxy.CombinedInterceptorAndDecoratorStackMethodHandler.invoke(CombinedInterceptorAndDecoratorStackMethodHandler.java:68)
        at org.zanata.service.impl.MachineTranslationServiceImpl$Proxy$_$$_WeldSubclass.prefillProjectVersionWithMachineTranslation(Unknown Source)
        at org.zanata.service.impl.MachineTranslationServiceImpl$Proxy$_$$_WeldClientProxy.prefillProjectVersionWithMachineTranslation(Unknown Source)
        at sun.reflect.NativeMethodAccessorImpl.invoke0(Native Method)
        at sun.reflect.NativeMethodAccessorImpl.invoke(NativeMethodAccessorImpl.java:62)
        at sun.reflect.DelegatingMethodAccessorImpl.invoke(DelegatingMethodAccessorImpl.java:43)
        at java.lang.reflect.Method.invoke(Method.java:498)
        at org.zanata.async.AsyncMethodInterceptor.lambda$aroundInvoke$1(AsyncMethodInterceptor.java:94)
        at org.zanata.async.AsyncTaskManager.lambda$startTask$0(AsyncTaskManager.java:105)
        at java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1149)
        at java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:624)
        at java.lang.Thread.run(Thread.java:748)
Caused by: org.hibernate.TypeMismatchException: Provided id of the wrong type for class org.zanata.model.po.HPoTargetHeader. Expected: class java.lang.Long, got class org.hibernate.action.internal.DelayedPostInsertIdentifier
        at org.hibernate.event.internal.DefaultLoadEventListener.checkIdClass(DefaultLoadEventListener.java:166)
        at org.hibernate.event.internal.DefaultLoadEventListener.onLoad(DefaultLoadEventListener.java:86)
        at org.hibernate.internal.SessionImpl.fireLoad(SessionImpl.java:1129)
        at org.hibernate.internal.SessionImpl.internalLoad(SessionImpl.java:1022)
        at org.hibernate.type.EntityType.resolveIdentifier(EntityType.java:632)
        at org.hibernate.type.EntityType.resolve(EntityType.java:424)
        at org.hibernate.type.EntityType.replace(EntityType.java:323)
        at org.hibernate.type.MapType.replaceElements(MapType.java:66)
        at org.hibernate.type.CollectionType.replace(CollectionType.java:670)
        at org.hibernate.type.TypeHelper.replace(TypeHelper.java:177)
        at org.hibernate.event.internal.DefaultMergeEventListener.copyValues(DefaultMergeEventListener.java:401)
        at org.hibernate.event.internal.DefaultMergeEventListener.entityIsPersistent(DefaultMergeEventListener.java:203)
        at org.hibernate.event.internal.DefaultMergeEventListener.onMerge(DefaultMergeEventListener.java:176)
        at org.hibernate.event.internal.DefaultMergeEventListener.onMerge(DefaultMergeEventListener.java:69)
        at org.hibernate.internal.SessionImpl.fireMerge(SessionImpl.java:840)
        at org.hibernate.internal.SessionImpl.merge(SessionImpl.java:822)
        at org.hibernate.internal.SessionImpl.merge(SessionImpl.java:827)
        at org.hibernate.jpa.spi.AbstractEntityManagerImpl.merge(AbstractEntityManagerImpl.java:1161)
        ... 36 more
```

Related to https://github.com/zanata/zanata-platform/pull/954

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
