### PR TITLE
fix(ZNTA-2711)(ZNTA-2714)  alignment of admin TM list items and editor pagination

### DIFF
--- a/server/functional-test/src/main/java/org/zanata/page/administration/ManageUserPage.java
+++ b/server/functional-test/src/main/java/org/zanata/page/administration/ManageUserPage.java
@@ -101,9 +101,9 @@ public class ManageUserPage extends BasePage {
                 List<WebElement> linksUnderneath =
                         listItem.findElements(By.tagName("a"));
                 for (WebElement link : linksUnderneath) {
-                    String onclickCallback = link.getAttribute("onclick");
+                    String onclickCallback = link.getAttribute("href");
                     if (onclickCallback != null
-                            && onclickCallback.contains("editUser")) {
+                            && onclickCallback.contains("/userdetail?")) {
                         return link;
                     }
                 }

--- a/server/zanata-frontend/src/app/editor/components/Pager/Pager.test.tsx
+++ b/server/zanata-frontend/src/app/editor/components/Pager/Pager.test.tsx
@@ -34,7 +34,7 @@ describe('PagerTest', () => {
         </IntlProvider>)
 
     const expected = ReactDOMServer.renderToStaticMarkup(
-      <ul className='u-listHorizontal tc'>
+      <ul className='u-listHorizontal tc inline-flex items-center'>
         <li>
           <a className='Link--neutral u-sizeHeight-1_1-2 u-textNoSelect'
             title='First page'>
@@ -48,7 +48,7 @@ describe('PagerTest', () => {
           </a>
         </li>
         <li className='u-sizeHeight-1 u-sPH-1-4'>
-          <span className='u-textNeutral'>
+          <span className='u-textNeutral lh-title'>
             <option>7 of 11</option>
           </span>
         </li>

--- a/server/zanata-frontend/src/app/editor/components/Pager/index.js
+++ b/server/zanata-frontend/src/app/editor/components/Pager/index.js
@@ -117,11 +117,11 @@ const Pager = ({
   }
 
   return (
-    <ul className="u-listHorizontal tc">
+    <ul className="u-listHorizontal tc inline-flex items-center">
       <PagerButton {...buttons.first} />
       <PagerButton {...buttons.prev} />
       <li className="u-sizeHeight-1 u-sPH-1-4">
-        <span className="u-textNeutral">
+        <span className="u-textNeutral lh-title">
           {pageXofY}
         </span>
       </li>

--- a/server/zanata-frontend/src/app/editor/containers/ControlsHeader.js
+++ b/server/zanata-frontend/src/app/editor/containers/ControlsHeader.js
@@ -125,7 +125,7 @@ export const ControlsHeader = ({
   }) => {
   return (
     /* eslint-disable max-len */
-    <nav className="flex flex-wrapper u-bgHighest u-sPH-1-2 l--cf-of">
+    <nav className="flex center flex-wrapper u-bgHighest u-sPH-1-2 l--cf-of">
       <TranslatingIndicator permissions={permissions} />
       <div className="u-floatLeft controlHeader-left Input">
         <PhraseStatusFilter /></div>
@@ -136,7 +136,7 @@ export const ControlsHeader = ({
         <EditorSearchInput />
       </div>
       <div className="u-floatRight controlHeader-right">
-        <ul className="u-listHorizontal tc">
+        <ul className="u-listHorizontal tc inline-flex items-center">
           <li className="u-sMV-1-4">
             <Pager
               firstPage={firstPage}

--- a/server/zanata-frontend/src/app/styles/frontend-jsf.less
+++ b/server/zanata-frontend/src/app/styles/frontend-jsf.less
@@ -30,6 +30,8 @@ body.bodyStyle {
   }
   .list--stats .list__item__stats {
     width: 12rem;
+    position: absolute;
+    right: 1rem;
   }
   #copy-trans-modal {
     .button--group input[type="radio"] + .button--success {

--- a/server/zanata-frontend/src/app/styles/frontend-jsf.less
+++ b/server/zanata-frontend/src/app/styles/frontend-jsf.less
@@ -108,6 +108,7 @@ body.bodyStyle {
   }
   .list--stats .list__item__content {
     display: inline-table;
+    width: auto !important;
   }
   .panel__header__actions a.button--snug {
     padding: 0.1rem;

--- a/server/zanata-frontend/src/app/styles/frontend-jsf.less
+++ b/server/zanata-frontend/src/app/styles/frontend-jsf.less
@@ -28,11 +28,6 @@ body.bodyStyle {
     font-size: 1.75em;
     padding-top: 1rem !important;
   }
-  .list--stats .list__item__stats {
-    width: 12rem;
-    position: absolute;
-    right: 1rem;
-  }
   #copy-trans-modal {
     .button--group input[type="radio"] + .button--success {
       color: @success-color !important;
@@ -112,7 +107,7 @@ body.bodyStyle {
     width: 100%;
   }
   .list--stats .list__item__content {
-    width: inherit !important;
+    display: inline-table;
   }
   .panel__header__actions a.button--snug {
     padding: 0.1rem;


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2711

 alignment of admin TM list items - make sure all right aligned

fix: 
![tmrowfix](https://user-images.githubusercontent.com/18179401/43235765-4aeb5354-90c5-11e8-951b-7a58081104ec.png)

JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2714

Alignment of pagination numbers in editor.
The alignment is not consistent across different operating systems (macOS and Fedora) so I have center aligned it as best I can across both systems, with Fedora taking priority.

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
