### PR TITLE
chore: downgrade typescript version

### DIFF
--- a/server/zanata-frontend/src/package.json
+++ b/server/zanata-frontend/src/package.json
@@ -143,7 +143,7 @@
     "ts-import-plugin": "^1.4.4",
     "tslint": "^5.11.0",
     "tslint-loader": "^3.6.0",
-    "typescript": "^3.0.1",
+    "typescript": "2.9.2",
     "webpack": "4.16.1",
     "webpack-dev-server": "^3.1.4",
     "webpack-manifest-plugin": "2.0.0",

--- a/server/zanata-frontend/src/yarn.lock
+++ b/server/zanata-frontend/src/yarn.lock
@@ -13971,13 +13971,13 @@ typescript-react-intl@^0.1.7:
   dependencies:
     typescript "^2.3.4"
 
+typescript@2.9.2:
+  version "2.9.2"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.9.2.tgz#1cbf61d05d6b96269244eb6a3bce4bd914e0f00c"
+
 typescript@^2.3.4:
   version "2.6.2"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.6.2.tgz#3c5b6fd7f6de0914269027f03c0946758f7673a4"
-
-typescript@^3.0.1:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-3.0.1.tgz#43738f29585d3a87575520a4b93ab6026ef11fdb"
 
 ua-parser-js@^0.7.9:
   version "0.7.17"


### PR DESCRIPTION
JIRA issue URL: *paste URL here*

downgrade typescript version due to memory issue:

PR when upgrading: https://github.com/zanata/zanata-platform/pull/1022
Related discussion: https://github.com/Microsoft/TypeScript/issues/17112#issuecomment-326684693

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
