### PR TITLE
fix(ZNTA-2701) hover, focus, active border colour for language pagination

### DIFF
--- a/server/zanata-frontend/src/app/styles/antd.less
+++ b/server/zanata-frontend/src/app/styles/antd.less
@@ -99,6 +99,12 @@
   color: @info-color;
 }
 
+.ant-pagination-item-active,
+.ant-pagination-item:focus,
+.ant-pagination-item:hover {
+  border-color: @info-color;
+}
+
 .scrollView {
   align-items: center;
   -webkit-align-items: center;


### PR DESCRIPTION
JIRA issue URL: http://zanata.atlassian.net/browse/ZNTA-2701

Hover, focus, active border colour for language pagination
Use zanata colour scheme

Fix:

<img width="220" alt="pagination-fix" src="https://user-images.githubusercontent.com/18179401/43113985-03c1b71a-8f40-11e8-9b26-cbd0fe24eb4a.png">

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
