### PR TITLE
fix(ZNTA-2699) fix positioning of project glossary title

### DIFF
--- a/server/zanata-frontend/src/app/containers/Glossary/ViewHeader.js
+++ b/server/zanata-frontend/src/app/containers/Glossary/ViewHeader.js
@@ -133,17 +133,17 @@ class ViewHeader extends Component {
         permission.canUpdateEntry || permission.canDeleteEntry)
     const icon = isReadOnly && (
       <span title='read-only'>
-        <Icon type='lock' className='s1 lock' />
+        <Icon type='lock' className='s1 lock mr3' />
       </span>)
     const showDeleteAll = permission.canDeleteEntry && !isEmptyTerms
 
     const projectUrl = project && getProjectUrl(project.id)
 
     const projectLink = project && (
-      <div className='projectLink'>
+      <div className='ml3 projectLink'>
         <Link icon='project' link={projectUrl} useHref>
           <Row>
-            <Icon type='folder-open' className='iconProject' />
+            <Icon type='folder-open' className='txt-muted mr1' />
             <span className='hidden-lesm'>{project.name}</span>
           </Row>
         </Link>

--- a/server/zanata-frontend/src/app/containers/Glossary/index.less
+++ b/server/zanata-frontend/src/app/containers/Glossary/index.less
@@ -84,6 +84,10 @@
     margin-right: @spacing-sm;
     width: 4.5rem;
   }
+  .innerView h1 .ant-row {
+    display: flex;
+    align-items: center;
+  }
   .glossarySelect {
     position: relative;
     z-index: 999;


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2699

 fix positioning of project glossary title and read only icon

<img width="827" alt="glossaryheading" src="https://user-images.githubusercontent.com/18179401/43113285-228f6352-8f3d-11e8-9a4f-72dd9434960e.png">

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
