### PR TITLE
fix(ZNTA-2730): clear hibernate cache before and after batch

### DIFF
--- a/server/services/src/main/java/org/zanata/service/impl/MachineTranslationServiceImpl.java
+++ b/server/services/src/main/java/org/zanata/service/impl/MachineTranslationServiceImpl.java
@@ -268,6 +268,7 @@ public class MachineTranslationServiceImpl implements
             String backendId) {
         DocumentId documentId = new DocumentId(doc.getId(),
                 doc.getDocId());
+        entityManager.clear();
         List<HTextFlow> textFlowsToTranslate =
                 getTextFlowsByDocumentIdWithConstraints(targetLocale,
                         documentId, overwriteFuzzy);

--- a/server/services/src/main/java/org/zanata/service/impl/TranslationServiceImpl.java
+++ b/server/services/src/main/java/org/zanata/service/impl/TranslationServiceImpl.java
@@ -22,10 +22,7 @@ package org.zanata.service.impl;
 
 import static org.zanata.transaction.TransactionUtilImpl.runInTransaction;
 
-import java.lang.reflect.Field;
 import java.text.MessageFormat;
-import java.time.Duration;
-import java.time.Instant;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.HashSet;
@@ -44,9 +41,6 @@ import org.hibernate.HibernateException;
 import javax.inject.Inject;
 import javax.inject.Named;
 import org.apache.deltaspike.jpa.api.transaction.Transactional;
-import org.hibernate.engine.internal.StatefulPersistenceContext;
-import org.hibernate.engine.spi.PersistenceContext;
-import org.hibernate.engine.spi.SessionImplementor;
 import org.jetbrains.annotations.NotNull;
 import org.zanata.async.Async;
 import org.zanata.async.AsyncTaskHandle;
@@ -186,20 +180,6 @@ public class TranslationServiceImpl implements TranslationService {
         List<TextFlowTargetStateChange> targetStates = Lists.newArrayList();
         Map<ContentState, Long> contentStateDeltas = Maps.newHashMap();
 
-        System.out.println("        Processing translations...");
-        Instant start = Instant.now();
-        try {
-            SessionImplementor sessionImpl = (SessionImplementor) entityManager.getDelegate();
-            PersistenceContext persistenceContext = sessionImpl.getPersistenceContext();
-            Field entityEntriesField = StatefulPersistenceContext.class.getDeclaredField("entitiesByKey");
-            entityEntriesField.setAccessible(true);
-            Map map = (Map) entityEntriesField.get(persistenceContext);
-            log.info("Pre-entitiesManager size {}", map.size());
-        } catch (Exception e)
-        {
-            log.error(e.getMessage());
-        }
-
         for (TransUnitUpdateRequest request : translationRequests) {
             ContentState newContentState = request.getNewContentState();
             HTextFlow hTextFlow = entityManager.find(HTextFlow.class,
@@ -280,18 +260,7 @@ public class TranslationServiceImpl implements TranslationService {
             result.translatedTextFlowTarget = hTextFlowTarget;
             results.add(result);
         }
-        try {
-            SessionImplementor sessionImpl = (SessionImplementor) entityManager.getDelegate();
-            PersistenceContext persistenceContext = sessionImpl.getPersistenceContext();
-            Field entityEntriesField = StatefulPersistenceContext.class.getDeclaredField("entitiesByKey");
-            entityEntriesField.setAccessible(true);
-            Map map = (Map) entityEntriesField.get(persistenceContext);
-            log.info("Post EntityManager size {}", map.size());
-        } catch (Exception e)
-        {
-            log.error(e.getMessage());
-        }
-        System.out.println("          Done processing (" + Duration.between(start, Instant.now()).toMillis() + ")");
+
         if (!targetStates.isEmpty()) {
             DocumentLocaleKey documentLocaleKey =
                     new DocumentLocaleKey(sampleHTextFlow.getDocument().getId(),

--- a/server/services/src/main/java/org/zanata/service/impl/TranslationServiceImpl.java
+++ b/server/services/src/main/java/org/zanata/service/impl/TranslationServiceImpl.java
@@ -21,7 +21,6 @@
 package org.zanata.service.impl;
 
 import static org.zanata.transaction.TransactionUtilImpl.runInTransaction;
-
 import java.text.MessageFormat;
 import java.util.ArrayList;
 import java.util.Collection;
@@ -179,12 +178,10 @@ public class TranslationServiceImpl implements TranslationService {
                 projectIteration, hLocale);
         List<TextFlowTargetStateChange> targetStates = Lists.newArrayList();
         Map<ContentState, Long> contentStateDeltas = Maps.newHashMap();
-
         for (TransUnitUpdateRequest request : translationRequests) {
             ContentState newContentState = request.getNewContentState();
             HTextFlow hTextFlow = entityManager.find(HTextFlow.class,
                     request.getTransUnitId().getValue());
-
             TranslationResultImpl result = new TranslationResultImpl();
             result.similarityPercent = request.getSimilarityPercent();
             if (runValidation) {
@@ -260,7 +257,6 @@ public class TranslationServiceImpl implements TranslationService {
             result.translatedTextFlowTarget = hTextFlowTarget;
             results.add(result);
         }
-
         if (!targetStates.isEmpty()) {
             DocumentLocaleKey documentLocaleKey =
                     new DocumentLocaleKey(sampleHTextFlow.getDocument().getId(),


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2730

Use EntityManager:clear after processing a batch of textflowtargets in a transaction, to prevent progressively increasing memory usage.

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
