### PR TITLE
fix(ZNTA-2706) alignment of react editor header nav arrows

### DIFF
--- a/server/zanata-frontend/src/app/editor/containers/NavHeader.js
+++ b/server/zanata-frontend/src/app/editor/containers/NavHeader.js
@@ -96,7 +96,7 @@ class NavHeader extends React.Component {
         <div className="u-posAbsoluteLeft">
           <Row className={directionClass}>
             <ProjectVersionLink {...ctx.projectVersion} />
-            <div className="u-inlineBlock u-sMH-1-4 u-textInvert u-textMuted u-sm-hidden">
+            <div className="u-inlineBlock u-sMH-1-4 u-textInvert u-textMuted u-sm-hidden Dropdown-toggleIcon">
               <Icon name="chevron-right" className="s1" />
             </div>
             <span className="Editor-docsDropdown">

--- a/server/zanata-frontend/src/app/editor/containers/Root/index.css
+++ b/server/zanata-frontend/src/app/editor/containers/Root/index.css
@@ -693,7 +693,7 @@ h4.modal-title {
 }
 
 .Editor-mainNav .Dropdown-toggleIcon {
-  vertical-align: middle;
+  vertical-align: sub;
 }
 
 .icon-history svg, .icon-comment svg {

--- a/server/zanata-frontend/src/app/editor/containers/Root/index.css
+++ b/server/zanata-frontend/src/app/editor/containers/Root/index.css
@@ -696,6 +696,14 @@ h4.modal-title {
   vertical-align: sub;
 }
 
+.Editor-currentProject {
+  font-size: 1rem;
+}
+
+.EditorDropdown-content ul {
+  margin-bottom: 0;
+}
+
 .icon-history svg, .icon-comment svg {
   vertical-align: sub;
 }


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2706

alignment of editor nav arrows
text size for project name in editor nav
remove extra padding form bottom of nav dropdown

fix:
<img width="467" alt="editornavfix" src="https://user-images.githubusercontent.com/18179401/43122308-eeebf41c-8f63-11e8-8112-c29cabd201b7.png">

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
