### PR TITLE
fix(ZNTA-2682): languages pagination

### DIFF
--- a/server/zanata-frontend/src/app/containers/Languages/index.js
+++ b/server/zanata-frontend/src/app/containers/Languages/index.js
@@ -124,12 +124,7 @@ class Languages extends Component {
     } = this.props
 
     const resetSearchText = this.resetSearchText
-
-    const totalPage = Math.floor(totalCount / size) +
-      (totalCount % size > 0 ? 1 : 0)
-
     const noResults = isEmpty(results)
-
     /* eslint-disable max-len, react/jsx-no-bind */
     return (
       <div className='languages wideView'>
@@ -185,10 +180,11 @@ class Languages extends Component {
                       })}
                     </Select>
                   </Col>
-                  <Col className='fr mr3 mb4'>
+                  <Col className=''>
                     <Pagination
-                      total={totalPage}
-                      defaultCurrent={page}
+                      pageSize={size}
+                      total={totalCount}
+                      current={page}
                       onChange={handlePageChanged} />
                   </Col>
                 </span>)}
@@ -270,8 +266,8 @@ const mapDispatchToProps = (dispatch) => {
     handleDelete: (localeId) => {
       dispatch(handleDelete(localeId))
     },
-    handleOnUpdatePageSize: (event) => {
-      dispatch(handleUpdatePageSize(event.target.value || ''))
+    handleOnUpdatePageSize: (value) => {
+      dispatch(handleUpdatePageSize(value || ''))
     },
     handleOnUpdateSort: (event) => {
       dispatch(handleUpdateSort(event.target.value || ''))

--- a/server/zanata-frontend/src/app/containers/Languages/index.js
+++ b/server/zanata-frontend/src/app/containers/Languages/index.js
@@ -180,7 +180,7 @@ class Languages extends Component {
                       })}
                     </Select>
                   </Col>
-                  <Col className=''>
+                  <Col className='fr mr3 mb4'>
                     <Pagination
                       pageSize={size}
                       total={totalCount}

--- a/server/zanata-frontend/src/app/containers/Languages/index.js
+++ b/server/zanata-frontend/src/app/containers/Languages/index.js
@@ -81,13 +81,28 @@ class Languages extends Component {
   }
 
   componentDidUpdate (prevProps) {
-    const { notification } = this.props
+    const {
+      notification,
+      totalCount,
+      size,
+      page,
+      handlePageChanged
+    } = this.props
     if (notification && prevProps.notification !== notification) {
       Notification[notification.severity]({
         message: notification.message,
         description: notification.description,
         duration: notification.duration
       })
+    }
+    /* Reset to the first page when changing pagination size
+     * results higher than max page value */
+    if (prevProps.size !== size) {
+      const totalPage = Math.floor(totalCount / size) +
+        (totalCount % size > 0 ? 1 : 0)
+      if (page > totalPage) {
+        handlePageChanged(1)
+      }
     }
   }
 

--- a/server/zanata-frontend/src/app/styles/antd.less
+++ b/server/zanata-frontend/src/app/styles/antd.less
@@ -222,11 +222,6 @@ h4 {
   vertical-align: sub;
 }
 
-.ant-pagination *,
-.ant-pagination-disabled * {
-  border: none !important;
-}
-
 .cc-link {
   color: @info-color !important;
   font-weight: 600;


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2682

Fixed the page size selector and pagination components on the Languages page.

Removed the border disabled override on ant pagination, displays current selected:
![languagespaginate](https://user-images.githubusercontent.com/7971187/43052143-0a17c67a-8e66-11e8-9711-c4cd523120f5.png)

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
