### PR TITLE
fix(ZNTA-2698) vertically align modal footer content

### DIFF
--- a/server/zanata-frontend/src/app/styles/frontend-jsf.less
+++ b/server/zanata-frontend/src/app/styles/frontend-jsf.less
@@ -45,12 +45,12 @@ body.bodyStyle {
       background-color: @error-color !important;
       color: #f7f7f7 !important;
     }
-    .modal__footer {
-      height: auto !important;
-    }
   }
   .use-global, .remove-locale, .copy-proj-type, .copy-proj-val {
     height: 3rem !important;
+  }
+  .modal__footer {
+    height: auto !important;
   }
   .flex-btn-group {
     display: inline-flex !important;


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2698

In the old jsf modals the buttons are not center aligned. This has been fixed by removing the value set for height of the footer in the jsf.less file.

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
