### PR TITLE
fix(ZNTA-2703) hover colour for link panels on admin homepage

### DIFF
--- a/server/zanata-frontend/src/app/containers/Admin/index.less
+++ b/server/zanata-frontend/src/app/containers/Admin/index.less
@@ -12,7 +12,7 @@
   padding: 1rem;
   font-weight: 600;
   line-height: 1.5rem;
-  color: @processing-color;
+  color: @processing-color !important;
   svg.s2 {
     margin-right: 1.5em !important
   }
@@ -25,6 +25,6 @@
 
 #admin .list-group-item:hover, #admin .list-group-item:focus {
   background-color: @processing-color;
-  color: #fafafa;
+  color: #fafafa !important;
 }
 


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2703

Change hover text colour to white for items on admin homepage

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
