### PR TITLE
fix(ZNTA-2700) use ellipsis to handle long glossary input text

### DIFF
--- a/server/zanata-frontend/src/app/styles/antd.less
+++ b/server/zanata-frontend/src/app/styles/antd.less
@@ -412,6 +412,12 @@ textarea.textInput::placeholder {
   vertical-align: middle;
 }
 
+.ellipsis {
+  white-space: nowrap;
+  text-overflow: ellipsis;
+  overflow: hidden;
+}
+
 .editable {
   border-radius: 4px;
   transition: all 0.3s cubic-bezier(0.19, 1, 0.22, 1);


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2700

Add ellipsis class to antd.less to handle long glossary input text

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
