### PR TITLE
fix(ZNTA-2704) alignment of save and delete buttons on review criteria admin page

### DIFF
--- a/server/zanata-frontend/src/app/components/RejectionsForm/index.js
+++ b/server/zanata-frontend/src/app/components/RejectionsForm/index.js
@@ -111,7 +111,7 @@ class RejectionsForm extends Component {
       <Tooltip title='Delete criteria'>
         <span>
           <Button type='danger' className='btn-danger' onClick={this.onDelete}>
-            <Icon name='trash' className='s0' />
+            <Icon name='trash' className='s0 v-mid' />
           </Button>
         </span>
       </Tooltip>
@@ -132,7 +132,7 @@ class RejectionsForm extends Component {
               <Button type='primary'
                 onClick={this.onSave}
                 disabled={error}>
-                <Icon name='tick' className='s0' />
+                <Icon name='tick' className='s0 v-mid' />
               </Button>
             </span>
           </Tooltip>
@@ -177,7 +177,7 @@ class RejectionsForm extends Component {
           <Col xs={24} md={8} lg={6}>
             {commentToggle}
           </Col>
-          <Col xs={4} md={2} lg={2} className='fr'>
+          <Col xs={4} md={2} lg={3} className='fr'>
             {formBtn}
           </Col>
         </Row>


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2704

alignment of save and delete buttons on review criteria admin page

fix:
<img width="501" alt="reviewfix" src="https://user-images.githubusercontent.com/18179401/43120911-2aeedbbe-8f5f-11e8-9d57-65904655488a.png">


## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
