### PR TITLE
fix(ZNTA-2680) fix height of project settings languages buttons

### DIFF
--- a/server/zanata-frontend/src/app/styles/frontend-jsf.less
+++ b/server/zanata-frontend/src/app/styles/frontend-jsf.less
@@ -20,6 +20,12 @@ body.bodyStyle {
   h1.l--push-all-0 {
     line-height: initial !important;
   }
+  .use-global, .remove-locale {
+    height: 3rem !important;
+  }
+  .flex-btn-group {
+    display: inline-flex !important;
+  }
   .autocomplete {
   position: inherit !important;
   z-index: 9999 !important;

--- a/server/zanata-war/src/main/webapp/WEB-INF/layout/project/settings-tab-languages.xhtml
+++ b/server/zanata-war/src/main/webapp/WEB-INF/layout/project/settings-tab-languages.xhtml
@@ -14,14 +14,15 @@
   <h:form id="settings-languages-form" styleClass="l--push-bottom-0" onsubmit="return false">
     <h:panelGroup layout="block"  id="settings-languages-list">
 
-      <button styleClass="button--small l--push-bottom-half" jsfc="a4j:commandButton"
+      <button styleClass="button--small l--push-bottom-half use-global"
+              jsfc="a4j:commandButton"
         value="#{msgs['jsf.Language.useGlobal']}"
         rendered="#{projectHome.overrideLocales}"
         action="#{projectHome.useDefaultLocales()}"
         render="settings-languages-form"/>
 
       <button jsfc="a4j:commandButton"
-        styleClass="button--small l--push-bottom-half l--push-left-half"
+        styleClass="button--small remove-locale l--push-bottom-half l--push-left-half"
         value="#{msgs['jsf.localeAlias.RemoveAllAliases']}"
         rendered="#{not empty projectHome.localeAliases}"
         action="#{projectHome.removeAllLocaleAliases()}"
@@ -100,7 +101,7 @@
                 <div id="language-actions-#{locale.localeId}"
                   class="l--push-right-quarter reveal__target">
                   <div class="dropdown dropdown--small dropdown--right dropdown--single js-dropdown">
-                    <div class="button--group">
+                    <div class="button--group flex-btn-group">
                       <zanata:ajax-command-button
                         oncomplete="refreshStatistics();"
                         action="#{projectHome.disableLocale(locale)}"


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2680

Fix height of buttons on project language page and set Disable buttons to use display: inline-flex so they always appear inline.

<img width="815" alt="projsettings" src="https://user-images.githubusercontent.com/18179401/42987409-8e774ae8-8c3c-11e8-9b5b-850d1b29934d.png">

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
