### PR TITLE
Increase JS heap

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -232,7 +232,6 @@ timestamps {
           // -Dmaven.test.failure.ignore: Continue building other modules
           // even after test failures.
           withEnv(['NODE_OPTIONS=--max_old_space_size=4096']) {
-            sh 'echo NODE_OPTIONS: $NODE_OPTIONS'
             sh """./run-clean.sh ./mvnw -e -V --builder singlethreaded \
               -Dbuildtime.output.csv -Dbuildtime.output.csv.file=buildtime.csv \
               clean install jxr:aggregate \

--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -231,21 +231,24 @@ timestamps {
           // suspected concurrency problems)
           // -Dmaven.test.failure.ignore: Continue building other modules
           // even after test failures.
-          sh """./run-clean.sh ./mvnw -e -V --builder singlethreaded \
-            -Dbuildtime.output.csv -Dbuildtime.output.csv.file=buildtime.csv \
-            clean install jxr:aggregate \
-            --batch-mode -Dstyle.color=never \
-            --update-snapshots \
-            -DstaticAnalysisCI \
-            -Doptimise \
-            $gwtOpts \
-            -Dkotlin.compiler.incremental=false \
-            -DskipFuncTests \
-            -DskipArqTests \
-            -Dmaven.compiler.failOnWarning \
-            -Dmaven.test.failure.ignore \
-            -Ddepcheck \
-          """
+          withEnv(['NODE_OPTIONS=--max_old_space_size=4096']) {
+            sh 'echo NODE_OPTIONS: $NODE_OPTIONS'
+            sh """./run-clean.sh ./mvnw -e -V --builder singlethreaded \
+              -Dbuildtime.output.csv -Dbuildtime.output.csv.file=buildtime.csv \
+              clean install jxr:aggregate \
+              --batch-mode -Dstyle.color=never \
+              --update-snapshots \
+              -DstaticAnalysisCI \
+              -Doptimise \
+              $gwtOpts \
+              -Dkotlin.compiler.incremental=false \
+              -DskipFuncTests \
+              -DskipArqTests \
+              -Dmaven.compiler.failOnWarning \
+              -Dmaven.test.failure.ignore \
+              -Ddepcheck \
+            """
+          }
 
           def surefireTestReports = 'target/surefire-reports/TEST-*.xml'
 


### PR DESCRIPTION
JIRA issue URL: *paste URL here*

Apparently the default for Node is 1.76GB on 64 bit machines: https://stackoverflow.com/questions/47381275/why-does-node-js-have-an-1-76-gb-memory-limit?rq=1

This change increases it to 4GB when built via Jenkins.

## Checklist

- JIRA link
- Check target branch
- Make sure all commit statuses are green or otherwise documented reasons to ignore
- QA needs to evaluate against the JIRA ticket
- Changed files and commits make sense for this PR

See [Zanata Development Guidelines](https://github.com/zanata/zanata-platform/wiki/Development-Guidelines) more for information.

----
*This template can be updated in .github/PULL_REQUEST_TEMPLATE.md*
