### PR TITLE
feat(ZNTA-2580): sorted and searchable locale select for TM Merge

### DIFF
--- a/server/zanata-frontend/src/app/components/LocaleSelect/index.tsx
+++ b/server/zanata-frontend/src/app/components/LocaleSelect/index.tsx
@@ -1,0 +1,42 @@
+import React from 'react'
+import Select from 'antd/lib/select'
+import 'antd/lib/select/style/css'
+import { Locale } from '../../utils/prop-types-util'
+const Option = Select.Option
+
+// Sort comparitor by locale Id
+const compareLocId = (a: Locale, b: Locale) => {
+    return a.localeId < b.localeId ? -1 : a.localeId > b.localeId ? 1 : 0
+}
+// Search by both id and displayname
+const filterOpt = (input: string, option: any) => (
+    (option.props.value + option.props.title).toLowerCase())
+    .indexOf(input.toLowerCase()) >= 0
+
+/**
+ * Sorted and Searchable Locale Selector with options showing ID and displayname
+ */
+const LocaleSelect: React.SFC<LocaleSelectProps> = ({ locales, onChange, style }) => {
+  return (
+    <Select
+      showSearch
+      style={style}
+      placeholder="Select a locale"
+      onChange={onChange}
+      filterOption={filterOpt}
+    >
+      {locales.sort(compareLocId).map(loc =>
+        <Option key={loc.localeId} value={loc.localeId} title={loc.displayName}>
+          <span className='blue'>{loc.localeId}</span> {loc.displayName}
+        </Option>)}
+    </Select>
+  )
+}
+
+interface LocaleSelectProps {
+  locales: Locale[]
+  onChange: (value: any) => void
+  style: object
+}
+
+export default LocaleSelect

--- a/server/zanata-frontend/src/app/components/MTMerge/MTMergeOptions.tsx
+++ b/server/zanata-frontend/src/app/components/MTMerge/MTMergeOptions.tsx
@@ -9,15 +9,13 @@ import Icon from 'antd/lib/icon'
 import 'antd/lib/icon/style/css'
 import Switch from 'antd/lib/switch'
 import 'antd/lib/switch/style/css'
-import Select from 'antd/lib/select'
-import 'antd/lib/select/style/css'
+import LocaleSelect from '../../components/LocaleSelect'
 import { CheckboxChangeEvent } from 'antd/lib/checkbox'
 import { CheckboxValueType } from 'antd/lib/checkbox/Group'
 import { LocaleId, Locale } from '../../utils/prop-types-util'
 import { STATUS_NEEDS_WORK, STATUS_TRANSLATED } from '../../editor/utils/phrase'
 
 const CheckboxGroup = Checkbox.Group
-const Option = Select.Option
 
 export type MTTranslationStatus = typeof STATUS_NEEDS_WORK | typeof STATUS_TRANSLATED
 
@@ -86,21 +84,11 @@ export class MTMergeOptions extends Component<Props> {
               </Checkbox>)}
             </CheckboxGroup>
           </div>
-          : <Select
-              showSearch
-              style={{ width: '100%' }}
-              placeholder="Select a locale"
+          : <LocaleSelect
+              locales={this.props.availableLocales}
               onChange={this.onSelectChange}
-              filterOption={(input, option) => (
-                // @ts-ignore
-                (option.props.value + option.props.title).toLowerCase())
-                .indexOf(input.toLowerCase()) >= 0}
-            >
-            {this.props.availableLocales.sort(this.compareLocId).map(loc =>
-              <Option key={loc.localeId} value={loc.localeId} title={loc.displayName}>
-                <span className='blue'>{loc.localeId}</span> {loc.displayName}
-              </Option>)}
-          </Select>
+              style={{ width: '100%' }}
+            />
         }
 
         {/* Other options */}
@@ -130,11 +118,6 @@ export class MTMergeOptions extends Component<Props> {
         }
       </React.Fragment>
     )
-  }
-
-  // Sort comparitor by locale Id
-  private compareLocId (a: Locale, b: Locale) {
-    return a.localeId < b.localeId ? -1 : a.localeId > b.localeId ? 1 : 0
   }
 
   private availableLocaleIds() {

--- a/server/zanata-frontend/src/app/containers/ProjectVersion/TMMergeModal.js
+++ b/server/zanata-frontend/src/app/containers/ProjectVersion/TMMergeModal.js
@@ -11,14 +11,16 @@ import Button from 'antd/lib/button'
 import 'antd/lib/button/style/css'
 import Collapse from 'antd/lib/collapse'
 import 'antd/lib/collapse/style/css'
-import Select from 'antd/lib/select'
-import 'antd/lib/select/style/css'
 import Row from 'antd/lib/row'
 import 'antd/lib/row/style/css'
 import Col from 'antd/lib/col'
 import 'antd/lib/col/style/css'
+import Select from 'antd/lib/select'
+import 'antd/lib/select/style/css'
 import {
-  Icon, LoaderText, Link} from '../../components'
+  Icon, LoaderText, Link
+} from '../../components'
+import LocaleSelect from '../../components/LocaleSelect'
 import {ProjectVersionHorizontal} from './project-version-displays'
 import CancellableProgressBar
   from '../../components/ProgressBar/CancellableProgressBar'
@@ -79,22 +81,11 @@ const MergeOptions = (
     locales.length > 0 &&
     mergeOptions.selectedLanguage &&
     !fetchingLocale
-    ? (
-      <span>
-        <Select
-          value={mergeOptions.selectedLanguage.localeId}
-          style={{ width: '15rem' }}
-          onChange={onLanguageSelection}>
-          {locales.map((locale) => {
-            return (
-              <Select.Option value={locale.localeId} >
-                {locale.displayName}
-              </Select.Option>
-            )
-          })}
-        </Select>
-      </span>
-    )
+    ? (<span><LocaleSelect
+      locales={locales}
+      onChange={onLanguageSelection}
+      style={{ width: '15rem' }}
+    /></span>)
     : <LoaderText loading={fetchingLocale}
       loadingText={'Fetching Locales'} />
   return (


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2580

Extract the searchable and sorted by ID locale select implementation from MT Merge modal, use as component in both MT and TM merge modals.

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
