### PR TITLE
fix(ZNTA-2633): include JAXB jars

### DIFF
--- a/client/zanata-cli/pom.xml
+++ b/client/zanata-cli/pom.xml
@@ -56,6 +56,37 @@
   </build>
 
   <dependencies>
+    <!-- Java 8 comes with JAXB Version 2.2.8.
+    To work with Java 8,9,11+ we include JAXB ourselves.
+    See https://stackoverflow.com/a/43574427/14379 -->
+    <dependency>
+      <groupId>javax.xml.bind</groupId>
+      <artifactId>jaxb-api</artifactId>
+      <version>2.2.11</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-core</artifactId>
+      <version>2.2.11</version>
+    </dependency>
+    <dependency>
+      <groupId>com.sun.xml.bind</groupId>
+      <artifactId>jaxb-impl</artifactId>
+      <version>2.2.11</version>
+    </dependency>
+
+    <!-- https://stackoverflow.com/a/50251510/14379 -->
+    <!--<dependency>-->
+      <!--<groupId>javax.xml.bind</groupId>-->
+      <!--<artifactId>jaxb-api</artifactId>-->
+      <!--<version>2.4.0</version>-->
+    <!--</dependency>-->
+    <!--<dependency>-->
+      <!--<groupId>org.glassfish.jaxb</groupId>-->
+      <!--<artifactId>jaxb-runtime</artifactId>-->
+      <!--<version>2.4.0</version>-->
+    <!--</dependency>-->
+
     <dependency>
       <groupId>args4j</groupId>
       <artifactId>args4j</artifactId>
@@ -166,6 +197,8 @@
             </executions>
             <configuration>
               <licenseHeaderFile>${basedir}/COPYING-header.txt</licenseHeaderFile>
+              <!-- Remove this when jaxb 2.4.0 is out. See https://stackoverflow.com/a/50251510/14379 -->
+              <extraJvmArguments>-Dcom.sun.xml.bind.v2.bytecode.ClassTailor.noOptimize</extraJvmArguments>
               <programs>
                 <program>
                   <mainClass>org.zanata.client.ZanataClient</mainClass>


### PR DESCRIPTION
JIRA issue URL: https://zanata.atlassian.net/browse/ZNTA-2633

Java 9 and 10 don't include JAXB on the classpath by default, and it's not included in Java 11 at all. So we need to add it as a dependency instead.

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
