### PR TITLE
fix(ZNTA-2714) alignment of pagination in editor

### DIFF
--- a/server/zanata-frontend/src/app/editor/components/Pager/index.js
+++ b/server/zanata-frontend/src/app/editor/components/Pager/index.js
@@ -117,7 +117,7 @@ const Pager = ({
   }
 
   return (
-    <ul className="u-listHorizontal tc flex center">
+    <ul className="u-listHorizontal tc inline-flex items-center">
       <PagerButton {...buttons.first} />
       <PagerButton {...buttons.prev} />
       <li className="u-sizeHeight-1 u-sPH-1-4">

--- a/server/zanata-frontend/src/app/editor/components/Pager/index.js
+++ b/server/zanata-frontend/src/app/editor/components/Pager/index.js
@@ -117,7 +117,7 @@ const Pager = ({
   }
 
   return (
-    <ul className="u-listHorizontal tc">
+    <ul className="u-listHorizontal tc flex center">
       <PagerButton {...buttons.first} />
       <PagerButton {...buttons.prev} />
       <li className="u-sizeHeight-1 u-sPH-1-4">

--- a/server/zanata-frontend/src/app/editor/components/Pager/index.js
+++ b/server/zanata-frontend/src/app/editor/components/Pager/index.js
@@ -121,7 +121,7 @@ const Pager = ({
       <PagerButton {...buttons.first} />
       <PagerButton {...buttons.prev} />
       <li className="u-sizeHeight-1 u-sPH-1-4">
-        <span className="u-textNeutral">
+        <span className="u-textNeutral lh-title">
           {pageXofY}
         </span>
       </li>

--- a/server/zanata-frontend/src/app/editor/containers/ControlsHeader.js
+++ b/server/zanata-frontend/src/app/editor/containers/ControlsHeader.js
@@ -136,7 +136,7 @@ export const ControlsHeader = ({
         <EditorSearchInput />
       </div>
       <div className="u-floatRight controlHeader-right">
-        <ul className="u-listHorizontal tc flex center">
+        <ul className="u-listHorizontal tc inline-flex items-center">
           <li className="u-sMV-1-4">
             <Pager
               firstPage={firstPage}

--- a/server/zanata-frontend/src/app/editor/containers/ControlsHeader.js
+++ b/server/zanata-frontend/src/app/editor/containers/ControlsHeader.js
@@ -125,7 +125,7 @@ export const ControlsHeader = ({
   }) => {
   return (
     /* eslint-disable max-len */
-    <nav className="flex flex-wrapper u-bgHighest u-sPH-1-2 l--cf-of">
+    <nav className="flex center flex-wrapper u-bgHighest u-sPH-1-2 l--cf-of">
       <TranslatingIndicator permissions={permissions} />
       <div className="u-floatLeft controlHeader-left Input">
         <PhraseStatusFilter /></div>
@@ -136,7 +136,7 @@ export const ControlsHeader = ({
         <EditorSearchInput />
       </div>
       <div className="u-floatRight controlHeader-right">
-        <ul className="u-listHorizontal tc">
+        <ul className="u-listHorizontal tc flex center">
           <li className="u-sMV-1-4">
             <Pager
               firstPage={firstPage}


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2714

Alignment of pagination numbers in editor.
The alignment is not consistent across different operating systems (macOS and Fedora) so I have center aligned it as best I can across both systems, with Fedora taking priority.

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
