### PR TITLE
fix(ZNTA-2679): React Editor status icon and disabled button styles

### DIFF
--- a/server/zanata-frontend/src/app/editor/components/Button/index.css
+++ b/server/zanata-frontend/src/app/editor/components/Button/index.css
@@ -108,7 +108,7 @@ not conflict with the other frontend code
 
 .Button--highlight,
 .ant-btn.Button--highlight{
-  color: var(--Button-color-text-invert);
+  color: var(--Button-color-text-invert) !important;
   background-color: var(--Button-color-highlight) !important;
 }
 

--- a/server/zanata-frontend/src/app/editor/components/TransUnit/index.css
+++ b/server/zanata-frontend/src/app/editor/components/TransUnit/index.css
@@ -326,7 +326,6 @@ h3.TransUnit-heading {
   left: 0;
 }
 .TransUnit-metaDataComments,
-.TransUnit-metaDataErrors,
 .TransUnit-metaDataMT button{
   width: 17px;
   height: 17px;


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2679

1. Error status icon picking up MT status icon styles
![eye](https://user-images.githubusercontent.com/7971187/42985969-0780ea4e-8c37-11e8-968c-a7bac78f07af.png)
2. Editor buttons text when disabled should be white
![disabledbutton](https://user-images.githubusercontent.com/7971187/42985974-0b0e80ae-8c37-11e8-8075-7939cb1229fa.png)

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
