### PR TITLE
fix(ZNTA-2697) remove extra spacing from dashboard lists

### DIFF
--- a/server/zanata-frontend/src/app/styles/frontend-jsf.less
+++ b/server/zanata-frontend/src/app/styles/frontend-jsf.less
@@ -20,6 +20,9 @@ body.bodyStyle {
   h1.l--push-all-0 {
     line-height: initial !important;
   }
+  .list__item__content .projectList {
+    padding-bottom: 0 !important;
+  }
   #copy-trans-modal {
     .button--group input[type="radio"] + .button--success {
       color: @success-color !important;

--- a/server/zanata-frontend/src/app/styles/frontend-jsf.less
+++ b/server/zanata-frontend/src/app/styles/frontend-jsf.less
@@ -22,6 +22,11 @@ body.bodyStyle {
   }
   .list__item__content .projectList {
     padding-bottom: 0 !important;
+    height: 3rem !important;
+  }
+  .stats--mini .stats__figure {
+    font-size: 1.75em;
+    padding-top: 1rem !important;
   }
   #copy-trans-modal {
     .button--group input[type="radio"] + .button--success {

--- a/server/zanata-frontend/src/app/styles/frontend-jsf.less
+++ b/server/zanata-frontend/src/app/styles/frontend-jsf.less
@@ -28,6 +28,9 @@ body.bodyStyle {
     font-size: 1.75em;
     padding-top: 1rem !important;
   }
+  .list--stats .list__item__stats {
+    width: 12rem;
+  }
   #copy-trans-modal {
     .button--group input[type="radio"] + .button--success {
       color: @success-color !important;

--- a/server/zanata-war/src/main/webapp/WEB-INF/layout/dashboard/projects.xhtml
+++ b/server/zanata-war/src/main/webapp/WEB-INF/layout/dashboard/projects.xhtml
@@ -69,7 +69,7 @@
             <h:link outcome="/project/project.xhtml">
               <f:param name="slug" value="#{project.slug}"/>
               <div class="list__item__content">
-                <div class="list__item__info g g--tighter">
+                <div class="list__item__info g g--tighter projectList">
                   <div class="g__item w--6-12">
                     <h3 class="list__title bx--inline-block">#{project.name}</h3>
                     <p class="list__item__meta">#{project.description}</p>


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2697

The dashboard project lists were not center aligned because of some frontend css.
Added a class that removes unnecessary padding from these lists.

Fix:

<img width="786" alt="projectlist" src="https://user-images.githubusercontent.com/18179401/43114539-f7ee4356-8f42-11e8-92b3-92d84f66cb21.png">



## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
