### PR TITLE
fix(ZNTA-2707) use zanata colours for antd notification icons

### DIFF
--- a/server/zanata-frontend/src/app/styles/antd.less
+++ b/server/zanata-frontend/src/app/styles/antd.less
@@ -756,12 +756,22 @@ span.svg {
   background-color: @info-color;
 }
 
-.ant-alert-info .ant-alert-icon {
+.ant-alert-info .ant-alert-icon,
+.ant-notification-notice-icon-info {
   color: @info-color;
 }
 
-.ant-alert-warning .ant-alert-icon {
+.ant-alert-warning .ant-alert-icon,
+.ant-notification-notice-icon-warning {
   color: @warning-color;
+}
+
+.ant-notification-notice-icon-success {
+  color: @success-color;
+}
+
+.ant-notification-notice-icon-danger {
+  color: @error-color;
 }
 
 table {


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2707

The pop up toast notifications in frontend now use the status colours for zanata instead of the antd defaults.

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
