### PR TITLE
fix(ZNTA-2702) add margin between MT Merge modal alerts

### DIFF
--- a/server/zanata-frontend/src/.storybook-frontend/__snapshots__/storyshots-frontend.test.js.snap
+++ b/server/zanata-frontend/src/.storybook-frontend/__snapshots__/storyshots-frontend.test.js.snap
@@ -6518,11 +6518,11 @@ exports[`Frontend Storyshots MTMerge single 1`] = `
 >
   <mock-icons />
   <Alert
-    className="mb2"
     message="Have you run TM Merge first?"
     showIcon={true}
     type="warning"
   />
+  <br />
   <Alert
     message="Only .po (gettext) and .properties files are supported"
     showIcon={true}
@@ -6700,11 +6700,11 @@ exports[`Frontend Storyshots MTMergeModal single 1`] = `
     visible={true}
   >
     <Alert
-      className="mb2"
       message="Have you run TM Merge first?"
       showIcon={true}
       type="warning"
     />
+    <br />
     <Alert
       message="Only .po (gettext) and .properties files are supported"
       showIcon={true}

--- a/server/zanata-frontend/src/app/components/MTMerge/MTMergeOptions.tsx
+++ b/server/zanata-frontend/src/app/components/MTMerge/MTMergeOptions.tsx
@@ -55,7 +55,8 @@ export class MTMergeOptions extends Component<Props> {
     return (
       <React.Fragment>
         <Alert message="Have you run TM Merge first?" type="warning"
-          showIcon className='mb2'/>
+          showIcon />
+        <br />
         <Alert message="Only .po (gettext) and .properties files are supported"
           type="info" showIcon/>
         {/* Select Languages */}


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2702

add margin between MT Merge modal alerts
update snapshot tests

fix:

<img width="546" alt="mtfix" src="https://user-images.githubusercontent.com/18179401/43119326-599b1e06-8f59-11e8-9d5d-2d4e1b4ebd78.png">

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
