### PR TITLE
fix(ZNTA-2705) reduce spacing between explore page search and content

### DIFF
--- a/server/zanata-frontend/src/app/containers/Explore/index.js
+++ b/server/zanata-frontend/src/app/containers/Explore/index.js
@@ -143,7 +143,7 @@ class Explore extends Component {
     return (
       <div className='scrollView' id='explore'>
         <Helmet title='Search' />
-        <div className='mb5'>
+        <div className='mb3'>
           <h1 className='dn'>Search</h1>
           <div className='searchView'>
             <Icon type='search' className='s0 v-mid' />


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2705

reduce spacing between explore page search and content

Fix:

<img width="1366" alt="explore-fix" src="https://user-images.githubusercontent.com/18179401/43111434-9b686192-8f34-11e8-976b-ba80d34e19e2.png">

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
