### PR TITLE
fix(ZNTA-2676) colour for copytrans modal state buttons

### DIFF
--- a/server/zanata-frontend/src/app/styles/frontend-jsf.less
+++ b/server/zanata-frontend/src/app/styles/frontend-jsf.less
@@ -20,6 +20,35 @@ body.bodyStyle {
   h1.l--push-all-0 {
     line-height: initial !important;
   }
+  #copy-trans-modal {
+    .button--group input[type="radio"] + .button--success {
+      color: @success-color !important;
+      background-color: #f7f7f7 !important;
+    }
+    .button--group input[type="radio"] + .button--unsure {
+      color: @unsure-color !important;
+      background-color: #f0f0f0 !important;
+    }
+    .button--group input[type="radio"] + .button--danger {
+      color: @error-color !important;
+      background-color: #f7f7f7 !important;
+    }
+    .button--group input[type="radio"]:checked + .button--success {
+      background-color: @success-color !important;
+      color: #f7f7f7 !important;
+    }
+    .button--group input[type="radio"]:checked + .button--unsure {
+      background-color: @unsure-color !important;
+      color: #f0f0f0 !important;
+    }
+    .button--group input[type="radio"]:checked + .button--danger {
+      background-color: @error-color !important;
+      color: #f7f7f7 !important;
+    }
+    .modal__footer {
+      height: auto !important;
+    }
+  }
   .autocomplete {
   position: inherit !important;
   z-index: 9999 !important;


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2676

Fixes:
* Colours of copytrans buttons
* Darkened background for Continue as Fuzzy buttons to improve contrast against yellow text
* Modal footer button is centered

Screenshot:
<img width="786" alt="copytrans" src="https://user-images.githubusercontent.com/18179401/42990380-d5093314-8c45-11e8-9c8d-7a260af66a54.png">

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
