### PR TITLE
fix(ZNTA-2708): specify duration for mtmerge process status notifications

### DIFF
--- a/server/zanata-frontend/src/app/reducers/version-reducer.js
+++ b/server/zanata-frontend/src/app/reducers/version-reducer.js
@@ -229,7 +229,8 @@ const version = handleActions({
             ? statusToSeverity(state.MTMerge.processStatus.statusCode)
             : SEVERITY.INFO}`,
           message: `MT Merge finished ${state.MTMerge.processStatus
-            ? 'with status: ' + state.MTMerge.processStatus.statusCode : ''}`
+            ? 'with status: ' + state.MTMerge.processStatus.statusCode : ''}`,
+          duration: SEVERITY.ERROR ? null : 3.5
         }
       }
     })


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2708

MT Merge process status errors should not auto-dismiss themselves.

1. Go to a project version
2. Select Machine Translation from the menu
3. Select an unavailable locale (eg am)
4. Press Merge

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
